### PR TITLE
Add missing lang attributes to HTML documents

### DIFF
--- a/test/e2e/core/axisInferring.html
+++ b/test/e2e/core/axisInferring.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 
 <head>

--- a/test/e2e/core/axisInferring.html
+++ b/test/e2e/core/axisInferring.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 
 <head>
   <title>Inferring Axes</title>

--- a/test/e2e/core/debugMode.html
+++ b/test/e2e/core/debugMode.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <title>cbmt-test.html</title>

--- a/test/e2e/core/drag.html
+++ b/test/e2e/core/drag.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
 	<title>Drag Test</title>

--- a/test/e2e/core/keyboardInteraction.html
+++ b/test/e2e/core/keyboardInteraction.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 
 <head>

--- a/test/e2e/core/keyboardInteraction.html
+++ b/test/e2e/core/keyboardInteraction.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 
 <head>
   <title>Keyboard Interaction Test</title>

--- a/test/e2e/core/layerContextMenu.html
+++ b/test/e2e/core/layerContextMenu.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <title>cbmt-test.html</title>

--- a/test/e2e/core/mapElement.html
+++ b/test/e2e/core/mapElement.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <title>cbmt-test.html</title>

--- a/test/e2e/core/metaDefault.html
+++ b/test/e2e/core/metaDefault.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 
 <head>

--- a/test/e2e/core/metaDefault.html
+++ b/test/e2e/core/metaDefault.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 
 <head>
   <title>Missing Meta Parameters Test</title>

--- a/test/e2e/core/missingMetaParameters.html
+++ b/test/e2e/core/missingMetaParameters.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 
 <head>

--- a/test/e2e/core/missingMetaParameters.html
+++ b/test/e2e/core/missingMetaParameters.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 
 <head>
   <title>Missing Meta Parameters Test</title>

--- a/test/e2e/core/styleParsing.html
+++ b/test/e2e/core/styleParsing.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 
 <head>

--- a/test/e2e/core/styleParsing.html
+++ b/test/e2e/core/styleParsing.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 
 <head>
   <title>Style Parsing Test</title>

--- a/test/e2e/core/tms.html
+++ b/test/e2e/core/tms.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <title>Painting Example</title>
         <meta charset="UTF-8">

--- a/test/e2e/layers/clientTemplatedTileLayer.html
+++ b/test/e2e/layers/clientTemplatedTileLayer.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 
 <head>

--- a/test/e2e/layers/clientTemplatedTileLayer.html
+++ b/test/e2e/layers/clientTemplatedTileLayer.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 
 <head>
   <title>Client Tiles</title>

--- a/test/e2e/layers/mapMLFeatures.html
+++ b/test/e2e/layers/mapMLFeatures.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 
 <head>

--- a/test/e2e/layers/mapMLFeatures.html
+++ b/test/e2e/layers/mapMLFeatures.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 
 <head>
   <title>Static Features Test</title>

--- a/test/e2e/layers/mapMLStaticTileLayer.html
+++ b/test/e2e/layers/mapMLStaticTileLayer.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <title>Static Tile Test</title>

--- a/test/e2e/layers/mapMLTemplatedFeatures.html
+++ b/test/e2e/layers/mapMLTemplatedFeatures.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 
 <head>

--- a/test/e2e/layers/mapMLTemplatedFeatures.html
+++ b/test/e2e/layers/mapMLTemplatedFeatures.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 
 <head>
   <title>Templated Features Test</title>

--- a/test/e2e/layers/mapMLTemplatedImageLayer.html
+++ b/test/e2e/layers/mapMLTemplatedImageLayer.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <title>Templated Image Test</title>

--- a/test/e2e/layers/mapMLTemplatedTileLayer.html
+++ b/test/e2e/layers/mapMLTemplatedTileLayer.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <title>Templated Tile Test</title>

--- a/test/e2e/mapml-viewer/customTCRS.html
+++ b/test/e2e/mapml-viewer/customTCRS.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 
 <head>

--- a/test/e2e/mapml-viewer/mapml-viewer.html
+++ b/test/e2e/mapml-viewer/mapml-viewer.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <title>cbmt-test.html</title>


### PR DESCRIPTION
Screen readers often pronounce things incorrectly without an appropriate `lang` attribute, adding `lang="en"` to `<html>`.

Also adding missing doctype declarations to HTML documents.