### PR TITLE
Programmatically identifiable map

### DIFF
--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -193,6 +193,11 @@ export class MapViewer extends HTMLElement {
           }
         }
 
+        // Make the Leaflet container element programmatically identifiable
+        // (https://github.com/Leaflet/Leaflet/issues/7193).
+        this._container.setAttribute('role', 'region');
+        this._container.setAttribute('aria-label', 'Interactive map');
+
         this._setUpEvents();
         // this.fire('load', {target: this});
       }

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -225,6 +225,12 @@ export class WebMap extends HTMLMapElement {
         if (this.poster) {
           this.poster.style.display = 'none';
         }
+        
+        // Make the Leaflet container element programmatically identifiable
+        // (https://github.com/Leaflet/Leaflet/issues/7193).
+        this._container.setAttribute('role', 'region');
+        this._container.setAttribute('aria-label', 'Interactive map');
+        
         this._setUpEvents();
         // this.fire('load', {target: this});
       }


### PR DESCRIPTION
Gives the focusable `.leaflet-container` a descriptive accessible name, as well as a role of `region`. See inline comments for the upstream Leaflet issue for more details.