### PR TITLE
Disable pointer-events on tooltips

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -334,6 +334,7 @@
 }
 
 /* Disable pointer events where they'd interfere with the intended action. */
+.leaflet-tooltip,
 .leaflet-crosshair *,
 .mapml-contextmenu-item > *,
 .mapml-control-layers label[for^="o"],


### PR DESCRIPTION
Fix #355.

It should be safe to disable pointer-events on tooltips, I don't think they're intended to hold interactive elements. This would also disable text selection in tooltips if that wasn't already impossible.

## Preview

<table><td width="450"><video src="https://user-images.githubusercontent.com/26493779/111503676-4087c700-8747-11eb-9ac4-dc8bed8ed9d9.mp4"></video></td></table>