### PR TITLE
Adds submenu item to allow copying all coordinate systems

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -81,7 +81,6 @@
 
 .mapml-contextmenu {
   display: none;
-  max-height: 100%;
   max-width: 100%;
   box-shadow: 0 1px 7px rgba(0,0,0,0.4);
   -webkit-border-radius: 4px;

--- a/src/mapml/handlers/ContextMenu.js
+++ b/src/mapml/handlers/ContextMenu.js
@@ -71,6 +71,13 @@ export var ContextMenu = L.Handler.extend({
             text:"gcrs",
             callback:this._copyGCRS,
           },
+          {
+            spacer:"-",
+          },
+          {
+            text:"All",
+            callback:this._copyAllCoords,
+          }
         ]
       },
       {
@@ -234,6 +241,23 @@ export var ContextMenu = L.Handler.extend({
     let mapEl = this.options.mapEl,
         click = this.contextMenu._clickEvent;
     this.contextMenu._copyData(`z:${mapEl.zoom}, i:${click.containerPoint.x}, j:${click.containerPoint.y}`);
+  },
+
+  _copyAllCoords: function(e){
+    let mapEl = this.options.mapEl,
+    click = this.contextMenu._clickEvent,
+    point = mapEl._map.project(click.latlng),
+    pointX = point.x % TILE_SIZE, pointY = point.y % TILE_SIZE,
+    scale = mapEl._map.options.crs.scale(+mapEl.zoom),
+    pcrs = mapEl._map.options.crs.transformation.untransform(point,scale);
+    let allData = `z:${mapEl.zoom}\n`;
+    allData += `tile: i:${Math.round(pointX)}, j:${Math.round(pointY)}\n`;
+    allData += `tilematrix: column:${point.x/TILE_SIZE}, row:${point.y/TILE_SIZE}\n`;
+    allData += `map: i:${click.containerPoint.x}, j:${click.containerPoint.y}\n`;
+    allData += `tcrs: x:${point.x}, y:${point.y}\n`;
+    allData += `pcrs: easting:${pcrs.x}, northing:${pcrs.y}\n`;
+    allData += `gcrs: lon :${click.latlng.lng}, lat:${click.latlng.lat}`;
+    this.contextMenu._copyData(allData);
   },
 
   _createItem: function (container, options, index) {

--- a/test/e2e/core/mapContextMenu.test.js
+++ b/test/e2e/core/mapContextMenu.test.js
@@ -178,6 +178,30 @@ jest.setTimeout(50000);
           expect(controlsOn).toEqual(0);
           expect(controlsOff).toEqual(2);
         });
+
+        test("[" + browserType + "]" + " Submenu, copy all coordinate systems", async () => {
+          await page.click("body > map");
+          await page.keyboard.press("Shift+F10");
+          await page.keyboard.press("c");
+
+          await page.click("#mapml-copy-submenu > a:nth-child(10)");
+
+          await page.click("body > textarea");
+          await page.keyboard.press("Control+v");
+          const copyValue = await page.$eval(
+            "body > textarea",
+            (text) => text.value
+          );
+          let expected = "z:1\n";
+          expected += "tile: i:30, j:50\n";
+          expected += "tilematrix: column:6.1171875000000036, row:6.195312500000004\n";
+          expected += "map: i:150, j:75\n";
+          expected += "tcrs: x:1566.000000000001, y:1586.0000000000011\n";
+          expected += "pcrs: easting:562957.9375158995, northing:3641449.4962322935\n";
+          expected += "gcrs: lon :-62.72946572940102, lat:80.88192121974802";
+
+          expect(copyValue).toEqual(expected);
+        });
       }
     );
   }

--- a/test/e2e/core/mapElement.html
+++ b/test/e2e/core/mapElement.html
@@ -33,6 +33,7 @@
       </extent>
     </layer->
   </map>
+  <textarea name="message" rows="10" cols="100"></textarea>
 </body>
 
 </html>


### PR DESCRIPTION
Closes #133 

Copys all coordinate systems in the following format:

z:1
tile: i:127, j:201
tilematrix: column:6.496093750000001, row:6.785156250000002
map: i:246, j:82
tcrs: x:1663.0000000000002, y:1737.0000000000005
pcrs: easting:2744451.8838371113, northing:245515.62103122473
gcrs: lon :-59.583493932359524, lat:44.20100515077798