### PR TITLE
Fix bug that causes unintentional activation when dropping layer items

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -357,6 +357,10 @@ summary {
   cursor: pointer;
 }
 
+.mapml-draggable * {
+  cursor: row-resize;
+}
+
 /*
  * Visibility hack – mitigates FOUC.
  * (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/154)
@@ -366,8 +370,4 @@ summary {
 .leaflet-container .mapml-contextmenu,
 .leaflet-container .leaflet-control-container {
   visibility: unset!important;
-}
-
-.mapml-draggable * {
-  cursor: row-resize;
 }

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -320,7 +320,8 @@
 .mapml-contextmenu-item > *,
 .mapml-control-layers label[for^="o"],
 .leaflet-crosshair > *,
-.leaflet-crosshair .leaflet-control {
+.leaflet-crosshair .leaflet-control,
+.mapml-draggable [aria-grabbed="true"] .mapml-control-layers > * {
   pointer-events: none!important;
 }
 


### PR DESCRIPTION
Fix: #254.

This also (somehow, unintentionally 🤭) fixes a related bug where it wasn't possible to drag the last item in the layers list.

## Preview

https://user-images.githubusercontent.com/26493779/105442782-ad607280-5c6a-11eb-9d84-70c51dbe0918.mp4

