### PR TITLE
Allows disabled attribute to update when controls are toggled off

### DIFF
--- a/test/e2e/core/debugMode.test.js
+++ b/test/e2e/core/debugMode.test.js
@@ -110,12 +110,32 @@ jest.setTimeout(50000);
           expect(gcrs).toEqual("gcrs: lon: -92.15, lat: 47.11");
         });
 
-        test("[" + browserType + "]" + " Debug mode correctly re-enabled after disabling", async () => {
+        test("[" + browserType + "]" + " Layer disabled attribute update when controls are toggled off", async () => {
           await page.$eval(
             "body > mapml-viewer",
             (map) => map.toggleDebug()
           );
 
+          await page.$eval(
+            "body > mapml-viewer",
+            (map) => map.zoomTo(-51, 170, 0)
+          );
+
+          await page.waitForTimeout(1000);
+
+          const layer = await page.$eval(
+            "body > mapml-viewer > layer-:nth-child(1)",
+            (elem) => elem.hasAttribute("disabled")
+          );
+
+          expect(layer).toEqual(true);
+        });
+
+        test("[" + browserType + "]" + " Debug mode correctly re-enabled after disabling", async () => {
+          await page.$eval(
+            "body > mapml-viewer",
+            (map) => map.back()
+          );
           await page.$eval(
             "body > mapml-viewer",
             (map) => map.toggleDebug()

--- a/test/e2e/core/layerAttributes.test.js
+++ b/test/e2e/core/layerAttributes.test.js
@@ -22,7 +22,7 @@ jest.setTimeout(50000);
           await browser.close();
         });
 
-        test("[" + browserType + "]" + " Initial map element extent", async () => {
+        test("[" + browserType + "]" + " Check attribute removed", async () => {
           await page.$eval("body > mapml-viewer > layer-",
             (layer) => layer.removeAttribute("checked"));
           await page.hover('div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > a');
@@ -31,7 +31,7 @@ jest.setTimeout(50000);
 
           expect(layerController).toEqual(false);
         });
-        test("[" + browserType + "]" + " Initial map element extent", async () => {
+        test("[" + browserType + "]" + " Check attribute added", async () => {
           await page.$eval("body > mapml-viewer > layer-",
             (layer) => layer.setAttribute("checked", ""));
           const layerController = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > details > summary > label > input",


### PR DESCRIPTION
Closes #190 

When controls on a map are toggled off the layer elements disabled attribute will still update. 