### PR TITLE
Increase default size of primary tap targets

### DIFF
--- a/index-mapml-viewer.html
+++ b/index-mapml-viewer.html
@@ -54,7 +54,7 @@
     </noscript>
   </head>
   <body>
-    <mapml-viewer projection="CBMTILE" zoom="2" lat="45" lon="-90" controls controlslist="nofullscreen">
+    <mapml-viewer projection="CBMTILE" zoom="2" lat="45" lon="-90" controls controlslist="nofullscreen noreload">
       <layer- label="CBMT" src="https://geogratis.gc.ca/mapml/en/cbmtile/cbmt/" checked></layer->
     </mapml-viewer>
   </body>

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -38,19 +38,27 @@
 /*
  * Controls.
  */
+ 
+ .leaflet-top .leaflet-control {
+   margin-top: 5px;
+ }
+ 
+ .leaflet-left .leaflet-control {
+   margin-left: 5px;
+ }
 
 .leaflet-bar a {
   box-sizing: border-box;
-  width: 30px !important;
-  height: 30px !important;
-  line-height: 30px !important;
-  font-size: 24px !important;
+  width: 44px !important;
+  height: 44px !important;
+  line-height: 44px !important;
+  font-size: 34px !important;
   font-weight: normal;
 }
 
 .leaflet-control-layers-toggle {
-  width: 36px !important;
-  height: 36px !important;
+  width: 44px !important;
+  height: 44px !important;
 }
 
 .leaflet-bar a,
@@ -103,12 +111,12 @@
  */
 
 .leaflet-control-fullscreen a {
-  background-size: 30px 60px !important;
-  background-position: 0 0 !important;
+  background-size: 38px 76px !important;
+  background-position: 3px 3px !important;
 }
 .leaflet-fullscreen-on .leaflet-control-fullscreen a {
-  background-size: 30px 60px !important;
-  background-position: 0 -30px !important;
+  background-size: 38px 76px !important;
+  background-position: 3px -35px !important;
 }
 
 /*
@@ -116,8 +124,8 @@
  */
 
 .leaflet-control-layers.leaflet-control {
-  margin-right: 10px;
-  margin-left: 10px;
+  margin-right: 5px;
+  margin-left: 5px;
   padding: 0;
 }
 

--- a/src/mapml/layers/DebugLayer.js
+++ b/src/mapml/layers/DebugLayer.js
@@ -20,8 +20,8 @@ export var DebugOverlay = L.Layer.extend({
       this._container.style.zIndex = 10000;
       this._container.style.position = "absolute";
       this._container.style.top = "auto";
-      this._container.style.bottom = "10px";
-      this._container.style.left = "10px";
+      this._container.style.bottom = "5px";
+      this._container.style.left = "5px";
       this._container.style.right = "auto";
     }
 


### PR DESCRIPTION
Fix https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/215. Although there may still be work to be done in this area, that issue is specifically about increasing the size of the default controls so I think it makes sense to close that one out, given this PR.

- [x] Increase default size of controls to 44x44px
- [x] Decrease margin of controls (not needed per se, but increases the size of the interaction area on the map display, especially in small sized maps)

Increasing the size of controls obviously leaves less room for additional controls, but that's a separate issue (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/224).

## Preview

### Current
<img width="300" src="https://user-images.githubusercontent.com/26493779/101674809-417acf80-3a59-11eb-8916-c224cb5a8e39.png" alt="old buttons">

### New
<img width="300" src="https://user-images.githubusercontent.com/26493779/101674580-f660bc80-3a58-11eb-9993-cb1cf6f330d8.png" alt="new buttons">

(albeit with added `noreload` to `controlslist`)

### New: larger map size, no controls excluded
<img width="450" src="https://user-images.githubusercontent.com/26493779/101674592-f9f44380-3a58-11eb-9d18-86587625e412.png" alt="new buttons, big map">

