### PR TITLE
Ability to reorder layer in control panel, reflect changes in DOM and map

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -71,7 +71,7 @@ export class MapLayer extends HTMLElement {
     // this is moved up here so that the layer control doesn't respond
     // to the layer being removed with the _onLayerChange execution
     // that is set up in _attached:
-    if(this.hasAttribute("moving")) return;
+    if(this.hasAttribute("data-moving")) return;
     this._removeEvents();
     if (this._layer._map) {
       this._layer._map.removeLayer(this._layer);
@@ -84,7 +84,7 @@ export class MapLayer extends HTMLElement {
   connectedCallback() {
     //creates listener that waits for createmap event, this allows for delayed builds of maps
     //this allows a safeguard for the case where loading a custom TCRS takes longer than loading mapml-viewer.js/web-map.js
-    if(this.hasAttribute("moving")) return;
+    if(this.hasAttribute("data-moving")) return;
     this.parentNode.addEventListener('createmap', ()=>{
       this._ready();
       // if the map has been attached, set this layer up wrt Leaflet map

--- a/src/layer.js
+++ b/src/layer.js
@@ -71,6 +71,7 @@ export class MapLayer extends HTMLElement {
     // this is moved up here so that the layer control doesn't respond
     // to the layer being removed with the _onLayerChange execution
     // that is set up in _attached:
+    if(this.hasAttribute("moving")) return;
     this._removeEvents();
     if (this._layer._map) {
       this._layer._map.removeLayer(this._layer);
@@ -83,6 +84,7 @@ export class MapLayer extends HTMLElement {
   connectedCallback() {
     //creates listener that waits for createmap event, this allows for delayed builds of maps
     //this allows a safeguard for the case where loading a custom TCRS takes longer than loading mapml-viewer.js/web-map.js
+    if(this.hasAttribute("moving")) return;
     this.parentNode.addEventListener('createmap', ()=>{
       this._ready();
       // if the map has been attached, set this layer up wrt Leaflet map

--- a/src/layer.js
+++ b/src/layer.js
@@ -237,9 +237,10 @@ export class MapLayer extends HTMLElement {
     for (var nodes = this.parentNode.children;i < nodes.length;i++) {
       if (this.parentNode.children[i].nodeName === "LAYER-") {
         if (this.parentNode.children[i] === this) {
-          break;
+          position = i + 1;
+        } else if (this.parentNode.children[i]._layer) {
+          this.parentNode.children[i]._layer.setZIndex(i+1);
         }
-        position++;
       }
     }
     var proj = this.parentNode.projection ? this.parentNode.projection : "OSMTILE";

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -354,10 +354,3 @@ summary {
 .leaflet-container .leaflet-control-container {
   visibility: unset!important;
 }
-
-.drag-active {
-  opacity: 0;
-  cursor: grabbing;
-  cursor: -moz-grabbing;
-  cursor: -webkit-grabbing;
-}

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -138,6 +138,7 @@
   border: none;
   margin: 0;
   padding: 0;
+  cursor: grab;
 }
 
 .leaflet-control-layers-overlays > fieldset > .mapml-control-layers > summary,
@@ -277,12 +278,6 @@
 /*
  * User interaction.
  */
-
-/* Disable dragging of controls. */
-.leaflet-control :not([draggable="true"]),
-.mapml-contextmenu :not([draggable="true"]) {
-  -webkit-user-drag: none;
-}
 
 /* Disable text selection in controls. */
 .leaflet-control,

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -356,7 +356,8 @@ summary {
 }
 
 .drag-active {
-  background: transparent;
-  color: transparent;
-  border: 1px solid #4ca1af;
+  opacity: 0;
+  cursor: grabbing;
+  cursor: -moz-grabbing;
+  cursor: -webkit-grabbing;
 }

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -354,3 +354,7 @@ summary {
 .leaflet-container .leaflet-control-container {
   visibility: unset!important;
 }
+
+.mapml-drag-active {
+  cursor: row-resize;
+}

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -355,6 +355,6 @@ summary {
   visibility: unset!important;
 }
 
-.mapml-draggable {
+.mapml-draggable * {
   cursor: row-resize;
 }

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -354,3 +354,9 @@ summary {
 .leaflet-container .leaflet-control-container {
   visibility: unset!important;
 }
+
+.drag-active {
+  background: transparent;
+  color: transparent;
+  border: 1px solid #4ca1af;
+}

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -138,7 +138,6 @@
   border: none;
   margin: 0;
   padding: 0;
-  cursor: grab;
 }
 
 .leaflet-control-layers-overlays > fieldset > .mapml-control-layers > summary,
@@ -278,6 +277,12 @@
 /*
  * User interaction.
  */
+
+/* Disable dragging of controls. */
+.leaflet-control :not([draggable="true"]),
+.mapml-contextmenu :not([draggable="true"]) {
+  -webkit-user-drag: none;
+}
 
 /* Disable text selection in controls. */
 .leaflet-control,

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -355,6 +355,6 @@ summary {
   visibility: unset!important;
 }
 
-.mapml-drag-active {
+.mapml-draggable {
   cursor: row-resize;
 }

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -488,7 +488,7 @@ export var MapMLLayer = L.Layer.extend({
         opacityControl = document.createElement('details'),
         opacityControlSummary = document.createElement('summary'),
         opacityControlSummaryLabel = document.createElement('label'),
-        root = this._layerEl.parentElement.shadowRoot;
+        root = this._layerEl.parentElement.shadowRoot, map = this._map;
 
         input.defaultChecked = this._map ? true: false;
         input.type = 'checkbox';
@@ -542,6 +542,17 @@ export var MapMLLayer = L.Layer.extend({
           e.target.classList.remove("drag-active");
           e.target.setAttribute("aria-grabbed", "false");
           e.target.removeAttribute("aria-dropeffect");
+          let controls = e.target.parentNode.children,
+              layers = map.getPane("overlayPane").children,
+              zIndex = 1;
+          for(let control of controls){
+            for (let layer of layers){
+              if(control.querySelector("span").layer._container == layer){
+                layer.style["z-index"] = zIndex;
+                zIndex++;
+              }
+            }
+          }
         };
 
         L.DomEvent.on(opacity,'change', this._changeOpacity, this);

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -545,11 +545,10 @@ export var MapMLLayer = L.Layer.extend({
           
           // Fixes flickering by only moving element when there is enough space
           let offset = e.offsetY < 0 ? Math.abs(e.offsetY*2) : Math.abs(e.offsetY);
-          if(offset <= swapControl.offsetHeight){
-            swapControl = control;
-          } 
+          swapControl = offset <= swapControl.offsetHeight ? control : swapControl;
 
           control.style.opacity = "0";
+          control.classList.add("leaflet-dragging");
           control.setAttribute("aria-grabbed", 'true');
           control.setAttribute("aria-dropeffect", "move");
           if(swapControl && controls === swapControl.parentNode){
@@ -560,6 +559,7 @@ export var MapMLLayer = L.Layer.extend({
         fieldset.ondragend = (e) => {
           e.preventDefault();
           e.target.style.opacity = null;
+          e.target.classList.remove("leaflet-dragging");
           e.target.setAttribute("aria-grabbed", "false");
           e.target.removeAttribute("aria-dropeffect");
           let controls = e.target.parentNode.children,

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -493,7 +493,6 @@ export var MapMLLayer = L.Layer.extend({
         input.defaultChecked = this._map ? true: false;
         input.type = 'checkbox';
         input.className = 'leaflet-control-layers-selector';
-        //name.draggable = true;
         name.layer = this;
 
         if (this._legendUrl) {
@@ -522,14 +521,23 @@ export var MapMLLayer = L.Layer.extend({
         opacity.setAttribute('step','0.1');
         opacity.value = this._container.style.opacity || '1.0';
 
-        fieldset.setAttribute("draggable", true);
         fieldset.setAttribute("aria-grabbed", "false");
         fieldset.draggable = true;
+
+        fieldset.onmousedown = (e) => {
+          e.target.closest("fieldset").draggable = e.target.tagName.toLowerCase() !== "input";
+        };
+
+        fieldset.onmouseup = (e) => {
+          e.target.closest("fieldset").draggable = true;
+        };
+
         fieldset.ondrag = (e) => {
           let control = e.target,
               controls = e.target.parentNode,
               x = e.clientX, y = e.clientY,
-              swapControl = root.elementFromPoint(x, y).parentNode.parentNode && root.elementFromPoint(x, y).parentNode.parentNode.draggable === false ? control : root.elementFromPoint(x, y).parentNode.parentNode;
+              elementAt = root.elementFromPoint(x, y),
+              swapControl = !elementAt || !elementAt.closest("fieldset") || elementAt.closest("fieldset").draggable === false ? control : elementAt.closest("fieldset");
           control.classList.add("drag-active");
           control.setAttribute("aria-grabbed", 'true');
           control.setAttribute("aria-dropeffect", "move");

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -488,7 +488,7 @@ export var MapMLLayer = L.Layer.extend({
         opacityControl = document.createElement('details'),
         opacityControlSummary = document.createElement('summary'),
         opacityControlSummaryLabel = document.createElement('label'),
-        root = this._layerEl.parentElement.shadowRoot, map = this._map;
+        root = this._layerEl.parentElement.shadowRoot, map = this._map, viewer = this._layerEl.parentNode;
 
         input.defaultChecked = this._map ? true: false;
         input.type = 'checkbox';
@@ -554,6 +554,11 @@ export var MapMLLayer = L.Layer.extend({
               layers = map.getPane("overlayPane").children,
               zIndex = 1;
           for(let control of controls){
+            let layerEl = control.querySelector("span").layer._layerEl;
+            layerEl.setAttribute("moving","");
+            viewer.insertAdjacentElement("beforeend", layerEl);
+            layerEl.removeAttribute("moving");
+
             for (let layer of layers){
               if(control.querySelector("span").layer._container == layer){
                 layer.style["z-index"] = zIndex;
@@ -564,19 +569,6 @@ export var MapMLLayer = L.Layer.extend({
         };
 
         L.DomEvent.on(opacity,'change', this._changeOpacity, this);
-/*         L.DomEvent.on(details,'ondrag', function(event) {
-          console.log("HERE2");
-            // will have to figure out how to drag and drop a whole element
-            // with its contents in the case where the <layer->content</layer-> 
-            // has no src but does have inline content.  
-            // Should be do-able, I think.
-            if (this._href) {
-              event.dataTransfer.setData("text/uri-list",this._href);
-              // Why use a second .setData("text/plain"...) ? This is very important:
-              // See https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types#link
-              event.dataTransfer.setData("text/plain", this._href); 
-            }
-          }, this); */
 
         fieldset.appendChild(details);
         details.appendChild(summary);

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -488,8 +488,7 @@ export var MapMLLayer = L.Layer.extend({
         opacityControl = document.createElement('details'),
         opacityControlSummary = document.createElement('summary'),
         opacityControlSummaryLabel = document.createElement('label'),
-        root = this._layerEl.parentElement.shadowRoot, map = this._map,
-        viewer = this._layerEl.parentNode;
+        mapEl = this._layerEl.parentNode;
 
         input.defaultChecked = this._map ? true: false;
         input.type = 'checkbox';
@@ -545,6 +544,7 @@ export var MapMLLayer = L.Layer.extend({
             
             controls.classList.add("mapml-draggable");
             let x = moveEvent.clientX, y = moveEvent.clientY,
+                root = mapEl.tagName === "MAPML-VIEWER" ? mapEl.shadowRoot : mapEl.querySelector(".web-map").shadowRoot,
                 elementAt = root.elementFromPoint(x, y),
                 swapControl = !elementAt || !elementAt.closest("fieldset") ? control : elementAt.closest("fieldset");
       
@@ -568,7 +568,7 @@ export var MapMLLayer = L.Layer.extend({
               let layerEl = c.querySelector("span").layer._layerEl;
               
               layerEl.setAttribute("data-moving","");
-              viewer.insertAdjacentElement("beforeend", layerEl);
+              mapEl.insertAdjacentElement("beforeend", layerEl);
               layerEl.removeAttribute("data-moving");
 
               

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -487,12 +487,13 @@ export var MapMLLayer = L.Layer.extend({
         opacity = document.createElement('input'),
         opacityControl = document.createElement('details'),
         opacityControlSummary = document.createElement('summary'),
-        opacityControlSummaryLabel = document.createElement('label');
+        opacityControlSummaryLabel = document.createElement('label'),
+        root = this._layerEl.parentElement.shadowRoot;
 
         input.defaultChecked = this._map ? true: false;
         input.type = 'checkbox';
         input.className = 'leaflet-control-layers-selector';
-        name.draggable = true;
+        //name.draggable = true;
         name.layer = this;
 
         if (this._legendUrl) {
@@ -521,8 +522,26 @@ export var MapMLLayer = L.Layer.extend({
         opacity.setAttribute('step','0.1');
         opacity.value = this._container.style.opacity || '1.0';
 
+        fieldset.setAttribute("draggable", true);
+        fieldset.draggable = true;
+        fieldset.ondrag = (e) => {
+          let control = e.target,
+              controls = e.target.parentNode,
+              x = e.clientX, y = e.clientY,
+              swapControl = root.elementFromPoint(x, y).parentNode.parentNode && root.elementFromPoint(x, y).parentNode.parentNode.draggable === false ? control : root.elementFromPoint(x, y).parentNode.parentNode;
+          control.classList.add("drag-active");
+          if(swapControl && controls === swapControl.parentNode){
+            swapControl = swapControl !== control.nextSibling? swapControl : swapControl.nextSibling;
+            controls.insertBefore(control, swapControl);
+          }
+        };
+        fieldset.ondragend = (e) => {
+          e.target.classList.remove("drag-active");
+        };
+
         L.DomEvent.on(opacity,'change', this._changeOpacity, this);
-        L.DomEvent.on(name,'dragstart', function(event) {
+/*         L.DomEvent.on(details,'ondrag', function(event) {
+          console.log("HERE2");
             // will have to figure out how to drag and drop a whole element
             // with its contents in the case where the <layer->content</layer-> 
             // has no src but does have inline content.  
@@ -533,7 +552,7 @@ export var MapMLLayer = L.Layer.extend({
               // See https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types#link
               event.dataTransfer.setData("text/plain", this._href); 
             }
-          }, this);
+          }, this); */
 
         fieldset.appendChild(details);
         details.appendChild(summary);

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -523,6 +523,7 @@ export var MapMLLayer = L.Layer.extend({
         opacity.value = this._container.style.opacity || '1.0';
 
         fieldset.setAttribute("draggable", true);
+        fieldset.setAttribute("aria-grabbed", "false");
         fieldset.draggable = true;
         fieldset.ondrag = (e) => {
           let control = e.target,
@@ -530,6 +531,8 @@ export var MapMLLayer = L.Layer.extend({
               x = e.clientX, y = e.clientY,
               swapControl = root.elementFromPoint(x, y).parentNode.parentNode && root.elementFromPoint(x, y).parentNode.parentNode.draggable === false ? control : root.elementFromPoint(x, y).parentNode.parentNode;
           control.classList.add("drag-active");
+          control.setAttribute("aria-grabbed", 'true');
+          control.setAttribute("aria-dropeffect", "move");
           if(swapControl && controls === swapControl.parentNode){
             swapControl = swapControl !== control.nextSibling? swapControl : swapControl.nextSibling;
             controls.insertBefore(control, swapControl);
@@ -537,6 +540,8 @@ export var MapMLLayer = L.Layer.extend({
         };
         fieldset.ondragend = (e) => {
           e.target.classList.remove("drag-active");
+          e.target.setAttribute("aria-grabbed", "false");
+          e.target.removeAttribute("aria-dropeffect");
         };
 
         L.DomEvent.on(opacity,'change', this._changeOpacity, this);

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -543,10 +543,7 @@ export var MapMLLayer = L.Layer.extend({
                 controls.getBoundingClientRect().top > control.getBoundingClientRect().top || 
                 controls.getBoundingClientRect().bottom < control.getBoundingClientRect().bottom) return;            
             
-            for(let c of controls.children){
-              c.querySelector("summary").classList.add("mapml-draggable");
-            }
-            
+            controls.classList.add("mapml-draggable");
             let x = moveEvent.clientX, y = moveEvent.clientY,
                 elementAt = root.elementFromPoint(x, y),
                 swapControl = !elementAt || !elementAt.closest("fieldset") ? control : elementAt.closest("fieldset");
@@ -574,10 +571,11 @@ export var MapMLLayer = L.Layer.extend({
               viewer.insertAdjacentElement("beforeend", layerEl);
               layerEl.removeAttribute("data-moving");
 
-              c.querySelector("summary").classList.remove("mapml-draggable");
+              
               layerEl._layer.setZIndex(zIndex);
               zIndex++;
             }
+            controls.classList.remove("mapml-draggable");
             document.body.onmousemove = document.body.onmouseup = null;
           };
         };

--- a/test/e2e/core/drag.html
+++ b/test/e2e/core/drag.html
@@ -23,9 +23,18 @@
 </head>
 
 <body>
-	<map is="web-map" projection="CBMTILE" zoom="2" lat="45.5052040" lon="-75.2202344" controls>
+	<map is="web-map" style="width: 500px;height: 500px;" projection="CBMTILE" zoom="2" lat="45.5052040" lon="-75.2202344"
+		controls>
 		<layer- label="CBMT" src="data/cbmt.mapml" checked></layer->
-
+		<layer- label="Static MapML with tiles" checked>
+			<meta name="zoom" content="min=0,max=10">
+			<meta name="projection" content="CBMTILE">
+			<link rel="license"
+				href="https://www.nrcan.gc.ca/earth-sciences/geography/topographic-information/free-data-geogratis/licence/17285"
+				title="Canada Base Map © Natural Resources Canada">
+			<tile zoom="0" row="3" col="3" src="data/cbmt/0/c3_r3.png"></tile>
+		</layer->
+		<layer- label="vector states" src="data/us_pop_density.mapml" checked></layer->
 	</map>
 </body>
 


### PR DESCRIPTION
This PR allows the user to drag the control elements in order to reorder them, this reordering also changes the `<layer->` elements orders within the `<mapml-viewer>`.


![captured (1)](https://user-images.githubusercontent.com/55214462/105098050-842bc080-5a77-11eb-910b-30367efc2494.gif)


Closes #248 