### PR TITLE
Make the debug panel a data table

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -261,24 +261,33 @@
   max-height: 100%;
   max-width: 100%;
   border-radius: 4px;
-  padding: 10px;
+  padding: 5px 10px;
   background-color: #fff;
   cursor: default;
+  z-index: 1000;
+  position: absolute;
+  display: block;
+  top: auto;
+  right: 5px;
+  bottom: 5px;
+  left: 5px;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content
 }
 
 .mapml-debug-banner {
-  margin-left: 4px;
   font-weight: bold;
   text-transform: uppercase;
+  display: inline-block;
+  text-align: left;
+  text-align: inline-start;
+  line-height: 2;
 }
 
 .mapml-debug-panel,
 .mapml-debug-grid {
   font-family: monospace;
-}
-
-.mapml-debug-panel {
-  margin-top: 4px;
 }
 
 .mapml-debug-tile {
@@ -289,6 +298,20 @@
 .mapml-debug-coordinates {
   padding-left: 4px;
   padding-right: 4px;
+}
+
+.mapml-debug,
+.mapml-debug * {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.mapml-debug-coordinates:empty {
+  display: none;
+}
+
+.mapml-debug-coordinates > * {
+  display: inline;
 }
 
 /*

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -273,7 +273,8 @@
   left: 5px;
   width: -webkit-fit-content;
   width: -moz-fit-content;
-  width: fit-content
+  width: fit-content;
+  font: inherit;
 }
 
 .mapml-debug-banner {

--- a/src/mapml/layers/DebugLayer.js
+++ b/src/mapml/layers/DebugLayer.js
@@ -6,14 +6,7 @@ export var DebugOverlay = L.Layer.extend({
 
     //conditionally show container for debug panel/banner only when the map has enough space for it
     if (mapSize.x > 400 || mapSize.y > 300) {
-      this._container = L.DomUtil.create("div", "mapml-debug", map._container);
-      this._container.style.width = 150;
-      this._container.style.zIndex = 10000;
-      this._container.style.position = "absolute";
-      this._container.style.top = "auto";
-      this._container.style.bottom = "5px";
-      this._container.style.left = "5px";
-      this._container.style.right = "auto";
+      this._container = L.DomUtil.create("table", "mapml-debug", map._container);
 
       this._panel = debugPanel({
         className: "mapml-debug-panel",
@@ -62,20 +55,20 @@ export var DebugPanel = L.Layer.extend({
 
   onAdd: function (map) {
 
-    this._title = L.DomUtil.create("div", "mapml-debug-banner", this.options.pane);
+    this._title = L.DomUtil.create("caption", "mapml-debug-banner", this.options.pane);
     this._title.innerHTML = "Debug mode";
 
     map.debug = {};
-    map.debug._infoContainer = this._debugContainer = L.DomUtil.create("div", "mapml-debug-panel", this.options.pane);
+    map.debug._infoContainer = this._debugContainer = L.DomUtil.create("tbody", "mapml-debug-panel", this.options.pane);
 
     let infoContainer = map.debug._infoContainer;
 
-    map.debug._tileCoord = L.DomUtil.create("div", "mapml-debug-coordinates", infoContainer);
-    map.debug._tileMatrixCoord = L.DomUtil.create("div", "mapml-debug-coordinates", infoContainer);
-    map.debug._mapCoord = L.DomUtil.create("div", "mapml-debug-coordinates", infoContainer);
-    map.debug._tcrsCoord = L.DomUtil.create("div", "mapml-debug-coordinates", infoContainer);
-    map.debug._pcrsCoord = L.DomUtil.create("div", "mapml-debug-coordinates", infoContainer);
-    map.debug._gcrsCoord = L.DomUtil.create("div", "mapml-debug-coordinates", infoContainer);
+    map.debug._tileCoord = L.DomUtil.create("tr", "mapml-debug-coordinates", infoContainer);
+    map.debug._tileMatrixCoord = L.DomUtil.create("tr", "mapml-debug-coordinates", infoContainer);
+    map.debug._mapCoord = L.DomUtil.create("tr", "mapml-debug-coordinates", infoContainer);
+    map.debug._tcrsCoord = L.DomUtil.create("tr", "mapml-debug-coordinates", infoContainer);
+    map.debug._pcrsCoord = L.DomUtil.create("tr", "mapml-debug-coordinates", infoContainer);
+    map.debug._gcrsCoord = L.DomUtil.create("tr", "mapml-debug-coordinates", infoContainer);
 
     this._map.on("mousemove", this._updateCoords);
 
@@ -99,12 +92,36 @@ export var DebugPanel = L.Layer.extend({
     if (pointI < 0) pointI += tileSize;
     if (pointJ < 0) pointJ += tileSize;
 
-    this.debug._tileCoord.innerHTML = `tile: i: ${Math.trunc(pointI)}, j: ${Math.trunc(pointJ)}`;
-    this.debug._mapCoord.innerHTML = `map: i: ${Math.trunc(e.containerPoint.x)}, j: ${Math.trunc(e.containerPoint.y)}`;
-    this.debug._gcrsCoord.innerHTML = `gcrs: lon: ${e.latlng.lng.toFixed(6)}, lat: ${e.latlng.lat.toFixed(6)}`;
-    this.debug._tcrsCoord.innerHTML = `tcrs: x:${Math.trunc(point.x)}, y:${Math.trunc(point.y)}`;
-    this.debug._tileMatrixCoord.innerHTML = `tilematrix: column:${Math.trunc(point.x / tileSize)}, row:${Math.trunc(point.y / tileSize)}`;
-    this.debug._pcrsCoord.innerHTML = `pcrs: easting:${pcrs.x.toFixed(2)}, northing:${pcrs.y.toFixed(2)}`;
+    this.debug._tileCoord.innerHTML = `
+      <th scope="row">tile: </th>
+      <td>i: ${Math.trunc(pointI)}, </td>
+      <td>j: ${Math.trunc(pointJ)}</td>
+      `;
+    this.debug._mapCoord.innerHTML = `
+      <th scope="row">map: </th>
+      <td>i: ${Math.trunc(e.containerPoint.x)}, </td>
+      <td>j: ${Math.trunc(e.containerPoint.y)}</td>
+      `;
+    this.debug._gcrsCoord.innerHTML = `
+      <th scope="row">gcrs: </th>
+      <td>lon: ${e.latlng.lng.toFixed(6)}, </td>
+      <td>lat: ${e.latlng.lat.toFixed(6)}</td>
+      `;
+    this.debug._tcrsCoord.innerHTML = `
+      <th scope="row">tcrs: </th>
+      <td>x: ${Math.trunc(point.x)}, </td>
+      <td>y: ${Math.trunc(point.y)}</td>
+      `;
+    this.debug._tileMatrixCoord.innerHTML = `
+      <th scope="row">tilematrix: </th>
+      <td>column: ${Math.trunc(point.x / tileSize)}, </td>
+      <td>row: ${Math.trunc(point.y / tileSize)}</td>
+      `;
+    this.debug._pcrsCoord.innerHTML = `
+      <th scope="row">pcrs: </th>
+      <td>easting: ${pcrs.x.toFixed(2)}, </td>
+      <td>northing: ${pcrs.y.toFixed(2)}</td>
+      `;
   },
 
 });

--- a/test/e2e/core/debugMode.test.js
+++ b/test/e2e/core/debugMode.test.js
@@ -31,12 +31,12 @@ jest.setTimeout(50000);
           );
 
           const panel = await page.$eval(
-            "div > div.mapml-debug > div.mapml-debug-panel",
+            "div > table.mapml-debug > tbody.mapml-debug-panel",
             (panelElem) => panelElem.childElementCount
           );
 
           const banner = await page.$eval(
-            "div > div.mapml-debug > div.mapml-debug-banner",
+            "div > table.mapml-debug > caption.mapml-debug-banner",
             (bannerElem) => bannerElem.innerText
           );
 
@@ -78,35 +78,35 @@ jest.setTimeout(50000);
         test("[" + browserType + "]" + " Accurate debug coordinates", async () => {
           await page.hover("body > mapml-viewer");
           const tile = await page.$eval(
-            "div > div.mapml-debug > div.mapml-debug-panel > div:nth-child(1)",
+            "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(1)",
             (tileElem) => tileElem.innerText
           );
           const matrix = await page.$eval(
-            "div > div.mapml-debug > div.mapml-debug-panel > div:nth-child(2)",
+            "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(2)",
             (matrixElem) => matrixElem.innerText
           );
           const map = await page.$eval(
-            "div > div.mapml-debug > div.mapml-debug-panel > div:nth-child(3)",
+            "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(3)",
             (mapElem) => mapElem.innerText
           );
           const tcrs = await page.$eval(
-            "div > div.mapml-debug > div.mapml-debug-panel > div:nth-child(4)",
+            "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(4)",
             (tcrsElem) => tcrsElem.innerText
           );
           const pcrs = await page.$eval(
-            "div > div.mapml-debug > div.mapml-debug-panel > div:nth-child(5)",
+            "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(5)",
             (pcrsElem) => pcrsElem.innerText
           );
           const gcrs = await page.$eval(
-            "div > div.mapml-debug > div.mapml-debug-panel > div:nth-child(6)",
+            "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(6)",
             (gcrsElem) => gcrsElem.innerText
           );
 
           expect(tile).toEqual("tile: i: 141, j: 6");
-          expect(matrix).toEqual("tilematrix: column:3, row:4");
+          expect(matrix).toEqual("tilematrix: column: 3, row: 4");
           expect(map).toEqual("map: i: 250, j: 250");
-          expect(tcrs).toEqual("tcrs: x:909, y:1030");
-          expect(pcrs).toEqual("pcrs: easting:217676.00, northing:-205599.86");
+          expect(tcrs).toEqual("tcrs: x: 909, y: 1030");
+          expect(pcrs).toEqual("pcrs: easting: 217676.00, northing: -205599.86");
           expect(gcrs).toEqual("gcrs: lon: -92.152897, lat: 47.114275");
         });
 
@@ -142,12 +142,12 @@ jest.setTimeout(50000);
           );
 
           const panel = await page.$eval(
-            "div > div.mapml-debug > div.mapml-debug-panel",
+            "div > table.mapml-debug > tbody.mapml-debug-panel",
             (panelElem) => panelElem.childElementCount
           );
 
           const banner = await page.$eval(
-            "div > div.mapml-debug > div.mapml-debug-banner",
+            "div > table.mapml-debug > caption.mapml-debug-banner",
             (bannerElem) => bannerElem.innerText
           );
 


### PR DESCRIPTION
Changes the debug elements to use table elements as opposed to divs (e.g. debug panel from `<div>` to `<table>`, the debug banner from `<div>` to `<caption>`, etc.) for the reason of using semantic elements where possible.
