### PR TITLE
Allows layer deselecting after debug mode is re-enabled

### DIFF
--- a/src/mapml/layers/DebugLayer.js
+++ b/src/mapml/layers/DebugLayer.js
@@ -151,8 +151,7 @@ export var DebugVectors = L.LayerGroup.extend({
     let center = map.options.crs.transformation.transform(L.point(0, 0), map.options.crs.scale(0));
     this._centerVector = L.circle(map.options.crs.pointToLatLng(center, 0), { radius: 250 });
     this._centerVector.bindTooltip("Projection Center");
-
-    this.addLayer(this._centerVector);
+    
     this._addBounds();
   },
   onRemove: function (map) {

--- a/src/mapml/layers/DebugLayer.js
+++ b/src/mapml/layers/DebugLayer.js
@@ -151,16 +151,16 @@ export var DebugVectors = L.LayerGroup.extend({
     let center = map.options.crs.transformation.transform(L.point(0, 0), map.options.crs.scale(0));
     this._centerVector = L.circle(map.options.crs.pointToLatLng(center, 0), { radius: 250 });
     this._centerVector.bindTooltip("Projection Center");
-    
-    this._addBounds();
+
+    this._addBounds(map);
   },
   onRemove: function (map) {
     this.clearLayers();
   },
 
-  _addBounds: function () {
-    let id = Object.keys(this._map._layers),
-      layers = this._map._layers,
+  _addBounds: function (map) {
+    let id = Object.keys(map._layers),
+      layers = map._layers,
       colors = ["#FF5733", "#8DFF33", "#3397FF", "#E433FF", "#F3FF33"],
       j = 0;
 
@@ -190,7 +190,7 @@ export var DebugVectors = L.LayerGroup.extend({
 
   _mapLayerUpdate: function (e) {
     this.clearLayers();
-    this._addBounds();
+    this._addBounds(e.target);
   },
 });
 

--- a/test/e2e/core/debugMode.test.js
+++ b/test/e2e/core/debugMode.test.js
@@ -2,21 +2,6 @@ const playwright = require("playwright");
 jest.setTimeout(50000);
 (async () => {
 
-  //expected topLeft values in the different cs, at the different
-  //positions the map goes in
-  let expectedPCRS = [
-    { horizontal: -5537023.0124460235, vertical: 2671749.64016594 },
-    { horizontal: -2810486.309372615, vertical: 5328171.619676568 }];
-  let expectedGCRS = [
-    { horizontal: -134.50882532096858, vertical: 34.758856143866666 },
-    { horizontal: -146.23778791492126, vertical: 54.997129539321016 }];
-  let expectedFirstTileMatrix = [
-    { horizontal: 2.96484375, vertical: 3.7304687500000004 },
-    { horizontal: 3.242456896551724, vertical: 3.4599946120689657 }];
-  let expectedFirstTCRS = [
-    { horizontal: 759, vertical: 955.0000000000001 },
-    { horizontal: 830.0689655172414, vertical: 885.7586206896552 }];
-
   for (const browserType of BROWSER) {
     describe(
       "Playwright Map Element Tests in " + browserType,
@@ -123,6 +108,58 @@ jest.setTimeout(50000);
           expect(tcrs).toEqual("tcrs: x:909.00, y:1030.00");
           expect(pcrs).toEqual("pcrs: easting:217676.00, northing:-205599.86");
           expect(gcrs).toEqual("gcrs: lon: -92.15, lat: 47.11");
+        });
+
+        test("[" + browserType + "]" + " Debug mode correctly re-enabled after disabling", async () => {
+          await page.$eval(
+            "body > mapml-viewer",
+            (map) => map.toggleDebug()
+          );
+
+          await page.$eval(
+            "body > mapml-viewer",
+            (map) => map.toggleDebug()
+          );
+
+          const panel = await page.$eval(
+            "div > div.mapml-debug > div.mapml-debug-panel",
+            (panelElem) => panelElem.childElementCount
+          );
+
+          const banner = await page.$eval(
+            "div > div.mapml-debug > div.mapml-debug-banner",
+            (bannerElem) => bannerElem.innerText
+          );
+
+          const grid = await page.$eval(
+            "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid",
+            (gridElem) => gridElem.childElementCount
+          )
+
+          expect(panel).toEqual(6);
+          expect(banner).toEqual("DEBUG MODE");
+          expect(grid).toEqual(1);
+
+        });
+
+        test("[" + browserType + "]" + " Layer deselected then reselected", async () => {
+          await page.hover(".leaflet-top.leaflet-right");
+          await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > details > summary");
+          const feature = await page.$eval(
+            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g",
+            (tile) => tile.childElementCount
+          );
+          expect(feature).toEqual(3);
+        });
+
+        test("[" + browserType + "]" + " Layer deselected then reselected", async () => {
+          await page.hover(".leaflet-top.leaflet-right");
+          await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > details > summary");
+          const feature = await page.$eval(
+            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(4)",
+            (tile) => tile.getAttribute("d")
+          );
+          expect(feature).toEqual("M82.51724137931035 332.27586206896535L347.34482758620686 332.27586206896535L347.34482758620686 -38.48275862068965L82.51724137931035 -38.48275862068965z");
         });
       }
     );


### PR DESCRIPTION
Lets users enable -> disable -> re-enable debug mode and still have the option of deselecting layers without throwing an error in the console.

Closes #161 