### PR TITLE
Fixes setting of <layer>.extent of layers with multiple templates

### DIFF
--- a/src/mapml.js
+++ b/src/mapml.js
@@ -1222,7 +1222,8 @@ M.MapMLLayer = L.Layer.extend({
                   localBounds = this[type]._templates[j].layer.layerBounds;
                   localZoomRanges = this[type]._templates[j].layer.zoomBounds;
                 } else {
-                  localBounds.extend(this[type]._templates[j].layer.layerBounds);
+                  localBounds.extend(this[type]._templates[j].layer.layerBounds.min);
+                  localBounds.extend(this[type]._templates[j].layer.layerBounds.max);
                 }
               }
             }
@@ -1232,7 +1233,8 @@ M.MapMLLayer = L.Layer.extend({
                 localBounds = this[type].layerBounds;
                 localZoomRanges = this[type].zoomBounds;
               } else{
-                localBounds.extend(this[type].layerBounds);
+                localBounds.extend(this[type].layerBounds.min);
+                localBounds.extend(this[type].layerBounds.max);
               }
             } 
           }


### PR DESCRIPTION
Resolves #126 , error thrown when the following map was used:
`
<map is="web-map"  zoom="2" lat="45" lon="-90" controls>
      <layer- label="CBMT" src="https://geogratis.gc.ca/mapml/en/osmtile/cbmt/" checked></layer->
</map>
`

Issue was related to incorrect use of L.bounds.extend().