### PR TITLE
Downgrade proj4 to 2.3.14. At ^2.4.0 leaflet starts to break.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "leaflet": "^1.7.1",
     "path": "^0.12.7",
     "playwright": "^1.2.1",
-    "proj4": "^2.6.2",
+    "proj4": "^2.3.14",
     "proj4leaflet": "^1.0.2",
     "rollup": "^2.23.1"
   }


### PR DESCRIPTION
There are failing tests because of this change, maybe we can review together next week.  The custom projection that we're working on for Ben starts to work though.