### PR TITLE
CSS selection/dragging of controls + outline improvements

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -442,7 +442,9 @@ summary {
   outline-offset: -1px;
   z-index: 1000;
   pointer-events: none;
-  position: relative;
+  position: absolute;
+  height: 100%;
+  width: 100%;
 }
 
 /* Quick fix for https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/358,

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -309,6 +309,8 @@
 }
 
 /* Disable dragging of controls. */
+.mapml-popup-button,
+.leaflet-popup-close-button,
 .leaflet-control :not([draggable="true"]),
 .mapml-contextmenu :not([draggable="true"]) {
   -webkit-user-drag: none;
@@ -317,7 +319,8 @@
 /* Disable text selection in controls. */
 .leaflet-control,
 .mapml-contextmenu,
-.mapml-debug {
+.mapml-debug,
+.mapml-focus-buttons {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/src/mapml/layers/Crosshair.js
+++ b/src/mapml/layers/Crosshair.js
@@ -67,10 +67,6 @@ export var Crosshair = L.Layer.extend({
     let mapContainer = this._map._container;
     if (this._map.isFocused && !this._outline) {
       this._outline = L.DomUtil.create("div", "mapml-outline", mapContainer);
-      this._outline.style.width = mapContainer.style.width;
-      this._outline.style.height = mapContainer.style.height;
-      //mapContainer.style.outlineStyle = "auto";
-      //.mapContainer.style.outlineColor = "#44A7CB";
     } else if (!this._map.isFocused && this._outline) {
       L.DomUtil.remove(this._outline);
       delete this._outline;


### PR DESCRIPTION
- [x] https://github.com/Maps4HTML/Web-Map-Custom-Element/commit/5c0db77406b126b03f16383c0d23e65331303012: Add  `mapml-focus-buttons` and `leaflet-popup-close-button` to the selectors that disable dragging/selection of controls.
- [x] https://github.com/Maps4HTML/Web-Map-Custom-Element/commit/9dae9096adaa499a2a71aa0d3a9407797413f6e1: Ensure outline is always 100% the size of the container, as it currently may not span the entire container after resize (which in best case is perhaps only a developer annoyance):<br><br><img width="400" src="https://user-images.githubusercontent.com/26493779/113512946-6eeb0c00-9567-11eb-8301-2978be50cfd7.png">
