### PR TITLE
[debug mode] Fix issue with debug grid overlapping the tooltip

### DIFF
--- a/src/mapml/layers/DebugLayer.js
+++ b/src/mapml/layers/DebugLayer.js
@@ -28,7 +28,7 @@ export var DebugOverlay = L.Layer.extend({
     this._grid = debugGrid({
       className: "mapml-debug-grid",
       pane: map._panes.mapPane,
-      zIndex: 10000,
+      zIndex: 400,
     });
     map.addLayer(this._grid);
 


### PR DESCRIPTION
Fix an issue with the debug grid rendering on top of the tooltip by decreasing `mapml-debug-grid`'s `z-index`.

## Preview

### Before

![grid-debug-z-index-before](https://user-images.githubusercontent.com/26493779/103446316-88399f00-4c7e-11eb-97a0-45c32b37f996.png)

### After

![grid-debug-z-index-after](https://user-images.githubusercontent.com/26493779/103446339-b9b26a80-4c7e-11eb-82ef-d1b9d09fa7d0.png)
