### PR TITLE
Adds outline to map

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -427,3 +427,12 @@ summary {
   text-align: center;
   padding: 2px;
 }
+
+.mapml-outline {
+  outline-style: auto;
+  outline-offset: -1px;
+  outline-color: #44A7CB;
+  z-index: 1000;
+  pointer-events: none;
+  position: relative;
+}

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -431,7 +431,6 @@ summary {
 .mapml-outline {
   outline-style: auto;
   outline-offset: -1px;
-  outline-color: #44A7CB;
   z-index: 1000;
   pointer-events: none;
   position: relative;

--- a/src/mapml/layers/Crosshair.js
+++ b/src/mapml/layers/Crosshair.js
@@ -63,6 +63,20 @@ export var Crosshair = L.Layer.extend({
     }
   },
 
+  _addOrRemoveMapOutline: function (e) {
+    let mapContainer = this._map._container;
+    if (this._map.isFocused && !this._outline) {
+      this._outline = L.DomUtil.create("div", "mapml-outline", mapContainer);
+      this._outline.style.width = mapContainer.style.width;
+      this._outline.style.height = mapContainer.style.height;
+      //mapContainer.style.outlineStyle = "auto";
+      //.mapContainer.style.outlineColor = "#44A7CB";
+    } else if (!this._map.isFocused && this._outline) {
+      L.DomUtil.remove(this._outline);
+      delete this._outline;
+    }
+  },
+
   _hasQueryableLayer: function () {
     let layers = this._map.options.mapEl.layers;
     if (this._map.isFocused) {
@@ -84,6 +98,7 @@ export var Crosshair = L.Layer.extend({
     } else {
       this._map.isFocused = false;
     }
+    this._addOrRemoveMapOutline();
     this._addOrRemoveCrosshair();
   },
 

--- a/src/mapml/layers/FeatureLayer.js
+++ b/src/mapml/layers/FeatureLayer.js
@@ -281,10 +281,12 @@ export var MapMLFeatures = L.FeatureGroup.extend({
 
         if (options.onEachFeature) {
          options.onEachFeature(layer.properties, layer);
-         layer._events.keypress.push({
-           "ctx": layer,
-           "fn": this._onSpacePress,
-         });
+         if(layer._events){
+            layer._events.keypress.push({
+              "ctx": layer,
+              "fn": this._onSpacePress,
+            });
+          }
         }
         if(this._staticFeature){
           let featureZoom = mapml.getAttribute('zoom') || nativeZoom;


### PR DESCRIPTION
Uses JavaScript to create outline as the outline created using `:focus` flickers, this way the outline is smooth and only shows on keyboard tabbing into and out of the map. 

Edit: The outline color in the video is blue, but has since been changed to black.

https://user-images.githubusercontent.com/55214462/108253576-f00d5180-7127-11eb-9c8a-576e1f63d348.mp4



Closes #273 