### PR TITLE
Connect first and last points of a outline using modulo

### DIFF
--- a/src/mapml/features/feature.js
+++ b/src/mapml/features/feature.js
@@ -185,14 +185,15 @@ export var Feature = L.Path.extend({
       for (let n of nodes) {
         let line = [];
         if (!n.tagName) {  //no tagName means it's text content
-          let c = '';
-          if (cur - 1 > 0 && nodes[cur - 1].tagName) {
-            let prev = nodes[cur - 1].textContent.split(' ');
+          let c = '', ind = (((cur - 1)%nodes.length) + nodes.length) % nodes.length; // this equation turns Javascript's % to how it behaves in C for example
+          if (nodes[ind].tagName) {
+            let prev = nodes[ind].textContent.trim().split(/\s+/);
             c += `${prev[prev.length - 2]} ${prev[prev.length - 1]} `;
           }
           c += n.textContent;
-          if (cur + 1 < nodeLength && nodes[cur + 1].tagName) {
-            let next = nodes[cur + 1].textContent.split(' ');
+          ind = (((cur + 1)%nodes.length) + nodes.length) % nodes.length; // this is equivalent to C/C++'s (cur + 1) % nodes.length
+          if (nodes[ind].tagName) {
+            let next = nodes[ind].textContent.trim().split(/\s+/);
             c += `${next[0]} ${next[1]} `;
           }
           tempDiv.innerHTML = c;

--- a/src/mapml/utils/Util.js
+++ b/src/mapml/utils/Util.js
@@ -257,7 +257,7 @@ export var Util = {
   // input "max=5,min=4" => [[max,5][min,5]]
   metaContentToObject: function(input){
     if(!input || input instanceof Object)return {};
-    let content = input.split(" ").join("");
+    let content = input.split(/\s+/).join("");
     let contentArray = {};
     let stringSplit = content.split(',');
 


### PR DESCRIPTION
Test cases renders as:
![newfea](https://user-images.githubusercontent.com/55214462/112484473-59e4d080-8d50-11eb-8930-c5f875485bb3.PNG)


Cause of issue:
Needed to preform modulo when generating outline, without it the first and last coordinate pairs in a coordinates element didn't behave appropriately. Coordinates for a polygon are better thought of as a circular linked list rather than a sequence with a start and an end. 

On a side node, the behavior of `%` operator in JavaScript is not consistent at all, occasionally -1 % 4 = 3 and other times -1 % 4 = -1, there's a work around in this PR for it but it's odd nonetheless. 

Closes #368 