### PR TITLE
Use legible font-sizes (fix Lighthouse audit failure)

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -28,6 +28,7 @@
         visibility: inherit;
 }
 
+/* Use legible font-sizes (Leaflet upstream PR: https://github.com/Leaflet/Leaflet/pull/7346). */
 .leaflet-control-scale-line,
 .leaflet-container .leaflet-control-scale,
 .leaflet-container .leaflet-control-attribution {

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -28,6 +28,12 @@
         visibility: inherit;
 }
 
+.leaflet-control-scale-line,
+.leaflet-container .leaflet-control-scale,
+.leaflet-container .leaflet-control-attribution {
+  font-size: 12px;
+}
+
 /*
  * Controls.
  */


### PR DESCRIPTION
Fixes Lighthouse Audit failure (doc: https://web.dev/font-size/):

<img width="700" src="https://user-images.githubusercontent.com/26493779/99911229-330b8480-2cf3-11eb-9a21-9468626ca013.png" lalt="Lighthouse audit failure: document doesnt use legible font-sizes">

Has upstream Leaflet PR: https://github.com/Leaflet/Leaflet/pull/7346.