### PR TITLE
Add support for keywords for controlslist attribute

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -2,7 +2,6 @@ import './leaflet-src.js';  // a lightly modified version of Leaflet for use as 
 import './proj4-src.js';        // modified version of proj4; could be stripped down for mapml
 import './proj4leaflet.js'; // not modified, seems to adapt proj4 for leaflet use. 
 import './mapml.js';       // modified URI to make the function a property of window scope (possibly a bad thing to do).
-import { FALLBACK_PROJECTION } from '../utils/Constants';
 
 export class MapLayer extends HTMLElement {
   static get observedAttributes() {
@@ -175,7 +174,7 @@ export class MapLayer extends HTMLElement {
           layer._extent.getAttribute('content') ||
           layer._extent.querySelector("input[type=projection]").getAttribute('value');
       } else {
-        layerProjection = FALLBACK_PROJECTION;
+        layerProjection = "OSMTILE";
       }
       if( !layerProjection || layerProjection === map.options.mapEl.projection){
         for(let j = 0 ;j<layerTypes.length;j++){

--- a/src/layer.js
+++ b/src/layer.js
@@ -2,6 +2,7 @@ import './leaflet-src.js';  // a lightly modified version of Leaflet for use as 
 import './proj4-src.js';        // modified version of proj4; could be stripped down for mapml
 import './proj4leaflet.js'; // not modified, seems to adapt proj4 for leaflet use. 
 import './mapml.js';       // modified URI to make the function a property of window scope (possibly a bad thing to do).
+import { FALLBACK_PROJECTION } from '../utils/Constants';
 
 export class MapLayer extends HTMLElement {
   static get observedAttributes() {

--- a/src/mapml/control/ReloadButton.js
+++ b/src/mapml/control/ReloadButton.js
@@ -52,7 +52,7 @@ export var ReloadButton = L.Control.extend({
       L.DomUtil.removeClass(this._reloadButton, "leaflet-disabled");
       this._reloadButton.setAttribute("aria-disabled", "false");
 
-      if (this._disabled || this._map.options.mapEl._history.length <= 1) {
+      if (this._map && (this._disabled || this._map.options.mapEl._history.length <= 1)) {
         L.DomUtil.addClass(this._reloadButton, "leaflet-disabled");
         this._reloadButton.setAttribute("aria-disabled", "true");
       }

--- a/src/mapml/handlers/ContextMenu.js
+++ b/src/mapml/handlers/ContextMenu.js
@@ -251,7 +251,7 @@ export var ContextMenu = L.Handler.extend({
 
   _toggleControls: function(e){
     let mapEl = e instanceof KeyboardEvent?this._map.options.mapEl:this.options.mapEl;
-    mapEl._toggleControls(true);
+    mapEl._toggleControls();
   },
 
   _viewSource: function(e){

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -30,10 +30,12 @@ export class WebMap extends HTMLMapElement {
     return this.hasAttribute('controlslist') ? this.getAttribute("controlslist") : "";
   }
   set controlslist(val) {
-    if (val.toLowerCase() === "nofullscreen") {
-      this.setAttribute("controlslist", "nofullscreen");
-    }
+    let options = ["nofullscreen", "nozoom", "nolayer", "noreload"],
+        lowerVal = val.toLowerCase();
+    if (this.controlslist.includes(lowerVal) || !options.includes(lowerVal))return;
+    this.setAttribute("controlslist", this.controlslist+` ${lowerVal}`);
   }
+  
   get lat() {
     return this.hasAttribute("lat") ? this.getAttribute("lat") : "0";
   }
@@ -154,6 +156,14 @@ export class WebMap extends HTMLMapElement {
     this.appendChild(rootDiv);
     this.appendChild(hideElementsCSS);
     document.head.insertAdjacentElement('afterbegin', mapDefaultCSS);
+    this._toggleState = false;
+    this.controlsListObserver = new MutationObserver((m) => {
+      m.forEach((change)=>{
+        if(change.type==="attributes" && change.attributeName === "controlslist")
+          this.setControls(false,false,false);
+      });
+    });
+    this.controlsListObserver.observe(this, {attributes:true});
   }
   connectedCallback() {
     if (this.isConnected) {
@@ -212,15 +222,7 @@ export class WebMap extends HTMLMapElement {
         // the attribution control is not optional
         this._attributionControl =  this._map.attributionControl.setPrefix('<a href="https://www.w3.org/community/maps4html/" title="W3C Maps for HTML Community Group">Maps4HTML</a> | <a href="https://leafletjs.com" title="A JS library for interactive maps">Leaflet</a>');
 
-        // optionally add controls to the map
-        if (this.controls) {
-          this._layerControl = M.mapMlLayerControl(null,{"collapsed": true, mapEl: this}).addTo(this._map);
-          this._zoomControl = L.control.zoom().addTo(this._map);
-          this._reloadButton = M.reloadButton().addTo(this._map);
-          if (!this.controlslist.toLowerCase().includes("nofullscreen")) {
-            this._fullScreenControl = L.control.fullscreen().addTo(this._map);
-          }
-        }
+        this.setControls(false,false,true);
         if (this.hasAttribute('name')) {
           var name = this.getAttribute('name');
           if (name) {
@@ -260,6 +262,51 @@ export class WebMap extends HTMLMapElement {
   }
   adoptedCallback() {
 //    console.log('Custom map element moved to new page.');
+  }
+  setControls(isToggle, toggleShow, setup){
+    if (this.controls && this._map) {
+      let controls = ["_zoomControl", "_reloadButton", "_fullScreenControl", "_layerControl"],
+          options = ["nozoom", "noreload", "nofullscreen", 'nolayer'];
+
+      //removes the left hand controls, if not done they will be re-added in the incorrect order
+      //better to just reset them
+      for(let i = 0 ; i<3;i++){
+        if(this[controls[i]]){
+          this._map.removeControl(this[controls[i]]);
+          delete this[controls[i]];
+        }
+      }
+
+      if (!this.controlslist.toLowerCase().includes("nolayer") && !this._layerControl){
+        this._layerControl = M.mapMlLayerControl(null,{"collapsed": true, mapEl: this}).addTo(this._map);
+        //if this is the initial setup the layers dont need to be readded, causes issues if they are
+        if(!setup){
+          for (var i=0;i<this.layers.length;i++) {
+            if (!this.layers[i].hidden) {
+              this._layerControl.addOverlay(this.layers[i]._layer, this.layers[i].label);
+              this._map.on('moveend', this.layers[i]._validateDisabled,  this.layers[i]);
+              this.layers[i]._layerControl = this._layerControl;
+            }
+          }
+        }
+      }
+      if (!this.controlslist.toLowerCase().includes("nozoom") && !this._zoomControl){
+        this._zoomControl = L.control.zoom().addTo(this._map);
+      }
+      if (!this.controlslist.toLowerCase().includes("noreload") && !this._reloadButton){
+        this._reloadButton = M.reloadButton().addTo(this._map);
+      }
+      if (!this.controlslist.toLowerCase().includes("nofullscreen") && !this._fullScreenControl){
+        this._fullScreenControl = L.control.fullscreen().addTo(this._map);
+      }
+      //removes any control layers that are not needed, either by the toggling or by the controlslist attribute
+      for(let i in options){
+        if(this[controls[i]] && (this.controlslist.toLowerCase().includes(options[i]) || (isToggle && !toggleShow ))){
+          this._map.removeControl(this[controls[i]]);
+          delete this[controls[i]];
+        }
+      }
+    }
   }
   attributeChangedCallback(name, oldValue, newValue) {
 //    console.log('Attribute: ' + name + ' changed from: '+ oldValue + ' to: '+newValue);
@@ -433,34 +480,10 @@ export class WebMap extends HTMLMapElement {
           {target: this}}));
       }, this);
   }
-  _toggleControls(controls) {
+  _toggleControls() {
     if (this._map) {
-      if (controls && !this._layerControl) {
-        this._zoomControl = L.control.zoom().addTo(this._map);
-        this._reloadButton = M.reloadButton().addTo(this._map);
-        this._layerControl = M.mapMlLayerControl(null,{"collapsed": true, mapEl: this}).addTo(this._map);
-        if (!this.controlslist.toLowerCase().includes("nofullscreen")) {
-          this._fullScreenControl = L.control.fullscreen().addTo(this._map);
-        }
-        for (var i=0;i<this.layers.length;i++) {
-          if (!this.layers[i].hidden) {
-            this._layerControl.addOverlay(this.layers[i]._layer, this.layers[i].label);
-            this._map.on('moveend', this.layers[i]._validateDisabled,  this.layers[i]);
-            this.layers[i]._layerControl = this._layerControl;
-          }
-        }
-      } else if (this._layerControl) {
-        this._map.removeControl(this._layerControl);
-        this._map.removeControl(this._zoomControl);
-        this._map.removeControl(this._reloadButton);
-        if (this._fullScreenControl) {
-          this._map.removeControl(this._fullScreenControl);
-          delete this._fullScreenControl;
-        }
-        delete this._layerControl;
-        delete this._zoomControl;
-        delete this._reloadButton;
-      }
+        this.setControls(true, this._toggleState, false);
+        this._toggleState = !this._toggleState;
     }
   }
 


### PR DESCRIPTION
Adds support for nozoom, nolayer, noreload. (nofullscreen already supported).
This PR also consolidates code for toggle controls and controlslist change attribute into a new function `setControls(bool, bool, bool)`

MutationObserver watches for changes in the controlslist attribute, when change is detected the controls on the map are updated as needed. These changes are all compatible with the toggle controls menu item in the context menu.

Closes #173 
Closes #83 