### PR TITLE
Update to Leaflet 1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "web-map-custom-element",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5585,9 +5585,9 @@
       "dev": true
     },
     "leaflet": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.6.0.tgz",
-      "integrity": "sha512-CPkhyqWUKZKFJ6K8umN5/D2wrJ2+/8UIpXppY7QDnUZW5bZL5+SEI2J7GBpwh4LIupOKqbNSQXgqmrEJopHVNQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
+      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==",
       "dev": true
     },
     "leven": {
@@ -6552,19 +6552,19 @@
       "dev": true
     },
     "proj4": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.6.0.tgz",
-      "integrity": "sha512-ll2WyehUFOyzEZtN8hAiOTmZpuDCN5V+4A/HjhPbhlwVwlsFKnIHSZ3l3uhzgDndHjoL2MyERFGe9VmXN4rYUg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.6.2.tgz",
+      "integrity": "sha512-Pn0+HZtXb4JzuN8RR0VM7yyseegiYHbXkF+2FOdGpzRojcZ1BTjWxOh7qfp2vH0EyLu8pvcrhLxidwzgyUy/Gw==",
       "dev": true,
       "requires": {
         "mgrs": "1.0.0",
-        "wkt-parser": "^1.2.0"
+        "wkt-parser": "^1.2.4"
       }
     },
     "proj4leaflet": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/proj4leaflet/-/proj4leaflet-1.0.1.tgz",
-      "integrity": "sha1-llSEkERzBF3GlYGhnpTJZAR9l+c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/proj4leaflet/-/proj4leaflet-1.0.2.tgz",
+      "integrity": "sha512-6GdDeUlhX/tHUiMEj80xQhlPjwrXcdfD0D5OBymY8WvxfbmZcdhNqQk7n7nFf53ue6QdP9ls9ZPjsAxnbZDTsw==",
       "dev": true,
       "requires": {
         "proj4": "^2.3.14"

--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
     "grunt-rollup": "^11.3.0",
     "jest": "^26.1.0",
     "jest-playwright-preset": "^0.1.3",
-    "leaflet": "~1.6.0",
+    "leaflet": "^1.7.1",
     "path": "^0.12.7",
     "playwright": "^1.2.1",
-    "proj4": "2.6.0",
-    "proj4leaflet": "1.0.1",
+    "proj4": "^2.6.2",
+    "proj4leaflet": "^1.0.2",
     "rollup": "^2.23.1"
   }
 }


### PR DESCRIPTION
> The release was supposed to be numbered as 1.7.0, but a problem with the NPM dependencies appeared at the last minute, generating a bad build.

v1.7.0 includes plenty [bug fixes](https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#bug-fixes-1) and [usability/performance improvements](https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#improvements) which would be nice to get in.

- https://leafletjs.com/2020/09/04/leaflet-1.7.1.html
- https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md