### PR TITLE
Prefix the generic `web-map` class with `mapml-`

### DIFF
--- a/debug/vector-tile-test.css
+++ b/debug/vector-tile-test.css
@@ -1,7 +1,7 @@
 
 path.fclass { stroke: blue; }
 
-svg.web-map.style-scope path.fclass._1 { stroke: blue; fill: #FF8C00;}
+svg.mapml-web-map.style-scope path.fclass._1 { stroke: blue; fill: #FF8C00;}
 path.fclass._2 { stroke: blue; fill: #F5DEB3;}
 path.fclass._3 { stroke: blue; fill: #7CFC00;}
 path.fclass._4 { stroke: blue; fill: #E9967A;}

--- a/index-map-area.html
+++ b/index-map-area.html
@@ -33,7 +33,7 @@
       
       /* Pre-style to avoid FOUC of inline layer- and fallback content. */
       map[is="web-map"]:not(:defined) + img[usemap],
-      map[is="web-map"]:not(:defined) > :not(area):not(.web-map) {
+      map[is="web-map"]:not(:defined) > :not(area):not(.mapml-web-map) {
         display: none;
       }
       /* Ensure inline layer content is hidden if custom/built-in elements isn't

--- a/index-web-map.html
+++ b/index-web-map.html
@@ -33,7 +33,7 @@
       
       /* Pre-style to avoid FOUC of inline layer- and fallback content. */
       map[is="web-map"]:not(:defined) + img[usemap],
-      map[is="web-map"]:not(:defined) > :not(area):not(.web-map) {
+      map[is="web-map"]:not(:defined) > :not(area):not(.mapml-web-map) {
         display: none;
       }
       /* Ensure inline layer content is hidden if custom/built-in elements isn't

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -571,7 +571,7 @@ export var MapMLLayer = L.Layer.extend({
             control.style.pointerEvents = "none";
 
             let x = moveEvent.clientX, y = moveEvent.clientY,
-                root = mapEl.tagName === "MAPML-VIEWER" ? mapEl.shadowRoot : mapEl.querySelector(".web-map").shadowRoot,
+                root = mapEl.tagName === "MAPML-VIEWER" ? mapEl.shadowRoot : mapEl.querySelector(".mapml-web-map").shadowRoot,
                 elementAt = root.elementFromPoint(x, y),
                 swapControl = !elementAt || !elementAt.closest("fieldset") ? control : elementAt.closest("fieldset");
       

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -107,7 +107,7 @@ export class WebMap extends HTMLMapElement {
     `<link rel="stylesheet" href="${new URL("mapml.css", import.meta.url).href}">`;
 
     const rootDiv = document.createElement('div');
-    rootDiv.classList.add('web-map');
+    rootDiv.classList.add('mapml-web-map');
 
     let shadowRoot = rootDiv.attachShadow({mode: 'open'});
     this._container = document.createElement('div');
@@ -128,7 +128,7 @@ export class WebMap extends HTMLMapElement {
     `[is="web-map"][frameborder="0"] {` +
   	`border-width: 0;` +
   	`}` +
-    `[is="web-map"] .web-map {` +
+    `[is="web-map"] .mapml-web-map {` +
     `display: contents;` + // This div doesn't have to participate in layout by generating its own box.
     `}`;
     
@@ -146,7 +146,7 @@ export class WebMap extends HTMLMapElement {
     // `<area>` and `<div class="web-map">` (shadow root host) elements.
     let hideElementsCSS = document.createElement('style');
     hideElementsCSS.innerHTML =
-    `[is="web-map"] > :not(area):not(.web-map) {` +
+    `[is="web-map"] > :not(area):not(.mapml-web-map) {` +
     `display: none!important;` +
     `}`;
     

--- a/test/e2e/core/mapContextMenu.test.js
+++ b/test/e2e/core/mapContextMenu.test.js
@@ -41,7 +41,7 @@ jest.setTimeout(50000);
         test("[" + browserType + "]" + " Context menu focus on keyboard shortcut", async () => {
           await page.click("body > map");
           await page.keyboard.press("Shift+F10");
-          const aHandle = await page.evaluateHandle(() => document.querySelector(".web-map"));
+          const aHandle = await page.evaluateHandle(() => document.querySelector(".mapml-web-map"));
           const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
           const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
           const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
@@ -52,7 +52,7 @@ jest.setTimeout(50000);
 
         test("[" + browserType + "]" + " Context menu tab goes to next item", async () => {
           await page.keyboard.press("Tab");
-          const aHandle = await page.evaluateHandle(() => document.querySelector(".web-map"));
+          const aHandle = await page.evaluateHandle(() => document.querySelector(".mapml-web-map"));
           const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
           const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
           const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
@@ -64,7 +64,7 @@ jest.setTimeout(50000);
         test("[" + browserType + "]" + " Submenu opens on C with focus on first item", async () => {
           await page.keyboard.press("c");
           await page.keyboard.press("Tab");
-          const aHandle = await page.evaluateHandle(() => document.querySelector(".web-map"));
+          const aHandle = await page.evaluateHandle(() => document.querySelector(".mapml-web-map"));
           const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
           const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
           const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);

--- a/test/e2e/core/styleParsing.css
+++ b/test/e2e/core/styleParsing.css
@@ -10,7 +10,7 @@ svg path.fclass {
   stroke: blue;
 }
 
-svg.web-map.style-scope path.fclass._1 {
+svg.mapml-web-map.style-scope path.fclass._1 {
   stroke: blue;
   fill: #ff8c00;
 }


### PR DESCRIPTION
I named this class quite generically at some point, it's safer (and more consistent) to prefix it with `mapml-` to reduce the odds of clashing with authors' own perhaps generically named divs.