### PR TITLE
Rename mm-mapp to mapml-viewer

### DIFF
--- a/index-mapml-viewer.html
+++ b/index-mapml-viewer.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>index-mm-mapp.html</title>
-    <script type="module" src="dist/mm-mapp.js"></script>
+    <title>index-mapml-viewer.html</title>
+    <script type="module" src="dist/mapml-viewer.js"></script>
     <style>
       html,
       body {
@@ -19,7 +19,7 @@
       element, such that styles don't apply when fallback content is in use
       (e.g. when scripting is disabled or when custom/built-in elements isn't
       supported in the browser). */
-      mm-mapp:defined {
+      mapml-viewer:defined {
         /* Responsive map. */
         /* max-width: 100%; */
         
@@ -32,7 +32,7 @@
       }
       
       /* Pre-style to avoid FOUC of inline layer- and fallback content. */
-      mm-mapp:not(:defined) > * {
+      mapml-viewer:not(:defined) > * {
         display: none;
       }
       /* Ensure inline layer content is hidden if custom/built-in elements isn't
@@ -47,15 +47,15 @@
       <style>
         /* Ensure fallback content (children of the map element) is displayed if
         custom/built-in elements is supported but javascript is disabled. */
-        mm-mapp:not(:defined) > :not(layer-) {
+        mapml-viewer:not(:defined) > :not(layer-) {
           display: initial;
         }
       </style>
     </noscript>
   </head>
   <body>
-    <mm-mapp projection="CBMTILE" zoom="2" lat="45" lon="-90" controls controlslist="nofullscreen">
+    <mapml-viewer projection="CBMTILE" zoom="2" lat="45" lon="-90" controls controlslist="nofullscreen">
       <layer- label="CBMT" src="https://geogratis.gc.ca/mapml/en/cbmtile/cbmt/" checked></layer->
-    </mm-mapp>
+    </mapml-viewer>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-map-custom-element",
   "version": "0.7.0",
-  "description": "web-map customized built-in HTML <map> or custom <mm-mapp>",
+  "description": "web-map customized built-in HTML <map> or custom <mapml-viewer>",
   "keywords": [
     "web-components",
     "web",

--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -5,7 +5,7 @@ import './mapml.js';       // refactored URI usage, replaced with URL standard
 import './Leaflet.fullscreen.js';
 import { MapLayer } from './layer.js';
 
-export class MmMapp extends HTMLElement {
+export class MapViewer extends HTMLElement {
   static get observedAttributes() {
     return ['lat', 'lon', 'zoom', 'projection', 'width', 'height', 'controls'];
   }
@@ -116,13 +116,14 @@ export class MmMapp extends HTMLElement {
     // Hide all (light DOM) children of the map element.
     let hideElementsCSS = document.createElement('style');
     hideElementsCSS.innerHTML =
-    `mm-mapp > * {` +
+    `mapml-viewer > * {` +
     `display: none!important;` +
     `}`;
 
     shadowRoot.appendChild(mapDefaultCSS);
     shadowRoot.appendChild(tmpl.content.cloneNode(true));
     shadowRoot.appendChild(this._container);
+
     this.appendChild(hideElementsCSS);
   }
   connectedCallback() {
@@ -179,7 +180,6 @@ export class MmMapp extends HTMLElement {
           // See https://github.com/Maps4HTML/MapML-Leaflet-Client/issues/24
           fadeAnimation: true
         });
-
         // the attribution control is not optional
         this._attributionControl =  this._map.attributionControl.setPrefix('<a href="https://www.w3.org/community/maps4html/" title="W3C Maps4HTML Community Group">Maps4HTML</a> | <a href="https://leafletjs.com" title="A JS library for interactive maps">Leaflet</a>');
 
@@ -225,7 +225,7 @@ export class MmMapp extends HTMLElement {
   }
   _dropHandler(event) {
     event.preventDefault();
-    // create a new <layer-> child of this <mm-mapp> element
+    // create a new <layer-> child of this <mapml-viewer> element
       let l = new MapLayer();
       l.src = event.dataTransfer.getData("text");
       l.label = 'Layer';
@@ -503,5 +503,5 @@ export class MmMapp extends HTMLElement {
   }
 }
 // need to provide options { extends: ... }  for custom built-in elements
-window.customElements.define('mm-mapp', MmMapp);
+window.customElements.define('mapml-viewer', MapViewer);
 window.customElements.define('layer-', MapLayer);

--- a/test/e2e/mapml-viewer/mapml-viewer.html
+++ b/test/e2e/mapml-viewer/mapml-viewer.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>cbmt-test.html</title>
+  <meta charset="UTF-8">
+  <script type="module" src="mapml-viewer.js"></script>
+  <style>
+    html {
+      height: 100%
+    }
+
+    body,
+    map {
+      height: inherit
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <mapml-viewer projection="CBMTILE" zoom="0" lat="47" lon="-92" controls>
+    <layer- label="CBMT - INLINE" checked>
+      <extent units="CBMTILE">
+        <input name="zoomLevel" type="zoom" value="3" min="0" max="3" />
+        <input name="row" type="location" axis="row" units="tilematrix" min="14" max="21" />
+        <input name="col" type="location" axis="column" units="tilematrix" min="14" max="19" />
+        <link rel='tile' tref='/data/cbmt/{zoomLevel}/c{col}_r{row}.png' />
+      </extent>
+    </layer->
+  </mapml-viewer>
+  <textarea name="message" rows="10" cols="100"></textarea>
+</body>
+
+</html>

--- a/test/e2e/mapml-viewer/mapml-viewer.test.js
+++ b/test/e2e/mapml-viewer/mapml-viewer.test.js
@@ -1,0 +1,75 @@
+const playwright = require("playwright");
+jest.setTimeout(50000);
+(async () => {
+
+  //expected topLeft values in the different cs, at the different
+  //positions the map goes in
+  let expectedPCRS = [
+    { horizontal: -5537023.0124460235, vertical: 2671749.64016594 },
+    { horizontal: -2810486.309372615, vertical: 5328171.619676568 }];
+  let expectedGCRS = [
+    { horizontal: -134.50882532096858, vertical: 34.758856143866666 },
+    { horizontal: -146.23778791492126, vertical: 54.997129539321016 }];
+  let expectedFirstTileMatrix = [
+    { horizontal: 2.96484375, vertical: 3.7304687500000004 },
+    { horizontal: 3.242456896551724, vertical: 3.4599946120689657 }];
+  let expectedFirstTCRS = [
+    { horizontal: 759, vertical: 955.0000000000001 },
+    { horizontal: 830.0689655172414, vertical: 885.7586206896552 }];
+
+  for (const browserType of BROWSER) {
+    describe(
+      "Playwright mapml-viewer Element Tests in " + browserType,
+      () => {
+        beforeAll(async () => {
+          browser = await playwright[browserType].launch({
+            headless: ISHEADLESS,
+            slowMo: 50,
+          });
+          context = await browser.newContext();
+          page = await context.newPage();
+          if (browserType === "firefox") {
+            await page.waitForNavigation();
+          }
+          await page.goto(PATH + "mapml-viewer.html");
+        });
+
+        afterAll(async function () {
+          await browser.close();
+        });
+
+        test("[" + browserType + "]" + " Initial map element extent", async () => {
+          const extent = await page.$eval(
+            "body > mapml-viewer",
+            (map) => map.extent
+          );
+
+          expect(extent.projection).toEqual("CBMTILE");
+          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
+          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
+          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
+          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
+        });
+        test("[" + browserType + "]" + " Panned and zoomed initial map's extent", async () => {
+          await page.$eval(
+            "body > mapml-viewer",
+            (map) => map.zoomTo(81, -63, 1)
+          );
+          const extent = await page.$eval(
+            "body > mapml-viewer",
+            (map) => map.extent
+          );
+
+          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
+          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
+          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
+          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
+        });
+
+        
+      }
+    );
+  }
+})();

--- a/test/e2e/mapml-viewer/viewerContextMenu.test.js
+++ b/test/e2e/mapml-viewer/viewerContextMenu.test.js
@@ -1,0 +1,241 @@
+const playwright = require("playwright");
+jest.setTimeout(50000);
+(async () => {
+
+  //expected topLeft values in the different cs, at the different
+  //positions the map goes in
+  let expectedPCRS = [
+    { horizontal: -5537023.0124460235, vertical: 2671749.64016594 },
+    { horizontal: -2810486.309372615, vertical: 5328171.619676568 }];
+  let expectedGCRS = [
+    { horizontal: -134.50882532096858, vertical: 34.758856143866666 },
+    { horizontal: -146.23778791492126, vertical: 54.997129539321016 }];
+  let expectedFirstTileMatrix = [
+    { horizontal: 2.96484375, vertical: 3.7304687500000004 },
+    { horizontal: 3.242456896551724, vertical: 3.4599946120689657 }];
+  let expectedFirstTCRS = [
+    { horizontal: 759, vertical: 955.0000000000001 },
+    { horizontal: 830.0689655172414, vertical: 885.7586206896552 }];
+
+  for (const browserType of BROWSER) {
+    describe(
+      "Playwright mapml-viewer Context Menu (and api) Tests in " + browserType,
+      () => {
+        beforeAll(async () => {
+          browser = await playwright[browserType].launch({
+            headless: ISHEADLESS,
+            slowMo: 50,
+          });
+          context = await browser.newContext();
+          page = await context.newPage();
+          if (browserType === "firefox") {
+            await page.waitForNavigation();
+          }
+          await page.goto(PATH + "mapml-viewer.html");
+        });
+
+        afterAll(async function () {
+          await browser.close();
+        });
+
+        test("[" + browserType + "]" + " Context menu focus on keyboard shortcut", async () => {
+          await page.click("body > mapml-viewer");
+          await page.keyboard.press("Shift+F10");
+          const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+          const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
+          const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
+          const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
+          let name = await nameHandle.jsonValue();
+          await nameHandle.dispose();
+          expect(name).toEqual("Back (B)");
+        });
+
+        test("[" + browserType + "]" + " Context menu tab goes to next item", async () => {
+          await page.keyboard.press("Tab");
+          const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+          const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
+          const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
+          const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
+          let name = await nameHandle.jsonValue();
+          await nameHandle.dispose();
+          expect(name).toEqual("Forward (F)");
+        });
+
+        test("[" + browserType + "]" + " Submenu opens on C with focus on first item", async () => {
+          await page.keyboard.press("c");
+          await page.keyboard.press("Tab");
+          const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+          const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
+          const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
+          const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
+          let name = await nameHandle.jsonValue();
+          await nameHandle.dispose();
+          expect(name).toEqual("tile");
+        });
+
+        test("[" + browserType + "]" + " Context menu displaying on map", async () => {
+          await page.click("body > mapml-viewer", { button: "right" });
+          const contextMenu = await page.$eval(
+            "div > div.mapml-contextmenu",
+            (menu) => menu.style.display
+          );
+          expect(contextMenu).toEqual("block");
+        });
+        test("[" + browserType + "]" + " Context menu, back item", async () => {
+          const mapMove = await page.$eval(
+            "body > mapml-viewer",
+            (map) => map.zoomTo(81, -63, 1)
+          );
+          await page.click("body > mapml-viewer", { button: "right" });
+          await page.click("div > div.mapml-contextmenu > a:nth-child(1)");
+          const extent = await page.$eval(
+            "body > mapml-viewer",
+            (map) => map.extent
+          );
+
+          expect(extent.projection).toEqual("CBMTILE");
+          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
+          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
+          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
+          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
+        });
+        test("[" + browserType + "]" + " Context menu, back item at intial location", async () => {
+          await page.click("body > mapml-viewer", { button: "right" });
+          await page.click("div > div.mapml-contextmenu > a:nth-child(1)");
+          const extent = await page.$eval(
+            "body > mapml-viewer",
+            (map) => map.extent
+          );
+
+          expect(extent.projection).toEqual("CBMTILE");
+          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
+          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
+          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
+          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
+        });
+        test("[" + browserType + "]" + " Context menu, forward item", async () => {
+          await page.click("body > mapml-viewer", { button: "right" });
+          await page.click("div > div.mapml-contextmenu > a:nth-child(2)");
+          const extent = await page.$eval(
+            "body > mapml-viewer",
+            (map) => map.extent
+          );
+
+          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
+          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
+          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
+          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
+        });
+        test("[" + browserType + "]" + " Context menu, forward item at most recent location", async () => {
+          await page.click("body > mapml-viewer", { button: "right" });
+          await page.click("div > div.mapml-contextmenu > a:nth-child(2)");
+          const extent = await page.$eval(
+            "body > mapml-viewer",
+            (map) => map.extent
+          );
+
+          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
+          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
+          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
+          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
+        });
+
+        describe("Context Menu, Toggle Controls " + browserType, () => {
+          test("[" + browserType + "]" + " Context menu, toggle controls off", async () => {
+            const controlsOn = await page.$eval(
+              "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
+              (controls) => controls.childElementCount
+            );
+
+            await page.click("body > mapml-viewer", { button: "right" });
+            await page.click("div > div.mapml-contextmenu > a:nth-child(5)");
+
+            const controlsOff = await page.$eval(
+              "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
+              (controls) => controls.childElementCount
+            );
+
+            expect(controlsOn).toEqual(2);
+            expect(controlsOff).toEqual(0);
+          });
+
+          test("[" + browserType + "]" + " Context menu, toggle controls on", async () => {
+            const controlsOn = await page.$eval(
+              "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
+              (controls) => controls.childElementCount
+            );
+
+            await page.click("body > mapml-viewer", { button: "right" });
+            await page.click("div > div.mapml-contextmenu > a:nth-child(5)");
+
+            const controlsOff = await page.$eval(
+              "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
+              (controls) => controls.childElementCount
+            );
+
+            expect(controlsOn).toEqual(0);
+            expect(controlsOff).toEqual(2);
+          });
+
+          test("[" + browserType + "]" + " Context menu, toggle controls after changing opacity", async () => {
+            await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
+            await page.$eval(
+              "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > details",
+              (div) => div.open = true
+            );
+            await page.$eval(
+              "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > details > details",
+              (div) => div.open = true
+            );
+            await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > details > details > input");
+            const valueBefore = await page.$eval(
+              "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > details > details > input",
+              (opacity) => opacity.value
+            );
+            expect(valueBefore).toEqual("0.5");
+
+            await page.click("body > mapml-viewer", { button: "right" });
+            await page.click("div > div.mapml-contextmenu > a:nth-child(5)");
+            await page.click("body > mapml-viewer", { button: "right" });
+            await page.click("div > div.mapml-contextmenu > a:nth-child(5)");
+
+            const valueAfter = await page.$eval(
+              "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > details > details > input",
+              (opacity) => opacity.value
+            );
+
+            expect(valueAfter).toEqual("0.5");
+          });
+        });
+
+        test("[" + browserType + "]" + " Submenu, copy all coordinate systems", async () => {
+          await page.click("body > mapml-viewer");
+          await page.keyboard.press("Shift+F10");
+          await page.keyboard.press("c");
+
+          await page.click("#mapml-copy-submenu > a:nth-child(10)");
+
+          await page.click("body > textarea");
+          await page.keyboard.press("Control+v");
+          const copyValue = await page.$eval(
+            "body > textarea",
+            (text) => text.value
+          );
+          let expected = "z:1\n";
+          expected += "tile: i:30, j:50\n";
+          expected += "tilematrix: column:6.1171875000000036, row:6.195312500000004\n";
+          expected += "map: i:150, j:75\n";
+          expected += "tcrs: x:1566.000000000001, y:1586.0000000000011\n";
+          expected += "pcrs: easting:562957.9375158995, northing:3641449.4962322935\n";
+          expected += "gcrs: lon :-62.72946572940102, lat:80.88192121974802";
+
+          expect(copyValue).toEqual(expected);
+        });
+      }
+    );
+  }
+})();

--- a/test/server.js
+++ b/test/server.js
@@ -7,6 +7,7 @@ const port = 30001;
 app.use(express.static(path.join(__dirname, "../dist")));
 app.use(express.static(path.join(__dirname, "e2e/core")));
 app.use(express.static(path.join(__dirname, "e2e/layers")));
+app.use(express.static(path.join(__dirname, "e2e/mapml-viewer")));
 app.use("/data", express.static(path.join(__dirname, "e2e/data/tiles/cbmt")));
 app.use("/data", express.static(path.join(__dirname, "e2e/data/tiles/wgs84")));
 app.use(


### PR DESCRIPTION
Renames mm-mapp to mapml-viewer and adds a handful of tests related to `<mapml-viewer>`'s latest api additions

Closes #104 