### PR TITLE
Creates debug extents using new layer defined using PCRS coordinates

### DIFF
--- a/test/e2e/core/debugMode.html
+++ b/test/e2e/core/debugMode.html
@@ -32,6 +32,22 @@
         <link rel='tile' tref='/data/cbmt/{zoomLevel}/c{col}_r{row}.png' />
       </extent>
     </layer->
+    <layer- label="CBMT - Large Extent" checked>
+      <extent units="CBMTILE">
+        <input name="zoomLevel" type="zoom" value="0" min="0" max="3" />
+        <input name="row" type="location" axis="row" units="tilematrix" min="0" max="5" />
+        <input name="col" type="location" axis="column" units="tilematrix" min="0" max="4" />
+        <link rel='tile' tref='/data/cbmt/{zoomLevel}/c{col}_r{row}.png' />
+      </extent>
+    </layer->
+    <layer- label="CBMT - Beyond Range Extent" checked>
+      <extent units="CBMTILE">
+        <input name="zoomLevel" type="zoom" value="0" min="0" max="3" />
+        <input name="row" type="location" axis="row" units="tilematrix" min="-2" max="8" />
+        <input name="col" type="location" axis="column" units="tilematrix" min="-4" max="7" />
+        <link rel='tile' tref='/data/cbmt/{zoomLevel}/c{col}_r{row}.png' />
+      </extent>
+    </layer->
   </mapml-viewer>
 </body>
 

--- a/test/e2e/core/debugMode.test.js
+++ b/test/e2e/core/debugMode.test.js
@@ -66,6 +66,30 @@ jest.setTimeout(50000);
 
         });
 
+        test("[" + browserType + "]" + " Reasonable debug layer extent created", async () => {
+          const feature = await page.$eval(
+            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(2)",
+            (tile) => tile.getAttribute("d")
+          );
+          expect(feature).toEqual("M82.51724137931035 332.27586206896535L347.34482758620686 332.27586206896535L347.34482758620686 -38.48275862068965L82.51724137931035 -38.48275862068965z");
+        });
+
+        test("[" + browserType + "]" + " Large debug layer extent created", async () => {
+          const feature = await page.$eval(
+            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(3)",
+            (tile) => tile.getAttribute("d")
+          );
+          expect(feature).toEqual("M-659 500L365 500L365 -780L-659 -780z");
+        });
+
+        test("[" + browserType + "]" + " Debug layer extent beyond ((0,0), (5,5))  created", async () => {
+          const feature = await page.$eval(
+            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(4)",
+            (tile) => tile.getAttribute("d")
+          );
+          expect(feature).toEqual("M-1683 1268L1133 1268L1133 -1292L-1683 -1292z");
+        });
+
         test("[" + browserType + "]" + " Accurate debug coordinates", async () => {
           await page.hover("body > mapml-viewer");
           const tile = await page.$eval(


### PR DESCRIPTION
Prior to this PR, debug mode used L.Polygon to create the extents, this resulted in odd shapes (not rectangles as expected) to be created in certain projections when the extent exceeded a certain value.

This was due to the use of LatLng to define the polygon.

Also displays the coordinate panel conditionally, if the map is not large enough the panel is not displayed as it takes up the entire map view losing its utility.