### PR TITLE
Updates layer controls and map visibility based on <layer-> checked attribute

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -113,7 +113,7 @@ export class MapLayer extends HTMLElement {
       break;
       case 'checked': 
         if (this._layer) {
-          if (newValue !== null) {
+          if (typeof newValue === "string") {
             this.parentElement._map.addLayer(this._layer);
           } else {
             this.parentElement._map.removeLayer(this._layer);

--- a/src/layer.js
+++ b/src/layer.js
@@ -5,7 +5,7 @@ import './mapml.js';       // modified URI to make the function a property of wi
 
 export class MapLayer extends HTMLElement {
   static get observedAttributes() {
-    return ['src', 'label', 'checked', 'disabled', 'hidden'];
+    return ['src', 'label', 'checked', 'hidden'];
   }
   get src() {
     return this.hasAttribute('src')?this.getAttribute('src'):'';
@@ -105,12 +105,22 @@ export class MapLayer extends HTMLElement {
   }
   attributeChangedCallback(name, oldValue, newValue) {
     switch(name) {
-      case 'label': {
-          if (oldValue !== newValue) {
-            this.dispatchEvent(new CustomEvent('labelchanged', {detail: 
-              {target: this}}));
+      case 'label': 
+        if (oldValue !== newValue) {
+          this.dispatchEvent(new CustomEvent('labelchanged', {detail: 
+            {target: this}}));
+        }
+      break;
+      case 'checked': 
+        if (this._layer) {
+          if (newValue !== null) {
+            this.parentElement._map.addLayer(this._layer);
+          } else {
+            this.parentElement._map.removeLayer(this._layer);
           }
-      }
+          this.dispatchEvent(new Event("change", { bubbles: true }));
+        }
+      break;
     }
   }
   _onLayerExtentLoad(e) {

--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -199,7 +199,7 @@ export class MapViewer extends HTMLElement {
 
         // optionally add controls to the map
         if (this.controls) {
-          this._layerControl = M.mapMlLayerControl(null,{"collapsed": true}).addTo(this._map);
+          this._layerControl = M.mapMlLayerControl(null,{"collapsed": true, mapEl: this}).addTo(this._map);
           this._zoomControl = L.control.zoom().addTo(this._map);
           if (!this.controlslist.toLowerCase().includes("nofullscreen")) {
             this._fullScreenControl = L.control.fullscreen().addTo(this._map);
@@ -284,6 +284,12 @@ export class MapViewer extends HTMLElement {
   _setUpEvents() {
     this.addEventListener("drop", this._dropHandler, false);
     this.addEventListener("dragover", this._dragoverHandler, false);
+    this.addEventListener("change",
+    function(e) {
+      if(e.target.tagName === "LAYER-"){
+        this.dispatchEvent(new CustomEvent("layerchange", {details:{target: this, originalEvent: e}}));
+      }
+    }, false);
     this._map.on('load',
       function () {
         this.dispatchEvent(new CustomEvent('load', {detail: {target: this}}));
@@ -393,7 +399,7 @@ export class MapViewer extends HTMLElement {
     if (this._map) {
       if (controls && !this._layerControl) {
         this._zoomControl = L.control.zoom().addTo(this._map);
-        this._layerControl = M.mapMlLayerControl(null,{"collapsed": true}).addTo(this._map);
+        this._layerControl = M.mapMlLayerControl(null,{"collapsed": true, mapEl: this}).addTo(this._map);
         if (!this.controlslist.toLowerCase().includes("nofullscreen")) {
           this._fullScreenControl = L.control.fullscreen().addTo(this._map);
         }

--- a/src/mapml/layers/ControlLayer.js
+++ b/src/mapml/layers/ControlLayer.js
@@ -26,6 +26,7 @@ export var MapMLLayerControl = L.Control.Layers.extend({
     onAdd: function () {
         this._initLayout();
         this._map.on('moveend', this._validateExtents, this);
+        L.DomEvent.on(this.options.mapEl, "layerchange", this._validateExtents, this);
         this._update();
         //this._validateExtents();
         if(this._layers.length < 1 && !this._map._showControls){
@@ -70,6 +71,7 @@ export var MapMLLayerControl = L.Control.Layers.extend({
         let layerTypes = ["_staticTileLayer","_imageLayer","_mapmlvectors","_templatedLayer"],layerProjection;
         for (let i = 0; i < this._layers.length; i++) {
           let count = 0, total=0;
+          this._layers[i].input.checked = this._layers[i].layer._layerEl.checked;
           if(this._layers[i].layer._extent){
             layerProjection = this._layers[i].layer._extent.getAttribute('units') || 
               this._layers[i].layer._extent.getAttribute('content') ||

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -214,7 +214,7 @@ export class WebMap extends HTMLMapElement {
 
         // optionally add controls to the map
         if (this.controls) {
-          this._layerControl = M.mapMlLayerControl(null,{"collapsed": true}).addTo(this._map);
+          this._layerControl = M.mapMlLayerControl(null,{"collapsed": true, mapEl: this}).addTo(this._map);
           this._zoomControl = L.control.zoom().addTo(this._map);
           if (!this.controlslist.toLowerCase().includes("nofullscreen")) {
             this._fullScreenControl = L.control.fullscreen().addTo(this._map);
@@ -321,6 +321,12 @@ export class WebMap extends HTMLMapElement {
   _setUpEvents() {
     this.addEventListener("drop", this._dropHandler, false);
     this.addEventListener("dragover", this._dragoverHandler, false);
+    this.addEventListener("change",
+    function(e) {
+      if(e.target.tagName === "LAYER-"){
+        this.dispatchEvent(new CustomEvent("layerchange", {details:{target: this, originalEvent: e}}));
+      }
+    }, false);
     this._map.on('load',
       function () {
         this.dispatchEvent(new CustomEvent('load', {detail: {target: this}}));
@@ -430,7 +436,7 @@ export class WebMap extends HTMLMapElement {
     if (this._map) {
       if (controls && !this._layerControl) {
         this._zoomControl = L.control.zoom().addTo(this._map);
-        this._layerControl = M.mapMlLayerControl(null,{"collapsed": true}).addTo(this._map);
+        this._layerControl = M.mapMlLayerControl(null,{"collapsed": true, mapEl: this}).addTo(this._map);
         if (!this.controlslist.toLowerCase().includes("nofullscreen")) {
           this._fullScreenControl = L.control.fullscreen().addTo(this._map);
         }

--- a/test/e2e/core/checkedAttribute.test.js
+++ b/test/e2e/core/checkedAttribute.test.js
@@ -1,0 +1,45 @@
+const playwright = require("playwright");
+jest.setTimeout(50000);
+(async () => {
+  for (const browserType of BROWSER) {
+    describe(
+      "Playwright Checked Attribute Tests in " + browserType,
+      () => {
+        beforeAll(async () => {
+          browser = await playwright[browserType].launch({
+            headless: ISHEADLESS,
+            slowMo: 50,
+          });
+          context = await browser.newContext();
+          page = await context.newPage();
+          if (browserType === "firefox") {
+            await page.waitForNavigation();
+          }
+          await page.goto(PATH + "mapml-viewer.html");
+        });
+
+        afterAll(async function () {
+          await browser.close();
+        });
+
+        test("[" + browserType + "]" + " Initial map element extent", async () => {
+          await page.$eval("body > mapml-viewer > layer-",
+            (layer) => layer.removeAttribute("checked"));
+          await page.hover('div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > a');
+          const layerController = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > details > summary > label > input",
+            (controller) => controller.checked);
+
+          expect(layerController).toEqual(false);
+        });
+        test("[" + browserType + "]" + " Initial map element extent", async () => {
+          await page.$eval("body > mapml-viewer > layer-",
+            (layer) => layer.setAttribute("checked", ""));
+          const layerController = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > details > summary > label > input",
+            (controller) => controller.checked);
+
+          expect(layerController).toEqual(true);
+        });
+      }
+    );
+  }
+})();


### PR DESCRIPTION
Closes #175 

This PR adds the ability to change the `<layer->` checked attribute and have it reflected in the map and map layer controls.