### PR TITLE
Update debug mode styles

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -74,9 +74,12 @@
   border-style: inherit;
 }
 
+.mapml-contextmenu,
+.mapml-debug,
 .leaflet-bar,
 .leaflet-control-layers,
-.mapml-contextmenu,
+.leaflet-popup-content-wrapper,
+.leaflet-tooltip-pane .leaflet-tooltip,
 .leaflet-touch .leaflet-control-layers,
 .leaflet-touch .leaflet-bar {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2), 0 1px 2px rgb(0, 0, 0, 0.3);
@@ -225,6 +228,46 @@
 }
 
 /*
+ * Debug mode.
+ */
+
+.mapml-debug {
+  contain: content;
+  max-height: 100%;
+  max-width: 100%;
+  border-radius: 4px;
+  padding: 10px;
+  background-color: #fff;
+  cursor: default;
+}
+
+.mapml-debug-banner {
+  margin-left: 4px;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.mapml-debug-panel,
+.mapml-debug-grid {
+  font-family: monospace;
+}
+
+.mapml-debug-panel {
+  margin-top: 4px;
+}
+
+.mapml-debug-tile {
+  text-indent: 6px;
+  line-height: 1.8;
+}
+
+.mapml-debug-title,
+.mapml-debug-coordinates {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+/*
  * User interaction.
  */
 
@@ -236,7 +279,8 @@
 
 /* Disable text selection in controls. */
 .leaflet-control,
-.mapml-contextmenu {
+.mapml-contextmenu,
+.mapml-debug {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -302,28 +346,4 @@ summary {
 .leaflet-container .mapml-contextmenu,
 .leaflet-container .leaflet-control-container {
   visibility: unset!important;
-}
-.mapml-debug-panel {
-  max-height: 100%;
-  max-width: 100%;
-  box-shadow: 0 1px 7px rgba(0,0,0,0.4);
-  -webkit-border-radius: 4px;
-          border-radius: 4px;
-  padding: 4px 0;
-  background-color: #fff;
-  cursor: default;
-  -webkit-user-select: none;
-     -moz-user-select: none;    
-      -ms-user-select: none;
-          user-select: none;
-}
-
-.mapml-debug-coordinates{
-  padding-left: 4px;
-  padding-right: 4px;
-}
-
-.mapml-debug-title{
-  padding-left: 4px;
-  padding-right: 4px;
 }

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -261,7 +261,6 @@
   line-height: 1.8;
 }
 
-.mapml-debug-title,
 .mapml-debug-coordinates {
   padding-left: 4px;
   padding-right: 4px;

--- a/src/mapml/handlers/ContextMenu.js
+++ b/src/mapml/handlers/ContextMenu.js
@@ -104,7 +104,7 @@ export var ContextMenu = L.Handler.extend({
     this._keyboardEvent = false;
 
     this._container = L.DomUtil.create("div", "mapml-contextmenu", map._container);
-    this._container.style.zIndex = 10000;
+    this._container.style.zIndex = 10001;
     this._container.style.position = "absolute";
 
     this._container.style.width = "150px";
@@ -114,7 +114,7 @@ export var ContextMenu = L.Handler.extend({
     }
 
     this._coordMenu = L.DomUtil.create("div", "mapml-contextmenu mapml-submenu", this._container);
-    this._coordMenu.style.zIndex = 10000;
+    this._coordMenu.style.zIndex = 10001;
     this._coordMenu.style.position = "absolute";
 
     this._coordMenu.style.width = "80px";
@@ -130,7 +130,7 @@ export var ContextMenu = L.Handler.extend({
     this._items[7].el = this._createItem(this._container, this._items[7]);
 
     this._layerMenu = L.DomUtil.create("div", "mapml-contextmenu mapml-layer-menu", map._container);
-    this._layerMenu.style.zIndex = 10000;
+    this._layerMenu.style.zIndex = 10001;
     this._layerMenu.style.position = "absolute";
     this._layerMenu.style.width = "150px";
     for (let i = 0; i < this._layerItems.length; i++) {

--- a/src/mapml/layers/DebugLayer.js
+++ b/src/mapml/layers/DebugLayer.js
@@ -10,6 +10,14 @@ export var DebugOverlay = L.Layer.extend({
         toggleGridBtn.overlay = this;
         L.DomEvent.on(toggleGridBtn, 'click',this._toggleGrid);
         this._controlPanel.appendChild(toggleGridBtn); */
+        
+    this._container.style.width = 150;
+    this._container.style.zIndex = 10000;
+    this._container.style.position = "absolute";
+    this._container.style.top = "auto";
+    this._container.style.bottom = "10px";
+    this._container.style.left = "10px";
+    this._container.style.right = "auto";
 
     this._grid = debugGrid({
       className: "mapml-debug-grid",
@@ -53,6 +61,9 @@ export var DebugPanel = L.Layer.extend({
 
   onAdd: function (map) {
     let mapSize = map.getSize();
+    
+    this._title = L.DomUtil.create("div", "mapml-debug-banner", this.options.pane);
+    this._title.innerHTML = "Debug mode";
 
     //conditionally show debug panel only when the map has enough space for it
     if (mapSize.x > 400 || mapSize.y > 300) {
@@ -60,13 +71,6 @@ export var DebugPanel = L.Layer.extend({
       map.debug._infoContainer = this._debugContainer = L.DomUtil.create("div", "mapml-debug-panel", this.options.pane);
 
       let infoContainer = map.debug._infoContainer;
-      infoContainer.style.zIndex = 10000;
-      infoContainer.style.width = 150;
-      infoContainer.style.position = "absolute";
-      infoContainer.style.top = "auto";
-      infoContainer.style.bottom = "4px";
-      infoContainer.style.right = "auto";
-      infoContainer.style.left = "4px";
 
       map.debug._tileCoord = L.DomUtil.create("div", "mapml-debug-coordinates", infoContainer);
       map.debug._tileMatrixCoord = L.DomUtil.create("div", "mapml-debug-coordinates", infoContainer);
@@ -78,14 +82,6 @@ export var DebugPanel = L.Layer.extend({
       this._map.on("mousemove", this._updateCoords);
     }
 
-    this._title = L.DomUtil.create("div", "mapml-debug-banner", this.options.pane);
-    this._title.innerHTML = "DEBUG MODE";
-    this._title.style.zIndex = 10000;
-    this._title.style.position = "absolute";
-    this._title.style.top = "4px";
-    this._title.style.bottom = "auto";
-    this._title.style.left = "auto";
-    this._title.style.right = "4px";
   },
   onRemove: function () {
     L.DomUtil.remove(this._title);

--- a/src/mapml/layers/DebugLayer.js
+++ b/src/mapml/layers/DebugLayer.js
@@ -1,23 +1,29 @@
 export var DebugOverlay = L.Layer.extend({
 
   onAdd: function (map) {
-    this._container = L.DomUtil.create("div", "mapml-debug", map._container);
+    
+    let mapSize = map.getSize();
+    
+    //conditionally show debug panel only when the map has enough space for it
+    if (mapSize.x > 400 || mapSize.y > 300) {
+      this._container = L.DomUtil.create("div", "mapml-debug", map._container);
 
-    //adds a control panel
-    /*  this._controlPanel = L.DomUtil.create("div", "mapml-debug-control mapml-debug-panel", this._container);
-        let toggleGridBtn = document.createElement('button'), gridBtnText = document.createTextNode("Toggle Grid");
-        toggleGridBtn.appendChild(gridBtnText);
-        toggleGridBtn.overlay = this;
-        L.DomEvent.on(toggleGridBtn, 'click',this._toggleGrid);
-        this._controlPanel.appendChild(toggleGridBtn); */
-        
-    this._container.style.width = 150;
-    this._container.style.zIndex = 10000;
-    this._container.style.position = "absolute";
-    this._container.style.top = "auto";
-    this._container.style.bottom = "10px";
-    this._container.style.left = "10px";
-    this._container.style.right = "auto";
+      //adds a control panel
+      /*  this._controlPanel = L.DomUtil.create("div", "mapml-debug-control mapml-debug-panel", this._container);
+          let toggleGridBtn = document.createElement('button'), gridBtnText = document.createTextNode("Toggle Grid");
+          toggleGridBtn.appendChild(gridBtnText);
+          toggleGridBtn.overlay = this;
+          L.DomEvent.on(toggleGridBtn, 'click',this._toggleGrid);
+          this._controlPanel.appendChild(toggleGridBtn); */
+          
+      this._container.style.width = 150;
+      this._container.style.zIndex = 10000;
+      this._container.style.position = "absolute";
+      this._container.style.top = "auto";
+      this._container.style.bottom = "10px";
+      this._container.style.left = "10px";
+      this._container.style.right = "auto";
+    }
 
     this._grid = debugGrid({
       className: "mapml-debug-grid",
@@ -61,12 +67,12 @@ export var DebugPanel = L.Layer.extend({
 
   onAdd: function (map) {
     let mapSize = map.getSize();
-    
-    this._title = L.DomUtil.create("div", "mapml-debug-banner", this.options.pane);
-    this._title.innerHTML = "Debug mode";
 
     //conditionally show debug panel only when the map has enough space for it
     if (mapSize.x > 400 || mapSize.y > 300) {
+      this._title = L.DomUtil.create("div", "mapml-debug-banner", this.options.pane);
+      this._title.innerHTML = "Debug mode";
+      
       map.debug = {};
       map.debug._infoContainer = this._debugContainer = L.DomUtil.create("div", "mapml-debug-panel", this.options.pane);
 

--- a/src/mapml/layers/DebugLayer.js
+++ b/src/mapml/layers/DebugLayer.js
@@ -4,7 +4,7 @@ export var DebugOverlay = L.Layer.extend({
     
     let mapSize = map.getSize();
     
-    //conditionally show debug panel only when the map has enough space for it
+    //conditionally show container for debug panel/banner only when the map has enough space for it
     if (mapSize.x > 400 || mapSize.y > 300) {
       this._container = L.DomUtil.create("div", "mapml-debug", map._container);
 


### PR DESCRIPTION
- [x] Update CSS including `margin`, `box-shadow`,  to match other components, such as the context menu and controls.
- [x] Create some spacing between the debug grid borders and its text by modifying `text-indent` and `line-height` of `.mapml-debug-tile`.
- [x] Move the "Debug mode" banner into `.debug-mode`, as such it wont overlap the layer control.

### Current style
<img width="450" src="https://user-images.githubusercontent.com/26493779/101285344-e93b9780-37e4-11eb-8004-20f0556b0cc8.png" alt="old debug mode styles">

### New style
<img width="450" src="https://user-images.githubusercontent.com/26493779/101285352-f193d280-37e4-11eb-9392-09a76d7cc45c.png" alt="new debug mode styles">