### PR TITLE
Remove opinionated link styles

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -35,6 +35,11 @@
   font-size: 12px;
 }
 
+/* Remove opinionated color of links. */
+.leaflet-container a {
+  color: initial;
+}
+
 /*
  * Controls.
  */

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -93,8 +93,15 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2), 0 1px 2px rgb(0, 0, 0, 0.3);
 }
 
+/* Increase contrast between the attribution container and the underlying content. */
 .leaflet-container .leaflet-control-attribution {
   background-color: rgba(255, 255, 255, 0.95);
+}
+
+/* Remove opinionated styles of attribution links. */
+.leaflet-control-attribution a {
+  color: revert;
+  text-decoration: revert;
 }
 
 /*


### PR DESCRIPTION
In accordance with the W3C TAG's Guidelines for custom components, we should try to [keep default styles to a bare minimum](https://w3ctag.github.io/webcomponents-design-guidelines/#:~:text=Elements%20should%20only%20have%20basic%20styling). Removing opinionated styles of links.