### PR TITLE
Add check for parser error

### DIFF
--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -698,9 +698,9 @@ export var MapMLLayer = L.Layer.extend({
         }
         function _processInitialExtent(content) {
             var mapml = this.responseXML || content;
-            if(mapml.querySelector('feature'))layer._content = mapml;
+            if(mapml.querySelector && mapml.querySelector('feature'))layer._content = mapml;
             if(!this.responseXML && this.responseText) mapml = new DOMParser().parseFromString(this.responseText,'text/xml');
-            if (this.readyState === this.DONE && mapml.querySelector) {
+            if (this.readyState === this.DONE && mapml.querySelector && !mapml.querySelector("parsererror")) {
                 var serverExtent = mapml.querySelector('extent') || mapml.querySelector('meta[name=projection]'), projection;
 
                 if (serverExtent.tagName.toLowerCase() === "extent" && serverExtent.hasAttribute('units')){


### PR DESCRIPTION
Checks if a parser error occurs before querying for mapml elements. 

Closes #389 