### PR TITLE
Follows updated keyboard interaction rules

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -391,9 +391,9 @@ summary {
 }
 
 .mapml-crosshair {
-  margin: -18px 0 0 -18px;
-  width: 36px;
-  height: 36px;
+  margin: -36px 0 0 -36px;
+  width: 72px;
+  height: 72px;
   left: 50%;
   top: 50%;
   content: '';

--- a/src/mapml/handlers/QueryHandler.js
+++ b/src/mapml/handlers/QueryHandler.js
@@ -22,13 +22,17 @@ export var QueryHandler = L.Handler.extend({
         }
     },
     _queryTopLayerAtMapCenter: function (event) {
-        if (event.originalEvent.key === " ") {
+      setTimeout(() => {
+        if (this._map.isFocused && !this._map._popupClosed && (event.originalEvent.key === " " || +event.originalEvent.keyCode === 13)) {
           this._map.fire('click', { 
               latlng: this._map.getCenter(),
               layerPoint: this._map.latLngToLayerPoint(this._map.getCenter()),
               containerPoint: this._map.latLngToContainerPoint(this._map.getCenter())
           });
+        } else {
+          delete this._map._popupClosed;
         }
+      }, 0);
     },
     _queryTopLayer: function(event) {
         var layer = this._getTopQueryableLayer();

--- a/src/mapml/layers/FeatureLayer.js
+++ b/src/mapml/layers/FeatureLayer.js
@@ -281,6 +281,10 @@ export var MapMLFeatures = L.FeatureGroup.extend({
 
         if (options.onEachFeature) {
          options.onEachFeature(layer.properties, layer);
+         layer._events.keypress.push({
+           "ctx": layer,
+           "fn": this._onSpacePress,
+         });
         }
         if(this._staticFeature){
           let featureZoom = mapml.getAttribute('zoom') || nativeZoom;
@@ -323,6 +327,11 @@ export var MapMLFeatures = L.FeatureGroup.extend({
       let toDelete = this._container.querySelectorAll("link[rel=stylesheet],style");
       for(let i = 0; i < toDelete.length;i++){
         this._container.removeChild(toDelete[i]);
+      }
+    },
+    _onSpacePress: function(e){
+      if(e.originalEvent.keyCode === 32){
+        this._openPopup(e);
       }
     },
 	 geometryToLayer: function (mapml, pointToLayer, coordsToLatLng, vectorOptions, nativeCS, zoom) {

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -95,7 +95,7 @@ export var MapMLLayer = L.Layer.extend({
                   var c = document.createElement('div');
                   c.classList.add("mapml-popup-content");
                   c.insertAdjacentHTML('afterbegin', properties.innerHTML);
-                  geometry.bindPopup(c, {autoPan:false, closeButton: false, minWidth: 108});
+                  geometry.bindPopup(c, {autoPan:false, minWidth: 108});
                 }
               }
             });
@@ -125,7 +125,7 @@ export var MapMLLayer = L.Layer.extend({
                       var c = document.createElement('div');
                       c.classList.add("mapml-popup-content");
                       c.insertAdjacentHTML('afterbegin', properties.innerHTML);
-                      geometry.bindPopup(c, {autoPan:false, closeButton: false, minWidth: 108});
+                      geometry.bindPopup(c, {autoPan:false, minWidth: 108});
                     }
                   }
                 }).addTo(map);
@@ -1258,7 +1258,7 @@ export var MapMLLayer = L.Layer.extend({
       function focusFeature(focusEvent){
         let isTab = focusEvent.originalEvent.keyCode === 9,
             shiftPressed = focusEvent.originalEvent.shiftKey;
-        if((focusEvent.originalEvent.path[0].title==="Focus Controls" && isTab && !shiftPressed) || focusEvent.originalEvent.keyCode === 27){
+        if((focusEvent.originalEvent.path[0].classList.contains("leaflet-popup-close-button") && isTab && !shiftPressed) || focusEvent.originalEvent.keyCode === 27){
           L.DomEvent.stop(focusEvent);
           map.closePopup(popup);
           path.focus();
@@ -1272,11 +1272,22 @@ export var MapMLLayer = L.Layer.extend({
       }
 
       function focusMap(focusEvent){
+        let isTab = focusEvent.originalEvent.keyCode === 9,
+        shiftPressed = focusEvent.originalEvent.shiftKey;
+
         if((focusEvent.originalEvent.keyCode === 13 && focusEvent.originalEvent.path[0].classList.contains("leaflet-popup-close-button")) || focusEvent.originalEvent.keyCode === 27 ){
           L.DomEvent.stopPropagation(focusEvent);
           map._container.focus();
-          map.closePopup();
+          map.closePopup(popup);
           if(focusEvent.originalEvent.keyCode !== 27)map._popupClosed = true;
+        } else if (isTab && focusEvent.originalEvent.path[0].classList.contains("leaflet-popup-close-button")){
+          map.closePopup(popup);
+        } else if ((focusEvent.originalEvent.path[0].title==="Focus Map" || focusEvent.originalEvent.path[0].classList.contains("mapml-popup-content")) && isTab && shiftPressed){
+          setTimeout(() => { //timeout needed so focus of the feature is done even after the keypressup event occurs
+            L.DomEvent.stop(focusEvent);
+            map.closePopup(popup);
+            map._container.focus();
+          }, 0);
         }
       }
 

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -1258,13 +1258,11 @@ export var MapMLLayer = L.Layer.extend({
       map.once("popupclose", removeHandlers);
       // When popup is open, what gets focused with tab needs to be done using JS as the DOM order is not in an accessibility friendly manner
       function focusFeature(focusEvent){
-        if(focusEvent.originalEvent.path[0].title==="Focus Controls" && +focusEvent.originalEvent.keyCode === 9){
+        if((focusEvent.originalEvent.path[0].title==="Focus Controls" && focusEvent.originalEvent.keyCode === 9 && !focusEvent.originalEvent.shiftKey) ||
+            (focusEvent.originalEvent.path[0].title==="Focus Map" && focusEvent.originalEvent.keyCode === 9 && focusEvent.originalEvent.shiftKey) ||
+             focusEvent.originalEvent.keyCode === 27){
           L.DomEvent.stop(focusEvent);
           map.closePopup(popup);
-          path.focus();
-        } else if(focusEvent.originalEvent.shiftKey && +focusEvent.originalEvent.keyCode === 9){
-          map.closePopup(popup);
-          L.DomEvent.stop(focusEvent);
           path.focus();
         }
       }

--- a/test/e2e/core/keyboardInteraction.test.js
+++ b/test/e2e/core/keyboardInteraction.test.js
@@ -7,7 +7,7 @@ jest.setTimeout(50000);
       () => {
         beforeAll(async () => {
           browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
+            headless: false,//ISHEADLESS,
             slowMo: 50,
           });
           context = await browser.newContext();
@@ -30,7 +30,7 @@ jest.setTimeout(50000);
             expect(afterTab).toEqual("");
           });
 
-          test("[" + browserType + "]" + " Crosshair remains on map move with arrow keys + space", async () => {
+          test("[" + browserType + "]" + " Crosshair remains on map move with arrow keys", async () => {
             await page.keyboard.press("ArrowUp");
             await page.waitForTimeout(500);
             await page.keyboard.press("ArrowDown");
@@ -39,13 +39,11 @@ jest.setTimeout(50000);
             await page.waitForTimeout(500);
             await page.keyboard.press("ArrowRight");
             await page.waitForTimeout(500);
-            await page.keyboard.press(" ")
-            await page.waitForTimeout(500);
             const afterMove = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
             expect(afterMove).toEqual("");
           });
 
-          test("[" + browserType + "]" + " Crosshair hidden on esc + tab out", async () => {
+          test("[" + browserType + "]" + " Crosshair shows on esc but hidden on tab out", async () => {
             await page.keyboard.press("Escape");
             const afterEsc = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
             await page.click("body");
@@ -55,7 +53,7 @@ jest.setTimeout(50000);
             await page.keyboard.press("Tab");
             const afterTab = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
 
-            expect(afterEsc).toEqual("hidden");
+            expect(afterEsc).toEqual("");
             expect(afterTab).toEqual("hidden");
           });
 
@@ -132,47 +130,37 @@ jest.setTimeout(50000);
             const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
             const rh = await page.evaluateHandle(root => root.activeElement, nh);
-            const f = await (await page.evaluateHandle(elem => elem.className, rh)).jsonValue();
+            const f = await (await page.evaluateHandle(elem => elem.title, rh)).jsonValue();
 
             await page.keyboard.press("Tab");
             const h2 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh2 = await page.evaluateHandle(doc => doc.shadowRoot, h2);
             const rh2 = await page.evaluateHandle(root => root.activeElement, nh2);
-            const f2 = await (await page.evaluateHandle(elem => elem.tagName, rh2)).jsonValue();
+            const f2 = await (await page.evaluateHandle(elem => elem.title, rh2)).jsonValue();
 
-            await page.keyboard.press("Tab");
+            await page.keyboard.press("Shift+Tab");
+            await page.keyboard.press("Shift+Tab");
             const h3 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh3 = await page.evaluateHandle(doc => doc.shadowRoot, h3);
             const rh3 = await page.evaluateHandle(root => root.activeElement, nh3);
             const f3 = await (await page.evaluateHandle(elem => elem.title, rh3)).jsonValue();
 
-            await page.keyboard.press("Tab");
+            await page.keyboard.press("Shift+Tab");
             const h4 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh4 = await page.evaluateHandle(doc => doc.shadowRoot, h4);
             const rh4 = await page.evaluateHandle(root => root.activeElement, nh4);
             const f4 = await (await page.evaluateHandle(elem => elem.title, rh4)).jsonValue();
 
-            await page.keyboard.press("Tab");
-            const h5 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nh5 = await page.evaluateHandle(doc => doc.shadowRoot, h5);
-            const rh5 = await page.evaluateHandle(root => root.activeElement, nh5);
-            const f5 = await (await page.evaluateHandle(elem => elem.title, rh5)).jsonValue();
-
-            await page.keyboard.press("Tab");
-            const h6 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nh6 = await page.evaluateHandle(doc => doc.shadowRoot, h6);
-            const rh6 = await page.evaluateHandle(root => root.activeElement, nh6);
-            const f6 = await (await page.evaluateHandle(elem => elem.title, rh6)).jsonValue();
-
-            expect(f).toEqual("mapml-popup-content");
-            expect(f2).toEqual("A");
-            expect(f3).toEqual("Focus Map");
-            expect(f4).toEqual("Previous Feature");
-            expect(f5).toEqual("Next Feature");
-            expect(f6).toEqual("Focus Controls");
+            expect(f).toEqual("Next Feature");
+            expect(f2).toEqual("Focus Controls");
+            expect(f3).toEqual("Previous Feature");
+            expect(f4).toEqual("Focus Map");
           });
 
           test("[" + browserType + "]" + " Tab to next feature after tabbing out of popup", async () => {
+            await page.keyboard.press("Tab");
+            await page.keyboard.press("Tab");
+            await page.keyboard.press("Tab");
             await page.keyboard.press("Tab");
             const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
@@ -185,6 +173,8 @@ jest.setTimeout(50000);
           test("[" + browserType + "]" + " Shift + Tab to previous feature while popup open", async () => {
             await page.keyboard.press("Enter");
             await page.keyboard.press("Shift+Tab");
+            await page.keyboard.press("Shift+Tab");
+            await page.keyboard.press("Shift+Tab");
             const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
             const rh = await page.evaluateHandle(root => root.activeElement, nh);
@@ -196,8 +186,7 @@ jest.setTimeout(50000);
           test("[" + browserType + "]" + " Previous feature button focuses previous feature", async () => {
             await page.keyboard.press("Tab");
             await page.keyboard.press("Enter");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Tab");
+            await page.keyboard.press("Shift+Tab");
             await page.keyboard.press("Enter");
             const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
@@ -210,9 +199,6 @@ jest.setTimeout(50000);
           test("[" + browserType + "]" + " Next feature button focuses next feature", async () => {
             await page.keyboard.press("Tab");
             await page.keyboard.press("Enter");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Tab");
             await page.keyboard.press("Enter");
             const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);

--- a/test/e2e/core/keyboardInteraction.test.js
+++ b/test/e2e/core/keyboardInteraction.test.js
@@ -130,38 +130,56 @@ jest.setTimeout(50000);
             const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
             const rh = await page.evaluateHandle(root => root.activeElement, nh);
-            const f = await (await page.evaluateHandle(elem => elem.title, rh)).jsonValue();
+            const f = await (await page.evaluateHandle(elem => elem.className, rh)).jsonValue();
 
             await page.keyboard.press("Tab");
             const h2 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh2 = await page.evaluateHandle(doc => doc.shadowRoot, h2);
             const rh2 = await page.evaluateHandle(root => root.activeElement, nh2);
-            const f2 = await (await page.evaluateHandle(elem => elem.title, rh2)).jsonValue();
+            const f2 = await (await page.evaluateHandle(elem => elem.tagName, rh2)).jsonValue();
 
-            await page.keyboard.press("Shift+Tab");
-            await page.keyboard.press("Shift+Tab");
+            await page.keyboard.press("Tab");
             const h3 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh3 = await page.evaluateHandle(doc => doc.shadowRoot, h3);
             const rh3 = await page.evaluateHandle(root => root.activeElement, nh3);
             const f3 = await (await page.evaluateHandle(elem => elem.title, rh3)).jsonValue();
 
-            await page.keyboard.press("Shift+Tab");
+            await page.keyboard.press("Tab");
             const h4 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh4 = await page.evaluateHandle(doc => doc.shadowRoot, h4);
             const rh4 = await page.evaluateHandle(root => root.activeElement, nh4);
             const f4 = await (await page.evaluateHandle(elem => elem.title, rh4)).jsonValue();
 
-            expect(f).toEqual("Next Feature");
-            expect(f2).toEqual("Focus Controls");
-            expect(f3).toEqual("Previous Feature");
-            expect(f4).toEqual("Focus Map");
+            await page.keyboard.press("Tab");
+            const h5 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+            const nh5 = await page.evaluateHandle(doc => doc.shadowRoot, h5);
+            const rh5 = await page.evaluateHandle(root => root.activeElement, nh5);
+            const f5 = await (await page.evaluateHandle(elem => elem.title, rh5)).jsonValue();
+
+            await page.keyboard.press("Tab");
+            const h6 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+            const nh6 = await page.evaluateHandle(doc => doc.shadowRoot, h6);
+            const rh6 = await page.evaluateHandle(root => root.activeElement, nh6);
+            const f6 = await (await page.evaluateHandle(elem => elem.title, rh6)).jsonValue();
+
+            await page.keyboard.press("Tab");
+            const h7 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+            const nh7 = await page.evaluateHandle(doc => doc.shadowRoot, h7);
+            const rh7 = await page.evaluateHandle(root => root.activeElement, nh7);
+            const f7 = await (await page.evaluateHandle(elem => elem.className, rh7)).jsonValue();
+
+            expect(f).toEqual("mapml-popup-content");
+            expect(f2.toUpperCase()).toEqual("A");
+            expect(f3).toEqual("Focus Map");
+            expect(f4).toEqual("Previous Feature");
+            expect(f5).toEqual("Next Feature");
+            expect(f6).toEqual("Focus Controls");
+            expect(f7).toEqual("leaflet-popup-close-button");
           });
 
           test("[" + browserType + "]" + " Tab to next feature after tabbing out of popup", async () => {
             await page.keyboard.press("Tab");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Tab");
+
             const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
             const rh = await page.evaluateHandle(root => root.activeElement, nh);
@@ -170,23 +188,22 @@ jest.setTimeout(50000);
             expect(f).toEqual("M-53 451L153 508L113 146L-53 191z");
           });
 
-          test("[" + browserType + "]" + " Shift + Tab to previous feature while popup open", async () => {
+          test("[" + browserType + "]" + " Shift + Tab to current feature while popup open", async () => {
             await page.keyboard.press("Enter");
             await page.keyboard.press("Shift+Tab");
-            await page.keyboard.press("Shift+Tab");
-            await page.keyboard.press("Shift+Tab");
+
             const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
             const rh = await page.evaluateHandle(root => root.activeElement, nh);
             const f = await (await page.evaluateHandle(elem => elem.getAttribute("d"), rh)).jsonValue();
 
-            expect(f).toEqual("M330 83L553 83L553 339L330 339z");
+            expect(f).toEqual("M-53 451L153 508L113 146L-53 191z");
           });
 
           test("[" + browserType + "]" + " Previous feature button focuses previous feature", async () => {
-            await page.keyboard.press("Tab");
             await page.keyboard.press("Enter");
-            await page.keyboard.press("Shift+Tab");
+            await page.keyboard.press("Tab");
+            await page.keyboard.press("Tab");
             await page.keyboard.press("Enter");
             const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
@@ -199,6 +216,9 @@ jest.setTimeout(50000);
           test("[" + browserType + "]" + " Next feature button focuses next feature", async () => {
             await page.keyboard.press("Tab");
             await page.keyboard.press("Enter");
+            await page.keyboard.press("Tab");
+            await page.keyboard.press("Tab");
+            await page.keyboard.press("Tab");
             await page.keyboard.press("Enter");
             const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
             const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);

--- a/test/e2e/core/keyboardInteraction.test.js
+++ b/test/e2e/core/keyboardInteraction.test.js
@@ -7,7 +7,7 @@ jest.setTimeout(50000);
       () => {
         beforeAll(async () => {
           browser = await playwright[browserType].launch({
-            headless: false,//ISHEADLESS,
+            headless: ISHEADLESS,
             slowMo: 50,
           });
           context = await browser.newContext();


### PR DESCRIPTION
This PR:

- [x] Doubles size of crosshair
- [x] Focuses `+` (Zoom control) instead of parent div when clicking `>|`
- [x] Doesn't hide the crosshair on keypresses as the crosshair is meant to indicate focus 
- [x] `Space` and `Enter` now query top layer
- [x] Pressing `Esc` or closing using the close button now focuses the map afterwards with the crosshair visible
- [x] Tabbing out of query popup focuses controls
- [x] Shift + Tabbing out of query popup focuses map
- [x]  Shift + Tabbing out of feature popup focuses the current feature
- [x] Re-adds close button to features popup 

Closes #291 