### PR TITLE
Increase size of fieldset to prevent flickering

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -138,7 +138,7 @@
   border: none;
   margin: 0;
   padding: 0;
-  min-height: 48px;
+  min-height: 44px;
 }
 
 .leaflet-control-layers-overlays > fieldset > .mapml-control-layers > summary,
@@ -148,8 +148,8 @@
 }
 
 .leaflet-control-layers-overlays > fieldset > .mapml-control-layers > summary {
-  padding-top: 7.5px;
-  padding-bottom: 7.5px;
+  padding-top: 12.5px;
+  padding-bottom: 12.5px;
 }
 
 .leaflet-control-layers-overlays > fieldset > .mapml-control-layers details > summary {

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -138,6 +138,7 @@
   border: none;
   margin: 0;
   padding: 0;
+  min-height: 48px;
 }
 
 .leaflet-control-layers-overlays > fieldset > .mapml-control-layers > summary,

--- a/test/e2e/core/drag.test.js
+++ b/test/e2e/core/drag.test.js
@@ -56,7 +56,7 @@ jest.setTimeout(30000);
         let controlBBox = await control.boundingBox();
         await page.mouse.move(controlBBox.x + controlBBox.width / 2, controlBBox.y + controlBBox.height / 2);
         await page.mouse.down();
-        await page.mouse.move(controlBBox.x + controlBBox.width / 2, (controlBBox.y + controlBBox.height / 2) + 45);
+        await page.mouse.move(controlBBox.x + controlBBox.width / 2, (controlBBox.y + controlBBox.height / 2) + 48);
         await page.mouse.up();
         await page.hover(".leaflet-top.leaflet-right");
 
@@ -84,7 +84,7 @@ jest.setTimeout(30000);
         let controlBBox = await control.boundingBox();
         await page.mouse.move(controlBBox.x + controlBBox.width / 2, controlBBox.y + controlBBox.height / 2);
         await page.mouse.down();
-        await page.mouse.move(controlBBox.x + controlBBox.width / 2, (controlBBox.y + controlBBox.height / 2) - 45);
+        await page.mouse.move(controlBBox.x + controlBBox.width / 2, (controlBBox.y + controlBBox.height / 2) - 48);
         await page.mouse.up();
         await page.hover(".leaflet-top.leaflet-right");
 


### PR DESCRIPTION
Control item padding increased to 12.5px. This prevents flickering when hovering over the button, I believe the button has to stay 44px due to accessibility guidelines as per issue #215 

![larger](https://user-images.githubusercontent.com/55214462/106622609-c3f7ab00-6541-11eb-8f33-64376ac07d48.png)

Closes #275 

