### PR TITLE
Hides layer controls panel when all layers have hidden controls

### DIFF
--- a/src/mapml/layers/ControlLayer.js
+++ b/src/mapml/layers/ControlLayer.js
@@ -28,6 +28,11 @@ export var MapMLLayerControl = L.Control.Layers.extend({
         this._map.on('moveend', this._validateExtents, this);
         this._update();
         //this._validateExtents();
+        if(this._layers.length < 1 && !this._map._showControls){
+          this._container.setAttribute("hidden","");
+        } else {
+          this._map._showControls = true;
+        }
         return this._container;
     },
     onRemove: function (map) {
@@ -51,6 +56,10 @@ export var MapMLLayerControl = L.Control.Layers.extend({
       }
       if (!alreadyThere) {
         this.addOverlay(layer, name);
+      }
+      if(this._layers.length > 0){
+        this._container.removeAttribute("hidden");
+        this._map._showControls = true;
       }
       return (this._map) ? this._update() : this;
     },

--- a/test/e2e/layers/mapMLLayerControl.html
+++ b/test/e2e/layers/mapMLLayerControl.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Layer Control Tests</title>
+  <script type="module" src="mapml-viewer.js"></script>
+  <style>
+    html,
+    body {
+      height: 100%;
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+    }
+
+    /* Specifying the `:defined` selector is recommended to style the map 
+       element, such that styles don't apply when fallback content is in use 
+       (e.g. when scripting is disabled or when custom/built-in elements isn't 
+       supported in the browser). */
+    mapml-viewer:defined {
+      /* Responsive map. */
+      max-width: 100%;
+
+      /* Full viewport. */
+      width: 100%;
+      height: 100%;
+
+      /* Remove default (native-like) border. */
+      /* border: none; */
+    }
+
+    /* Pre-style to avoid FOUC of inline layer- and fallback content. */
+    mapml-viewer:not(:defined)>* {
+      display: none;
+    }
+
+    /* Ensure inline layer content is hidden if custom/built-in elements isn't 
+       supported, or if javascript is disabled. This needs to be defined separately 
+       from the above, because the `:not(:defined)` selector invalidates the entire 
+       declaration in browsers that do not support it. */
+    layer- {
+      display: none;
+    }
+  </style>
+  <noscript>
+    <style>
+      /* Ensure fallback content (children of the map element) is displayed if 
+         custom/built-in elements is supported but javascript is disabled. */
+      mapml-viewer:not(:defined)> :not(layer-) {
+        display: initial;
+      }
+    </style>
+  </noscript>
+</head>
+
+<body>
+  <mapml-viewer projection="CBMTILE" zoom="2" lat="61.2091250" lon="-90.8508370" controls>
+    <layer- hidden label="Canada Base Map - Transportation (CBMT)" src="http://geogratis.gc.ca/mapml/en/cbmtile/cbmt/"
+      checked>
+    </layer->
+  </mapml-viewer>
+  <mapml-viewer projection="CBMTILE" zoom="2" lat="61.2091250" lon="-90.8508370" controls>
+    <layer- label="Canada Base Map - Transportation (CBMT)" src="http://geogratis.gc.ca/mapml/en/cbmtile/cbmt/" checked>
+    </layer->
+  </mapml-viewer>
+</body>
+
+</html>

--- a/test/e2e/layers/mapMLLayerControl.test.js
+++ b/test/e2e/layers/mapMLLayerControl.test.js
@@ -1,0 +1,46 @@
+const playwright = require("playwright");
+jest.setTimeout(50000);
+(async () => {
+
+  for (const browserType of BROWSER) {
+    describe(
+      "Playwright mapMLLayerControl Tests in " + browserType,
+      () => {
+        describe("Control Layer Panel Tests", () => {
+          beforeAll(async () => {
+            browser = await playwright[browserType].launch({
+              headless: ISHEADLESS,
+              slowMo: 50,
+            });
+            context = await browser.newContext();
+            page = await context.newPage();
+            if (browserType === "firefox") {
+              await page.waitForNavigation();
+            }
+            await page.goto(PATH + "mapMLLayerControl.html");
+          });
+
+          afterAll(async function () {
+            await browser.close();
+          });
+
+          test("[" + browserType + "]" + " Control panel hidden when no layers/all layers hidden", async () => {
+            const controlsHidden = await page.$eval(
+              "css=body > mapml-viewer:nth-child(1) >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div",
+              (elem) => elem.hasAttribute("hidden")
+            );
+            expect(controlsHidden).toEqual(true);
+          });
+
+          test("[" + browserType + "]" + " Control panel shown when layers are on map", async () => {
+            const controlsHidden = await page.$eval(
+              "css=body > mapml-viewer:nth-child(2) >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div",
+              (elem) => elem.hasAttribute("hidden")
+            );
+            expect(controlsHidden).toEqual(false);
+          });
+        });
+      }
+    );
+  }
+})();


### PR DESCRIPTION
Closes #159 

Hides layer controls panel when all layers are hidden/no layers, otherwise shows the layer controls panel as usual.