### PR TITLE
Template Layer ability to default to meta element before projection extent, also allows extent to be defined using different units

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3704,9 +3704,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "ip-regex": {

--- a/src/mapml/index.js
+++ b/src/mapml/index.js
@@ -573,6 +573,8 @@ window.M = M;
   });
 }());
 
+M.convertPCRSBounds = Util.convertPCRSBounds;
+M.axisToXY = Util.axisToXY;
 M.csToAxes = Util.csToAxes;
 M.convertAndFormatPCRS = Util.convertAndFormatPCRS;
 M.axisToCS = Util.axisToCS;

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -258,7 +258,7 @@ export var MapMLLayer = L.Layer.extend({
     },
     _onZoomAnim: function(e) {
       var toZoom = e.zoom,
-          zoom = this._extent.querySelector("input[type=zoom]"),
+          zoom = this._extent ? this._extent.querySelector("input[type=zoom]") : null,
           min = zoom && zoom.hasAttribute("min") ? parseInt(zoom.getAttribute("min")) : this._map.getMinZoom(),
           max =  zoom && zoom.hasAttribute("max") ? parseInt(zoom.getAttribute("max")) : this._map.getMaxZoom(),
           canZoom = (toZoom < min && this._extent.zoomout) || (toZoom > max && this._extent.zoomin);

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -620,9 +620,9 @@ export var MapMLLayer = L.Layer.extend({
             if (this.readyState === this.DONE && mapml.querySelector) {
                 var serverExtent = mapml.querySelector('extent') || mapml.querySelector('meta[name=projection]'), projection;
 
-                if (serverExtent.tagName === "extent" && serverExtent.hasAttribute('units')){
+                if (serverExtent.tagName.toLowerCase() === "extent" && serverExtent.hasAttribute('units')){
                   projection = serverExtent.getAttribute("units");
-                } else if (serverExtent.tagName === "meta" && serverExtent.hasAttribute('content')) {
+                } else if (serverExtent.tagName.toLowerCase() === "meta" && serverExtent.hasAttribute('content')) {
                   projection = M.metaContentToObject(serverExtent.getAttribute('content')).content;
                 }
                     

--- a/src/mapml/utils/Util.js
+++ b/src/mapml/utils/Util.js
@@ -176,6 +176,49 @@ export var Util = {
     } catch (e) {return undefined;}
   },
 
+  axisToXY: function(axis){
+    try{
+      switch(axis.toLowerCase()){
+        case "i":
+        case "column":
+        case "longitude":
+        case "x":
+        case "easting":
+          return "x";
+        case "row":
+        case "j":
+        case "latitude":
+        case "y":
+        case "northing":
+          return "y";
+
+        default:
+          return undefined;
+      }
+    } catch (e) {return undefined;}
+  },
+
+  convertPCRSBounds: function(pcrsBounds, zoom, projection, cs){
+    if(!pcrsBounds || !zoom && +zoom !== 0 || !cs) return undefined;
+    switch (cs.toLowerCase()) {
+      case "pcrs":
+        return pcrsBounds;
+      case "tcrs": 
+      case "tilematrix":
+        let minPixel = this[projection].transformation.transform(pcrsBounds.min, this[projection].scale(+zoom)),
+            maxPixel = this[projection].transformation.transform(pcrsBounds.max, this[projection].scale(+zoom));
+        if (cs.toLowerCase() === "tcrs") return L.bounds(minPixel, maxPixel);
+        let tileSize = M[projection].options.crs.tile.bounds.max.x;
+        return L.bounds(L.point(minPixel.x / tileSize, minPixel.y / tileSize), L.point(maxPixel.x / tileSize,maxPixel.y / tileSize)); 
+      case "gcrs":
+        let minGCRS = this[projection].unproject(pcrsBounds.min),
+            maxGCRS = this[projection].unproject(pcrsBounds.max);
+        return L.bounds(L.point(minGCRS.lng, minGCRS.lat), L.point(maxGCRS.lng, maxGCRS.lat)); 
+      default:
+        return undefined;
+    }
+  },
+
   boundsToPCRSBounds: function(bounds, zoom, projection,cs){
     if(!bounds || !zoom && +zoom !== 0 || !cs) return undefined;
     let tileSize = M[projection].options.crs.tile.bounds.max.x;

--- a/src/mapml/utils/Util.js
+++ b/src/mapml/utils/Util.js
@@ -5,7 +5,8 @@ export var Util = {
     if(!pcrsBounds || !map) return {};
 
     let tcrsTopLeft = [], tcrsBottomRight = [],
-        tileMatrixTopLeft = [], tileMatrixBottomRight = [];
+        tileMatrixTopLeft = [], tileMatrixBottomRight = [],
+        tileSize = map.options.crs.options.crs.tile.bounds.max.y;
 
     for(let i = 0;i<map.options.crs.options.resolutions.length;i++){
       let scale = map.options.crs.scale(i),
@@ -23,12 +24,12 @@ export var Util = {
 
       //converts the tcrs values from earlier to tilematrix
       tileMatrixTopLeft.push({
-        horizontal: tcrsTopLeft[i].horizontal / 256,
-        vertical:tcrsTopLeft[i].vertical / 256,
+        horizontal: tcrsTopLeft[i].horizontal / tileSize,
+        vertical:tcrsTopLeft[i].vertical / tileSize,
       });
       tileMatrixBottomRight.push({
-        horizontal: tcrsBottomRight[i].horizontal / 256,
-        vertical: tcrsBottomRight[i].vertical / 256,
+        horizontal: tcrsBottomRight[i].horizontal / tileSize,
+        vertical: tcrsBottomRight[i].vertical / tileSize,
       });
     }
     

--- a/test/e2e/core/metaDefault.html
+++ b/test/e2e/core/metaDefault.html
@@ -19,7 +19,7 @@
 </head>
 
 <body>
-  <mapml-viewer style="width: 500px; height: 500px;" projection="CBMTILE" zoom="4" lat="45.5052040" lon="-75.2202344"
+  <mapml-viewer style="width: 500px; height: 500px;" projection="CBMTILE" zoom="0" lat="45.5052040" lon="-75.2202344"
     controls>
     <layer- label="Map Layer" src="data/missing_min_max.mapml" checked></layer->
 

--- a/test/e2e/core/metaDefault.html
+++ b/test/e2e/core/metaDefault.html
@@ -19,7 +19,7 @@
 </head>
 
 <body>
-  <mapml-viewer style="width: 500px; height: 500px;" projection="CBMTILE" zoom="0" lat="45.5052040" lon="-75.2202344"
+  <mapml-viewer style="width: 500px; height: 500px;" projection="CBMTILE" zoom="4" lat="45.5052040" lon="-75.2202344"
     controls>
     <layer- label="Map Layer" src="data/missing_min_max.mapml" checked></layer->
 

--- a/test/e2e/core/metaDefault.html
+++ b/test/e2e/core/metaDefault.html
@@ -1,0 +1,46 @@
+<html>
+
+<head>
+  <title>Missing Meta Parameters Test</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type="module" src="mapml-viewer.js"></script>
+  <style>
+    [is=web-map] {
+      width: 100%;
+      height: 400px;
+      max-width: 100%;
+    }
+
+    .transparency {
+      opacity: 0.2;
+    }
+  </style>
+</head>
+
+<body>
+  <mapml-viewer style="width: 500px; height: 500px;" projection="CBMTILE" zoom="0" lat="45.5052040" lon="-75.2202344"
+    controls>
+    <layer- label="Map Layer" src="data/missing_min_max.mapml" checked></layer->
+
+    <layer- label="Toporama" checked>
+      <meta name="zoom" content="min=4,max=5" />
+      <meta name="extent"
+        content="zoom=19,top-left-easting=-7786477.0,top-left-northing=-927808.0,bottom-right-easting=7148753.0,bottom-right-northing=7928344.0" />
+      <extent units="CBMTILE">
+        <input name="z" type="zoom" value="11" min="4" max="4" />
+        <input name="w" type="width" />
+        <input name="h" type="height" />
+        <input name="xmin" type="location" units="pcrs" position="top-left" axis="easting" />
+        <input name="ymin" type="location" units="pcrs" position="bottom-left" axis="northing" />
+        <input name="xmax" type="location" units="pcrs" position="top-right" axis="easting" />
+        <input name="ymax" type="location" units="pcrs" position="top-left" axis="northing" />
+        <link rel="image"
+          tref="http://wms.ess-ws.nrcan.gc.ca/wms/toporama_en?SERVICE=WMS&REQUEST=GetMap&FORMAT=image/jpeg&TRANSPARENT=FALSE&STYLES=&VERSION=1.3.0&LAYERS=WMS-Toporama&WIDTH={w}&HEIGHT={h}&CRS=EPSG:3978&BBOX={xmin},{ymin},{xmax},{ymax}&m4h=t" />
+      </extent>
+    </layer->
+  </mapml-viewer>
+
+</body>
+
+</html>

--- a/test/e2e/core/metaDefault.test.js
+++ b/test/e2e/core/metaDefault.test.js
@@ -1,0 +1,97 @@
+jest.setTimeout(50000);
+const playwright = require("playwright");
+
+(async () => {
+
+  let expectedPCRSFirstLayer = {
+    topLeft: {
+      horizontal: -3263369.215138428,
+      vertical: 4046262.80585894,
+    },
+    bottomRight: {
+      horizontal: 3823752.959105924,
+      vertical: -1554448.395563461,
+    },
+  }, expectedGCRSFirstLayer = {
+    topLeft: {
+      horizontal: -125.78104358919225,
+      vertical: 56.11474703973131,
+    },
+    bottomRight: {
+      horizontal: -5.116088318047697,
+      vertical: 28.87016583287855,
+    },
+  };
+
+  let expectedPCRSSecondLayer = {
+    topLeft: {
+      horizontal: -7786477,
+      vertical: 7928344,
+    },
+    bottomRight: {
+      horizontal: 7148753,
+      vertical: -927808,
+    },
+  }, expectedGCRSSecondLayer = {
+    topLeft: {
+      horizontal: -155.3514099767017,
+      vertical: 22.2852694215843,
+    },
+    bottomRight: {
+      horizontal: 32.23057852696884,
+      vertical: 10.170068283825733,
+    },
+  };
+  for (const browserType of BROWSER) {
+    describe(
+      "Playwright Missing Min Max Attribute, Meta Default Tests in " + browserType,
+      () => {
+        beforeAll(async () => {
+          browser = await playwright[browserType].launch({
+            headless: ISHEADLESS,
+          });
+          context = await browser.newContext();
+          page = await context.newPage();
+          if (browserType === "firefox") {
+            await page.waitForNavigation();
+          }
+          await page.goto(PATH + "metaDefault.html");
+        });
+
+        afterAll(async function () {
+          await browser.close();
+        });
+
+        test("[" + browserType + "]" + " Inline layer extent test", async () => {
+          const extent = await page.$eval(
+            "body > mapml-viewer > layer-:nth-child(1)",
+            (layer) => layer.extent
+          );
+          expect(extent.hasOwnProperty("zoom")).toBeTruthy();
+          expect(extent.hasOwnProperty("topLeft")).toBeTruthy();
+          expect(extent.hasOwnProperty("bottomRight")).toBeTruthy();
+          expect(extent.hasOwnProperty("projection")).toBeTruthy();
+          expect(extent.topLeft.pcrs).toEqual(expectedPCRSFirstLayer.topLeft);
+          expect(extent.bottomRight.pcrs).toEqual(expectedPCRSFirstLayer.bottomRight);
+          expect(extent.topLeft.gcrs).toEqual(expectedGCRSFirstLayer.topLeft);
+          expect(extent.bottomRight.gcrs).toEqual(expectedGCRSFirstLayer.bottomRight);
+        });
+        test("[" + browserType + "]" + " Fetched layer extent test", async () => {
+          const extent = await page.$eval(
+            "body > mapml-viewer > layer-:nth-child(2)",
+            (layer) => layer.extent
+          );
+
+          expect(extent.hasOwnProperty("zoom")).toBeTruthy();
+          expect(extent.hasOwnProperty("topLeft")).toBeTruthy();
+          expect(extent.hasOwnProperty("bottomRight")).toBeTruthy();
+          expect(extent.hasOwnProperty("projection")).toBeTruthy();
+          expect(extent.topLeft.pcrs).toEqual(expectedPCRSSecondLayer.topLeft);
+          expect(extent.bottomRight.pcrs).toEqual(expectedPCRSSecondLayer.bottomRight);
+          expect(extent.topLeft.gcrs).toEqual(expectedGCRSSecondLayer.topLeft);
+          expect(extent.bottomRight.gcrs).toEqual(expectedGCRSSecondLayer.bottomRight);
+        });
+      }
+    );
+  }
+})();

--- a/test/e2e/data/tiles/cbmt/missing_min_max.mapml
+++ b/test/e2e/data/tiles/cbmt/missing_min_max.mapml
@@ -1,0 +1,19 @@
+<mapml>
+  <head>
+    <title>Canada Base Map - Transportation (CBMT)</title>
+    <meta http-equiv="Content-Type" content="text/mapml;projection=CBMTILE"/>
+    <meta charset="utf-8"/>
+    <base href=""/>
+    <link rel="license" href="https://www.nrcan.gc.ca/earth-sciences/geography/topographic-information/free-data-geogratis/licence/17285" title="Canada Base Map © Natural Resources Canada"/>
+    <link rel="zoomin" href="/mapml/en/cbmtile/cbmt/?z=18" type="text/mapml"/>
+    <meta name="extent" content="zoom=17,top-left-row=29750,top-left-column=26484,bottom-right-row=34475,bottom-right-column=32463" />
+  </head>
+  <body>
+    <extent units="CBMTILE">
+    <input name="z" type="zoom" value="17" min="0" max="17"/>
+    <input name="y" type="location" units="tilematrix" axis="row"/>
+    <input name="x" type="location" units="tilematrix" axis="column"/>
+    <link rel="tile" tref="cbmt/{z}/c{x}_r{y}.png" />
+    </extent>
+  </body>
+</mapml>


### PR DESCRIPTION
This PR adds a check to extent definition, it allows the inputs min and max attributes to first default to a meta element if one exists before defaulting to the projection extent. With this addition it also allows the min and max attribute to be defined using different units that are then converted to the appropriate type.

For example:
```xml
<mapml>
  <head>
    <title>Canada Base Map - Transportation (CBMT)</title>
    <meta http-equiv="Content-Type" content="text/mapml;projection=CBMTILE"/>
    <meta charset="utf-8"/>
    <base href=""/>
    <link rel="license" href="https://www.nrcan.gc.ca/earth-sciences/geography/topographic-information/free-data-geogratis/licence/17285" title="Canada Base Map © Natural Resources Canada"/>
    <link rel="zoomin" href="/mapml/en/cbmtile/cbmt/?z=18" type="text/mapml"/>
    <meta name="extent" content="zoom=17,top-left-easting=3426966.71,top-left-northing=4244700.70,bottom-right-easting=3171754.82, bottom-right-northing=-781069.77" />
  </head>
  <body>
    <extent units="CBMTILE">
    <input name="z" type="zoom" value="17" min="0" max="17"/>
    <input name="y" type="location" units="tilematrix" axis="row"/>
    <input name="x" type="location" units="tilematrix" axis="column"/>
    <link rel="tile" tref="cbmt/{z}/c{x}_r{y}.png" />
    </extent>
  </body>
</mapml>
```
This will work appropriately even though the meta[name=extent] element content is defined using pcrs.
Closes #156 also closes #242 