### PR TITLE
Add provisional support for the `width` and `height` attributes

### DIFF
--- a/debug/inline_vectors.html
+++ b/debug/inline_vectors.html
@@ -6,8 +6,6 @@
       <script type="module" src="../dist/web-map.js"></script>
       <style>
         [is=web-map] {
-          width: 100%;
-          height: 400px;
           max-width: 100%;
         }
         .transparency {
@@ -16,7 +14,7 @@
     </style>
   </head>
   <body>
-    <map style="width:500px;height:500px" is="web-map" projection="CBMTILE" zoom="2" lat="61.209125" lon="-90.850837" width="900" height="400" controls>
+    <map is="web-map" projection="CBMTILE" zoom="2" lat="61.209125" lon="-90.850837" width="500" height="500" controls>
       <!-- <layer- label="Canada Base Map - Transportation (CBMT)" src="http://geogratis.gc.ca/mapml/en/cbmtile/cbmt/" checked></layer-> -->
       
       <layer- label="US Population Density" checked style="display: none">

--- a/debug/select-test.html
+++ b/debug/select-test.html
@@ -9,7 +9,7 @@
         </style>
     </head>
   <body>
-    <map is="web-map" projection="CBMTILE" zoom="2" lat="61.209125" lon="-90.850837" width="900" height="400" controls>
+    <map is="web-map" projection="CBMTILE" zoom="2" lat="61.209125" lon="-90.850837" controls>
       <layer- label='Territorial Evolution MapML document' src='./select-test.mapml' ></layer->
       <layer- label="Territorial Evolution inline MapML-in-HTML" checked>
         <extent units="CBMTILE" method="GET">

--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -108,8 +108,8 @@ export class MapViewer extends HTMLElement {
     `contain: size;` + // Contain size calculations within the map element.
     `display: inline-block;` + // This together with dimension properties is required so that Leaflet isn't working with a height=0 box by default.
     `overflow: hidden;` + // Make the map element behave and look more like a native element.
-    `height: 150px;` + // Provide a "default object size" (https://github.com/Maps4HTML/HTML-Map-Element/issues/31).
-    `width: 300px;` +
+    `height: ${this.hasAttribute('height') ? this.getAttribute('height') + "px;" : "150px;"}` + // Provide a "default object size" (https://github.com/Maps4HTML/HTML-Map-Element/issues/31), unless `width` or `height` is used.
+    `width: ${this.hasAttribute('width') ? this.getAttribute('width') + "px;" : "300px;"}` +
     `border-width: 2px;` +
     `border-style: inset;` +
     `}` +

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -115,8 +115,8 @@ export class WebMap extends HTMLMapElement {
     `contain: size;` + // Contain size calculations within the map element.
     `display: inline-block;` + // This together with dimension properties is required so that Leaflet isn't working with a height=0 box by default.
     `overflow: hidden;` + // Make the map element behave and look more like a native element.
-    `height: 150px;` + // Provide a "default object size" (https://github.com/Maps4HTML/HTML-Map-Element/issues/31).
-    `width: 300px;` +
+    `height: ${this.hasAttribute('height') ? this.getAttribute('height') + "px;" : "150px;"}` + // Provide a "default object size" (https://github.com/Maps4HTML/HTML-Map-Element/issues/31), unless `width` or `height` is used.
+    `width: ${this.hasAttribute('width') ? this.getAttribute('width') + "px;" : "300px;"}` +
     `border-width: 2px;` +
     `border-style: inset;` +
     `}` +

--- a/test/e2e/layers/mapMLFeatures.html
+++ b/test/e2e/layers/mapMLFeatures.html
@@ -7,8 +7,6 @@
   <script type="module" src="web-map.js"></script>
   <style>
     [is=web-map] {
-      width: 100%;
-      height: 400px;
       max-width: 100%;
     }
 
@@ -19,7 +17,7 @@
 </head>
 
 <body>
-  <map style="height: 500px;width:500px;" is="web-map" projection="CBMTILE" zoom="2" lat="45.5052040" lon="-75.2202344"
+  <map is="web-map" projection="CBMTILE" zoom="2" lat="45.5052040" lon="-75.2202344" width="500" height="500"
     controls>
 
     <layer- label="Arizona" checked>

--- a/test/e2e/layers/mapMLStaticTileLayer.html
+++ b/test/e2e/layers/mapMLStaticTileLayer.html
@@ -23,7 +23,7 @@
 </head>
 
 <body>
-  <map is="web-map" projection="CBMTILE" zoom="2" lat="59.87304909" lon="-53.22587225" width="900" height="400"
+  <map is="web-map" projection="CBMTILE" zoom="2" lat="59.87304909" lon="-53.22587225"
     controls>
 
     <layer- label="Static MapML with tiles" checked>

--- a/test/e2e/layers/mapMLTemplatedFeatures.html
+++ b/test/e2e/layers/mapMLTemplatedFeatures.html
@@ -7,8 +7,6 @@
   <script type="module" src="web-map.js"></script>
   <style>
     [is=web-map] {
-      width: 100%;
-      height: 400px;
       max-width: 100%;
     }
 
@@ -19,7 +17,7 @@
 </head>
 
 <body>
-  <map style="width: 500px;height: 500px;" is="web-map" projection="CBMTILE" zoom="3" lat="45.5052040" lon="-75.2202344"
+  <map is="web-map" projection="CBMTILE" zoom="3" lat="45.5052040" lon="-75.2202344" width="500" height="500"
     controls>
     <layer- label="Alabama" checked>
       <meta name="zoom" content="min=2,max=5" />

--- a/test/e2e/layers/mapMLTemplatedTileLayer.html
+++ b/test/e2e/layers/mapMLTemplatedTileLayer.html
@@ -23,7 +23,7 @@
 </head>
 
 <body>
-  <map is="web-map" projection="WGS84" zoom="1" lat="59.87304909" lon="-53.22587225" width="900" height="400" controls>
+  <map is="web-map" projection="WGS84" zoom="1" lat="59.87304909" lon="-53.22587225" controls>
 
     <layer- label="Inline Templated Tile" checked>
       <meta name="zoom" content="min=1,max=2" />


### PR DESCRIPTION
Fix #152.

Add provisional support for `width` and `height` dimensional attributes on `<map>` and `<mapml-viewer>`.