### PR TITLE
CSS revision

### DIFF
--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -116,6 +116,10 @@ export class MapViewer extends HTMLElement {
     `:host([frameborder="0"]) {` +
     `border-width: 0;` +
     `}` +
+    `:host .mapml-contextmenu,` +
+    `:host .leaflet-control-container {` +
+    `visibility: hidden!important;` + // Visibility hack to improve percieved performance (mitigate FOUC) – visibility is unset in mapml.css! (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/154).
+    `}` +
     `:host .leaflet-container {` +
     `contain: strict;` + // Contain size, layout and paint calculations within the leaflet container element.
     `}` +

--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -105,7 +105,7 @@ export class MapViewer extends HTMLElement {
     mapDefaultCSS.innerHTML =
     `:host {` +
     `all: initial;` + // Reset properties inheritable from html/body, as some inherited styles may cause unexpected issues with the map element's components (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/140).
-    `contain: content;` + // Contain layout and paint calculations within the map element.
+    `contain: size;` + // Contain size calculations within the map element.
     `display: inline-block;` + // This together with dimension properties is required so that Leaflet isn't working with a height=0 box by default.
     `overflow: hidden;` + // Make the map element behave and look more like a native element.
     `height: 150px;` + // Provide a "default object size" (https://github.com/Maps4HTML/HTML-Map-Element/issues/31).
@@ -115,6 +115,9 @@ export class MapViewer extends HTMLElement {
     `}` +
     `:host([frameborder="0"]) {` +
     `border-width: 0;` +
+    `}` +
+    `:host .leaflet-container {` +
+    `contain: strict;` + // Contain size, layout and paint calculations within the leaflet container element.
     `}` +
     `:host(.leaflet-drag-target) .leaflet-control {` +
     `pointer-events: none;` + // Prevent `:hover` styles from applying to controls when the user is panning the map display and the cursor happens to move over a control.

--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -112,6 +112,9 @@ export class MapViewer extends HTMLElement {
     `width: 300px;` +
     `border-width: 2px;` +
     `border-style: inset;` +
+    `}` +
+    `:host(.leaflet-drag-target) .leaflet-control {` +
+    `pointer-events: none;` + // Prevent `:hover` styles from applying to controls when the user is panning the map display and the cursor happens to move over a control.
     `}`;
     
     // Hide all (light DOM) children of the map element.

--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -113,6 +113,9 @@ export class MapViewer extends HTMLElement {
     `border-width: 2px;` +
     `border-style: inset;` +
     `}` +
+    `:host([frameborder="0"]) {` +
+    `border-width: 0;` +
+    `}` +
     `:host(.leaflet-drag-target) .leaflet-control {` +
     `pointer-events: none;` + // Prevent `:hover` styles from applying to controls when the user is panning the map display and the cursor happens to move over a control.
     `}`;

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -168,28 +168,9 @@
   vertical-align: middle;
 }
 
-/* Disable dragging of controls. */
-.leaflet-control a {
-  -webkit-user-drag: none;
-}
-
-/* Hide unintended highlighting of controls from clicking the map display in
-   quick succession. This is a workaround for `user-select: contain`, since it has
-   virtually no browser support: https://www.chromestatus.com/feature/5730263904550912. */
-.leaflet-control a::selection,
-.leaflet-popup-close-button::selection,
-.leaflet-control-attribution::selection {
-  background-color: transparent;
-}
-
-/* Restore the default focus outline of UA stylesheets,
-   which Leaflet unfortunately removes (https://github.com/Leaflet/Leaflet/issues/6986). */
-.leaflet-container :focus {
-  outline-color: -webkit-focus-ring-color!important;
-  outline-style: auto!important;
-  outline-width: thin!important;
-  outline: revert!important;
-}
+/*
+ * Context menu.
+ */
 
 .mapml-contextmenu {
   display: none;
@@ -199,10 +180,6 @@
   padding: 4px 0;
   background-color: #fff;
   cursor: default;
-  -webkit-user-select: none;
-     -moz-user-select: none;    
-      -ms-user-select: none;
-          user-select: none;
 }
 
 .mapml-contextmenu a.mapml-contextmenu-item {
@@ -226,4 +203,73 @@
 .mapml-contextmenu-separator {
   border-bottom: 1px solid #e3e3e3;
   margin: 5px 0;
+}
+
+/*
+ * User interaction.
+ */
+
+/* Disable dragging of controls. */
+.leaflet-control :not([draggable="true"]),
+.mapml-contextmenu :not([draggable="true"]) {
+  -webkit-user-drag: none;
+}
+
+/* Disable text selection in controls. */
+.leaflet-control,
+.mapml-contextmenu {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+/* Hide unintended highlighting of controls from clicking the map display in
+   quick succession. This is a workaround for `user-select: contain`, since it has
+   virtually no browser support: https://www.chromestatus.com/feature/5730263904550912. */
+.leaflet-control a::selection,
+.leaflet-popup-close-button::selection,
+.leaflet-control-attribution::selection {
+  background-color: transparent;
+}
+
+/* Disable pointer events where they'd interfere with the intended action. */
+.mapml-contextmenu-item > *,
+.mapml-control-layers label[for^="o"],
+.leaflet-crosshair > *,
+.leaflet-crosshair .leaflet-control {
+  pointer-events: none!important;
+}
+
+/* Restore the default focus outline of UA stylesheets,
+   which Leaflet unfortunately removes (https://github.com/Leaflet/Leaflet/issues/6986). */
+.leaflet-container :focus {
+  outline-color: -webkit-focus-ring-color !important;
+  outline-style: auto !important;
+  outline-width: thin !important;
+  outline: revert !important;
+}
+/* Unset the outline that Leaflet occasionally sets on controls without also
+   delegating focus. */
+.leaflet-active:not(:focus) {
+  outline: unset !important;
+}
+
+/* Restore the default UA tap highlight color by overriding the opinionated tap
+   highlight color inherited from leaflet.css. */
+.leaflet-control a {
+  -webkit-tap-highlight-color: initial;
+}
+
+/* Less opinionated styles for the zoom box than inherited from leaflet.css. */
+.leaflet-zoom-box {
+  border: thin dotted;
+  background-color: rgba(255,255,255,0.33);
+}
+
+label,
+input,
+button,
+summary {
+  cursor: pointer;
 }

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -4,6 +4,10 @@
   background-color: transparent;
   max-height: 100%;
   max-width: 100%;
+  min-height: 100%;
+  min-width: 100%;
+  width: 100% !important;
+  height: 100% !important;
 }
 
 /* this is required by tiles which are actually divs with multiple images in them */

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -23,37 +23,145 @@
 .leaflet-image-loaded {
         visibility: inherit;
 }
-.leaflet-control-layers fieldset {
-    border: none;
+
+/*
+ * Controls.
+ */
+
+.leaflet-bar a {
+  box-sizing: border-box;
+  width: 30px !important;
+  height: 30px !important;
+  line-height: 30px !important;
+  font-size: 24px !important;
+  font-weight: normal;
 }
-/* this is to indent the nested details in the layer control */
-/* details/summary is in progress 2018-03-02 on ms-edge so gonna rely on that...
-   https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6261266-details-summary-elements */
-.leaflet-control-layers details.mapml-control-layers > details.mapml-control-layers {
-        margin-left: 1em;
+
+.leaflet-control-layers-toggle {
+  width: 36px !important;
+  height: 36px !important;
 }
-.leaflet-control-layers details.mapml-control-layers > * {
-        margin-left: 0;
-        margin-right: 0;
+
+.leaflet-bar a,
+.leaflet-control-layers {
+  border-color: #e3e3e3 !important;
 }
-.leaflet-control-layers details.mapml-control-layers > select,
-.leaflet-control-layers details.mapml-control-layers > span{
-        margin-left: 1em;
+
+.leaflet-control-layers {
+  border-radius: 4px !important;
 }
-.leaflet-control-layers details.mapml-control-layers > input {
-        margin-left: 1em;
-        width: 90%
+.leaflet-touch .leaflet-bar a:last-child {
+  border-bottom-left-radius: 4px !important;
+  border-bottom-right-radius: 4px !important;
 }
-.leaflet-control-layers details.mapml-control-layers > details.mapml-control-layers > span {
-    display: block;
+.leaflet-touch .leaflet-bar a:first-child {
+  border-top-left-radius: 4px !important;
+  border-top-right-radius: 4px !important;
 }
-.leaflet-control-layers label {
-    display: inline;
+.leaflet-touch .leaflet-control-layers,
+.leaflet-touch .leaflet-bar {
+  border-style: inherit;
 }
+
+.leaflet-bar,
+.leaflet-control-layers,
+.mapml-contextmenu,
+.leaflet-touch .leaflet-control-layers,
+.leaflet-touch .leaflet-bar {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2), 0 1px 2px rgb(0, 0, 0, 0.3);
+}
+
+.leaflet-container .leaflet-control-attribution {
+  background-color: rgba(255, 255, 255, 0.95);
+}
+
+/*
+ * Zoom controls.
+ */
+
+.leaflet-control-zoom-in,
+.leaflet-control-zoom-out {
+  text-indent: unset;
+}
+
+/*
+ * Fullscreen control.
+ */
+
+.leaflet-control-fullscreen a {
+  background-size: 30px 60px !important;
+  background-position: 0 0 !important;
+}
+.leaflet-fullscreen-on .leaflet-control-fullscreen a {
+  background-size: 30px 60px !important;
+  background-position: 0 -30px !important;
+}
+
+/*
+ * Layer controls.
+ */
 
 .leaflet-control-layers.leaflet-control {
   margin-right: 10px;
   margin-left: 10px;
+  padding: 0;
+}
+
+.leaflet-control-layers-list {
+  padding: 0;
+}
+
+.leaflet-control-layers fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.leaflet-control-layers-overlays > fieldset > .mapml-control-layers > summary,
+.leaflet-control-layers-overlays > fieldset > .mapml-control-layers > summary ~ * {
+  padding-left: 15px;
+  padding-right: 15px;
+}
+
+.leaflet-control-layers-overlays > fieldset > .mapml-control-layers > summary {
+  padding-top: 7.5px;
+  padding-bottom: 7.5px;
+}
+
+.leaflet-control-layers-overlays > fieldset > .mapml-control-layers details > summary {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.leaflet-control-layers-overlays > fieldset > .mapml-control-layers details {
+  padding-bottom: 4px;
+  margin: 0 0 0 24px;
+}
+
+.leaflet-control-layers-overlays > fieldset > .mapml-control-layers details > summary ~ * {
+  margin-top: 5px;
+}
+
+.leaflet-control-layers label {
+  display: inline;
+  margin-left: 5px;
+}
+
+.mapml-control-layers > input {
+  width: 100%;
+}
+
+.leaflet-control-layers-list .leaflet-control-layers-overlays > :not(:last-of-type) {
+  border-bottom: 1px solid #e3e3e3;
+}
+
+/* Revert Leaflet styles that are causing misalignment. */
+.leaflet-control-layers-selector {
+  margin-top: revert;
+  position: revert;
+}
+.mapml-control-layers summary label > * {
+  vertical-align: middle;
 }
 
 /* Disable dragging of controls. */
@@ -82,7 +190,6 @@
 .mapml-contextmenu {
   display: none;
   max-width: 100%;
-  box-shadow: 0 1px 7px rgba(0,0,0,0.4);
   -webkit-border-radius: 4px;
           border-radius: 4px;
   padding: 4px 0;
@@ -113,6 +220,6 @@
 }
       
 .mapml-contextmenu-separator {
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid #e3e3e3;
   margin: 5px 0;
 }

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -273,3 +273,14 @@ button,
 summary {
   cursor: pointer;
 }
+
+/*
+ * Visibility hack!
+ */
+
+/* Unset `visibility: hidden` in web-map.js/mapml-viewier.js – mitigates FOUC.
+   (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/154) */
+.leaflet-container .mapml-contextmenu,
+.leaflet-container .leaflet-control-container {
+  visibility: unset!important;
+}

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -110,7 +110,7 @@ export class WebMap extends HTMLMapElement {
     // Set default styles for the map element.
     let mapDefaultCSS = document.createElement('style');
     mapDefaultCSS.innerHTML =
-    `map[is="web-map"] {` +
+    `[is="web-map"] {` +
     `all: initial;` + // Reset properties inheritable from html/body, as some inherited styles may cause unexpected issues with the map element's components (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/140).
     `contain: content;` +  // Contain layout and paint calculations within the map element.
     `display: inline-block;` + // This together with dimension properties is required so that Leaflet isn't working with a height=0 box by default.
@@ -120,7 +120,7 @@ export class WebMap extends HTMLMapElement {
     `border-width: 2px;` +
     `border-style: inset;` +
     `}` +
-    `map[is="web-map"] .web-map {` +
+    `[is="web-map"] .web-map {` +
     `display: contents;` + // This div doesn't have to participate in layout by generating its own box.
     `}`;
     
@@ -128,7 +128,7 @@ export class WebMap extends HTMLMapElement {
     // `<area>` and `<div class="web-map">` (shadow root host) elements.
     let hideElementsCSS = document.createElement('style');
     hideElementsCSS.innerHTML =
-    `map[is="web-map"] > :not(area):not(.web-map) {` +
+    `[is="web-map"] > :not(area):not(.web-map) {` +
     `display: none!important;` +
     `}`;
     

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -112,7 +112,7 @@ export class WebMap extends HTMLMapElement {
     mapDefaultCSS.innerHTML =
     `[is="web-map"] {` +
     `all: initial;` + // Reset properties inheritable from html/body, as some inherited styles may cause unexpected issues with the map element's components (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/140).
-    `contain: content;` +  // Contain layout and paint calculations within the map element.
+    `contain: size;` + // Contain size calculations within the map element.
     `display: inline-block;` + // This together with dimension properties is required so that Leaflet isn't working with a height=0 box by default.
     `overflow: hidden;` + // Make the map element behave and look more like a native element.
     `height: 150px;` + // Provide a "default object size" (https://github.com/Maps4HTML/HTML-Map-Element/issues/31).
@@ -129,6 +129,9 @@ export class WebMap extends HTMLMapElement {
     
     let shadowRootCSS = document.createElement('style');
     shadowRootCSS.innerHTML =
+    `:host .leaflet-container {` +
+    `contain: strict;` + // Contain size, layout and paint calculations within the leaflet container element.
+    `}` +
     `:host(.leaflet-drag-target) .leaflet-control {` +
     `pointer-events: none;` + // Prevent `:hover` styles from applying to controls when the user is panning the map display and the cursor happens to move over a control.
     `}`;

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -129,6 +129,10 @@ export class WebMap extends HTMLMapElement {
     
     let shadowRootCSS = document.createElement('style');
     shadowRootCSS.innerHTML =
+    `:host .mapml-contextmenu,` +
+    `:host .leaflet-control-container {` +
+    `visibility: hidden!important;` + // Visibility hack to improve percieved performance (mitigate FOUC) – visibility is unset in mapml.css! (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/154).
+    `}` +
     `:host .leaflet-container {` +
     `contain: strict;` + // Contain size, layout and paint calculations within the leaflet container element.
     `}` +

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -120,6 +120,9 @@ export class WebMap extends HTMLMapElement {
     `border-width: 2px;` +
     `border-style: inset;` +
     `}` +
+    `[is="web-map"][frameborder="0"] {` +
+  	`border-width: 0;` +
+  	`}` +
     `[is="web-map"] .web-map {` +
     `display: contents;` + // This div doesn't have to participate in layout by generating its own box.
     `}`;

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -124,6 +124,12 @@ export class WebMap extends HTMLMapElement {
     `display: contents;` + // This div doesn't have to participate in layout by generating its own box.
     `}`;
     
+    let shadowRootCSS = document.createElement('style');
+    shadowRootCSS.innerHTML =
+    `:host(.leaflet-drag-target) .leaflet-control {` +
+    `pointer-events: none;` + // Prevent `:hover` styles from applying to controls when the user is panning the map display and the cursor happens to move over a control.
+    `}`;
+    
     // Hide all (light DOM) children of the map element except for the
     // `<area>` and `<div class="web-map">` (shadow root host) elements.
     let hideElementsCSS = document.createElement('style');
@@ -132,6 +138,7 @@ export class WebMap extends HTMLMapElement {
     `display: none!important;` +
     `}`;
     
+    shadowRoot.appendChild(shadowRootCSS);
     shadowRoot.appendChild(tmpl.content.cloneNode(true));
     shadowRoot.appendChild(this._container);
     this.appendChild(rootDiv);


### PR DESCRIPTION
A little CSS revision, most notable changes:

<details><summary>UI comparison</summary>

### Old (left) VS new (right)

<img width="800" src="https://user-images.githubusercontent.com/26493779/92416456-d8d03e00-f15d-11ea-96e3-fa49360033cb.png">

</details>

The UI update should improve usability, especially on touch devices.

<details><summary>FOUC mitigating <code>visibility</code> hack</summary>

### Old (left) VS new (right)

Simulated Fast 3G connection, page loaded from cold cache:

<img width="350" src="https://user-images.githubusercontent.com/26493779/92416613-a96e0100-f15e-11ea-9256-15c3635e2666.gif">
<img width="350" src="https://user-images.githubusercontent.com/26493779/92416622-af63e200-f15e-11ea-8589-16e8d5e7f33d.gif">


</details>

Partially solves https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/154. Not sure it's good enough to close out that issue however, as FOUC is still appearing when simulating _slow_ 3G connections, although the FOUC is visible for a much shorter period.

Thoughts?