### PR TITLE
Remove opinionated color of popup's close button

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -36,7 +36,9 @@
 }
 
 /* Remove opinionated color of links. */
-.leaflet-container a {
+.leaflet-container a,
+.leaflet-container a.leaflet-popup-close-button,
+.leaflet-container a.leaflet-popup-close-button:hover {
   color: initial;
 }
 


### PR DESCRIPTION
Close #348.

Popup's close button now conforms to all of the following WCAG success criteria:

> - [1.4.3 Contrast (Minimum)](https://www.w3.org/TR/WCAG21/#contrast-minimum)
> - [1.4.6 Contrast (Enhanced)](https://www.w3.org/TR/WCAG21/#contrast-enhanced)
> - [1.4.11 Non-text Contrast](https://www.w3.org/TR/WCAG21/#non-text-contrast)