### PR TITLE
Adds delays to test to allow mapml-viewer to update before checking condition and fixes decimal places on coordinates

### DIFF
--- a/src/mapml/layers/DebugLayer.js
+++ b/src/mapml/layers/DebugLayer.js
@@ -106,7 +106,7 @@ export var DebugPanel = L.Layer.extend({
     if (pointJ < 0) pointJ += 256;
 
     this.debug._tileCoord.innerHTML = `tile: i: ${Math.trunc(pointI)}, j: ${Math.trunc(pointJ)}`;
-    this.debug._mapCoord.innerHTML = `map: i: ${e.containerPoint.x}, j: ${e.containerPoint.y}`;
+    this.debug._mapCoord.innerHTML = `map: i: ${Math.trunc(e.containerPoint.x)}, j: ${Math.trunc(e.containerPoint.y)}`;
     this.debug._gcrsCoord.innerHTML = `gcrs: lon: ${e.latlng.lng.toFixed(6)}, lat: ${e.latlng.lat.toFixed(6)}`;
     this.debug._tcrsCoord.innerHTML = `tcrs: x:${Math.trunc(point.x)}, y:${Math.trunc(point.y)}`;
     this.debug._tileMatrixCoord.innerHTML = `tilematrix: column:${Math.trunc(point.x / 256)}, row:${Math.trunc(point.y / 256)}`;

--- a/src/mapml/layers/DebugLayer.js
+++ b/src/mapml/layers/DebugLayer.js
@@ -89,7 +89,7 @@ export var DebugPanel = L.Layer.extend({
   },
   onRemove: function () {
     L.DomUtil.remove(this._title);
-    if(this._debugContainer){
+    if (this._debugContainer) {
       L.DomUtil.remove(this._debugContainer);
       this._map.off("mousemove", this._updateCoords);
     }
@@ -105,11 +105,11 @@ export var DebugPanel = L.Layer.extend({
     if (pointI < 0) pointI += 256;
     if (pointJ < 0) pointJ += 256;
 
-    this.debug._tileCoord.innerHTML = `tile: i: ${Math.round(pointI)}, j: ${Math.round(pointJ)}`;
+    this.debug._tileCoord.innerHTML = `tile: i: ${Math.trunc(pointI)}, j: ${Math.trunc(pointJ)}`;
     this.debug._mapCoord.innerHTML = `map: i: ${e.containerPoint.x}, j: ${e.containerPoint.y}`;
-    this.debug._gcrsCoord.innerHTML = `gcrs: lon: ${e.latlng.lng.toFixed(2)}, lat: ${e.latlng.lat.toFixed(2)}`;
-    this.debug._tcrsCoord.innerHTML = `tcrs: x:${point.x.toFixed(2)}, y:${point.y.toFixed(2)}`;
-    this.debug._tileMatrixCoord.innerHTML = `tilematrix: column:${(point.x / 256).toFixed(2)}, row:${(point.y / 256).toFixed(2)}`;
+    this.debug._gcrsCoord.innerHTML = `gcrs: lon: ${e.latlng.lng.toFixed(6)}, lat: ${e.latlng.lat.toFixed(6)}`;
+    this.debug._tcrsCoord.innerHTML = `tcrs: x:${Math.trunc(point.x)}, y:${Math.trunc(point.y)}`;
+    this.debug._tileMatrixCoord.innerHTML = `tilematrix: column:${Math.trunc(point.x / 256)}, row:${Math.trunc(point.y / 256)}`;
     this.debug._pcrsCoord.innerHTML = `pcrs: easting:${pcrs.x.toFixed(2)}, northing:${pcrs.y.toFixed(2)}`;
   },
 

--- a/test/e2e/core/debugMode.test.js
+++ b/test/e2e/core/debugMode.test.js
@@ -103,11 +103,11 @@ jest.setTimeout(50000);
           );
 
           expect(tile).toEqual("tile: i: 141, j: 6");
-          expect(matrix).toEqual("tilematrix: column:3.55, row:4.02");
+          expect(matrix).toEqual("tilematrix: column:3, row:4");
           expect(map).toEqual("map: i: 250, j: 250");
-          expect(tcrs).toEqual("tcrs: x:909.00, y:1030.00");
+          expect(tcrs).toEqual("tcrs: x:909, y:1030");
           expect(pcrs).toEqual("pcrs: easting:217676.00, northing:-205599.86");
-          expect(gcrs).toEqual("gcrs: lon: -92.15, lat: 47.11");
+          expect(gcrs).toEqual("gcrs: lon: -92.152897, lat: 47.114275");
         });
 
         test("[" + browserType + "]" + " Layer disabled attribute update when controls are toggled off", async () => {

--- a/test/e2e/core/mapContextMenu.test.js
+++ b/test/e2e/core/mapContextMenu.test.js
@@ -89,6 +89,7 @@ jest.setTimeout(50000);
           await page.waitForTimeout(1000);
           await page.click("body > map", { button: "right" });
           await page.click("div > div.mapml-contextmenu > a:nth-child(1)");
+          await page.waitForTimeout(1000);
           const extent = await page.$eval(
             "body > map",
             (map) => map.extent
@@ -104,6 +105,7 @@ jest.setTimeout(50000);
         test("[" + browserType + "]" + " Context menu, back item at intial location", async () => {
           await page.click("body > map", { button: "right" });
           await page.click("div > div.mapml-contextmenu > a:nth-child(1)");
+          await page.waitForTimeout(1000);
           const extent = await page.$eval(
             "body > map",
             (map) => map.extent
@@ -119,6 +121,7 @@ jest.setTimeout(50000);
         test("[" + browserType + "]" + " Context menu, forward item", async () => {
           await page.click("body > map", { button: "right" });
           await page.click("div > div.mapml-contextmenu > a:nth-child(2)");
+          await page.waitForTimeout(1000);
           const extent = await page.$eval(
             "body > map",
             (map) => map.extent
@@ -133,6 +136,7 @@ jest.setTimeout(50000);
         test("[" + browserType + "]" + " Context menu, forward item at most recent location", async () => {
           await page.click("body > map", { button: "right" });
           await page.click("div > div.mapml-contextmenu > a:nth-child(2)");
+          await page.waitForTimeout(1000);
           const extent = await page.$eval(
             "body > map",
             (map) => map.extent

--- a/test/e2e/mapml-viewer/viewerContextMenu.test.js
+++ b/test/e2e/mapml-viewer/viewerContextMenu.test.js
@@ -89,6 +89,7 @@ jest.setTimeout(50000);
           await page.waitForTimeout(1000);
           await page.click("body > mapml-viewer", { button: "right" });
           await page.click("div > div.mapml-contextmenu > a:nth-child(1)");
+          await page.waitForTimeout(1000);
           const extent = await page.$eval(
             "body > mapml-viewer",
             (map) => map.extent
@@ -104,6 +105,7 @@ jest.setTimeout(50000);
         test("[" + browserType + "]" + " Context menu, back item at intial location", async () => {
           await page.click("body > mapml-viewer", { button: "right" });
           await page.click("div > div.mapml-contextmenu > a:nth-child(1)");
+          await page.waitForTimeout(1000);
           const extent = await page.$eval(
             "body > mapml-viewer",
             (map) => map.extent
@@ -119,6 +121,7 @@ jest.setTimeout(50000);
         test("[" + browserType + "]" + " Context menu, forward item", async () => {
           await page.click("body > mapml-viewer", { button: "right" });
           await page.click("div > div.mapml-contextmenu > a:nth-child(2)");
+          await page.waitForTimeout(1000);
           const extent = await page.$eval(
             "body > mapml-viewer",
             (map) => map.extent
@@ -133,6 +136,7 @@ jest.setTimeout(50000);
         test("[" + browserType + "]" + " Context menu, forward item at most recent location", async () => {
           await page.click("body > mapml-viewer", { button: "right" });
           await page.click("div > div.mapml-contextmenu > a:nth-child(2)");
+          await page.waitForTimeout(1000);
           const extent = await page.$eval(
             "body > mapml-viewer",
             (map) => map.extent


### PR DESCRIPTION
Closes #217 
Also Travis CI runs tests faster than local machines, they need to be told to wait for the mapml-viewer to update before moving to the next line of code in the tests. 

The delays in mapml-viewer are more visual animations than performance though, like the gliding and sliding effects.