### PR TITLE
Added <map>.extent() method and tests related to the method

### DIFF
--- a/src/web-map.js
+++ b/src/web-map.js
@@ -164,7 +164,13 @@ export class WebMap extends HTMLMapElement {
           // See https://github.com/Maps4HTML/MapML-Leaflet-Client/issues/24
           fadeAnimation: true
         });
-
+        this.extent = function (){
+          let pcrsBounds = M.pixelToPCRSBounds(
+            this._map.getPixelBounds(),
+            this._map.getZoom(),
+            this._map.options.projection);
+          return (M.convertAndFormatPCRS(pcrsBounds, this._map));
+        };
         // the attribution control is not optional
         this._attributionControl =  this._map.attributionControl.setPrefix('<a href="https://www.w3.org/community/maps4html/" title="W3C Maps4HTML Community Group">Maps4HTML</a> | <a href="https://leafletjs.com" title="A JS library for interactive maps">Leaflet</a>');
 

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -423,7 +423,7 @@ export class WebMap extends HTMLMapElement {
     }
   }
   zoomTo(lat, lon, zoom) {
-    zoom = zoom||this.zoom;
+    zoom = Number.isInteger(zoom)? zoom:this.zoom;
     var location = new L.LatLng(lat,lon);
     this._map.setView(location, zoom);
     this.zoom = zoom;

--- a/test/e2e/core/mapElement.html
+++ b/test/e2e/core/mapElement.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>cbmt-test.html</title>
+  <meta charset="UTF-8">
+  <script type="module" src="web-map.js"></script>
+  <style>
+    html {
+      height: 100%
+    }
+
+    body,
+    map {
+      height: inherit
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <map is="web-map" projection="CBMTILE" zoom="0" lat="47" lon="-92" controls>
+    <layer- label="CBMT - INLINE" checked>
+      <extent units="CBMTILE">
+        <input name="zoomLevel" type="zoom" value="3" min="0" max="3" />
+        <input name="row" type="location" axis="row" units="tilematrix" min="14" max="21" />
+        <input name="col" type="location" axis="column" units="tilematrix" min="14" max="19" />
+        <link rel='tile' tref='/data/cbmt/{zoomLevel}/c{col}_r{row}.png' />
+      </extent>
+    </layer->
+  </map>
+</body>
+
+</html>

--- a/test/e2e/core/mapElement.test.js
+++ b/test/e2e/core/mapElement.test.js
@@ -1,0 +1,70 @@
+const playwright = require("playwright");
+jest.setTimeout(50000);
+(async () => {
+
+  //expected topLeft values in the different cs, at the different
+  //positions the map goes in
+  let expectedPCRS = [
+    { horizontal: -5537023.0124460235, vertical: 2671749.64016594 },
+    { horizontal: -2810486.309372615, vertical: 5328171.619676568 }];
+  let expectedGCRS = [
+    { horizontal: -134.50882532096858, vertical: 34.758856143866666 },
+    { horizontal: -146.23778791492126, vertical: 54.997129539321016 }];
+  let expectedFirstTileMatrix = [
+    { horizontal: 2.96484375, vertical: 3.7304687500000004 },
+    { horizontal: 3.242456896551724, vertical: 3.4599946120689657 }];
+  let expectedFirstTCRS = [
+    { horizontal: 759, vertical: 955.0000000000001 },
+    { horizontal: 830.0689655172414, vertical: 885.7586206896552 }];
+
+  for (const browserType of BROWSER) {
+    describe(
+      "Playwright Map Element Tests in " + browserType,
+      () => {
+        beforeAll(async () => {
+          browser = await playwright[browserType].launch({
+            headless: ISHEADLESS,
+            slowMo: 50,
+          });
+          context = await browser.newContext();
+          page = await context.newPage();
+          if (browserType === "firefox") {
+            await page.waitForNavigation();
+          }
+          await page.goto(PATH + "mapElement.html");
+        });
+
+        afterAll(async function () {
+          await browser.close();
+        });
+
+        test("[" + browserType + "]" + " Initial map element extent", async () => {
+          const extent = await page.$eval(
+            "body > map",
+            (map) => map.extent()
+          );
+
+          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
+          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
+          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
+          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
+        });
+        test("[" + browserType + "]" + " Panned and zoomed initial map's extent", async () => {
+          const mapMove = await page.$eval(
+            "body > map",
+            (map) => map.zoomTo(81, -63, 1)
+          );
+          const extent = await page.$eval(
+            "body > map",
+            (map) => map.extent()
+          );
+
+          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
+          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
+          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
+          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
+        });
+      }
+    );
+  }
+})();

--- a/test/utils/boundsUtils.spec.js
+++ b/test/utils/boundsUtils.spec.js
@@ -239,4 +239,69 @@ describe("M.Util Bounds Related Tests", () => {
     });
   });
 
+  /* jshint ignore:start */
+  describe("M.convertAndFormatPCRS utility function tests", () => {
+    let projections = ["CBMTILE", "OSMTILE", "WGS84", "APSTILE"];
+    //all expected results are in the order of projections (CBMTILE then OSMTILE...)
+    //all referring to bottomRight
+    let expectedPCRS = [
+      { horizontal: 643, vertical: 16 },
+      { horizontal: 643, vertical: 16 },
+      { horizontal: 643, vertical: 16 },
+      { horizontal: 643, vertical: 16 }];
+    let expectedGCRS = [
+      { horizontal: -94.99116604546431, vertical: 49.00014387212851 },
+      { horizontal: 0.005776167276888522, vertical: 0.00014373044546862331 },
+      { horizontal: 643, vertical: 16 },
+      { horizontal: 164.6567832000427, vertical: 64.91659472871468 }];
+    let expectedFirstTileMatrix = [
+      { horizontal: 3.528683174767241, vertical: 4.00250190537931 },
+      { horizontal: 0.5000160449091025, vertical: 0.4999996007487626 },
+      { horizontal: 4.572222222222222, vertical: 0.41111111111111115 },
+      { horizontal: 0.4672963373316954, vertical: 0.5327139185619564 }];
+    let expectedFirstTCRS = [
+      { horizontal: 903.3428927404137, vertical: 1024.6404877771033 },
+      { horizontal: 128.00410749673023, vertical: 127.99989779168322 },
+      { horizontal: 1170.4888888888888, vertical: 105.24444444444445 },
+      { horizontal: 119.62786235691402, vertical: 136.37476315186083 }];
+    for (let i = 0; i < projections.length; i++) {
+      test(`Accurate conversion and formatting in ${projections[i]} projection`, () => {
+        let container = document.createElement('div'), mapEl = document.createElement('div');
+        let map = L.map(container, {
+          center: new L.LatLng(0, 0),
+          projection: projections[i],
+          query: true,
+          mapEl: mapEl,
+          crs: M[projections[i]],
+          zoom: 0,
+          zoomControl: false,
+          fadeAnimation: true
+        });
+        let pcrsBounds = L.bounds(L.point(14, 16), L.point(643, 24454));
+        let conversion = M.convertAndFormatPCRS(pcrsBounds, map);
+        expect(conversion.bottomRight.pcrs).toEqual(expectedPCRS[i]);
+        expect(conversion.bottomRight.gcrs).toEqual(expectedGCRS[i]);
+        expect(conversion.bottomRight.tilematrix[0]).toEqual(expectedFirstTileMatrix[i]);
+        expect(conversion.bottomRight.tcrs[0]).toEqual(expectedFirstTCRS[i]);
+      });
+      test(`Correct number of TCRS and TileMatrix conversions in ${projections[i]} projection`, () => {
+        let container = document.createElement('div'), mapEl = document.createElement('div');
+        let map = L.map(container, {
+          center: new L.LatLng(0, 0),
+          projection: projections[i],
+          query: true,
+          mapEl: mapEl,
+          crs: M[projections[i]],
+          zoom: 0,
+          zoomControl: false,
+          fadeAnimation: true
+        });
+        let pcrsBounds = L.bounds(L.point(14, 16), L.point(643, 24454));
+        let conversion = M.convertAndFormatPCRS(pcrsBounds, map);
+        expect(conversion.bottomRight.tilematrix.length).toEqual(M[projections[i]].options.resolutions.length);
+        expect(conversion.bottomRight.tcrs.length).toEqual(M[projections[i]].options.resolutions.length);
+      });
+    }
+  });
+  /* jshint ignore:end */
 });


### PR DESCRIPTION
Adds a extent() method to the <map> element and returns the map's current extent in a similar format to the `<layer>.extent` property.

Closes #110 and #115 