### PR TITLE
Adds opacity setter & getter & preserves opacity on _self links

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -59,6 +59,16 @@ export class MapLayer extends HTMLElement {
       this.removeAttribute('hidden');
     }
   }
+
+  get opacity(){
+    return this._layer._container.style.opacity || this._layer.options.opacity;
+  }
+
+  set opacity(val) {
+    if(+val > 1 || +val < 0) return;
+    this._layer.changeOpacity(val);
+  }
+
   constructor() {
     // Always call super first in constructor
     super();

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -70,6 +70,7 @@ export var MapMLLayer = L.Layer.extend({
     },
     changeOpacity: function(opacity) {
         this._container.style.opacity = opacity;
+        if(this.opacityEl) this.opacityEl.value = opacity;
     },
     onAdd: function (map) {
         if(this._extent && !this._validProjection(map)){
@@ -496,6 +497,7 @@ export var MapMLLayer = L.Layer.extend({
         opacityControlSummary = document.createElement('summary'),
         opacityControlSummaryLabel = document.createElement('label'),
         mapEl = this._layerEl.parentNode;
+        this.opacityEl = opacity;
         
         summaryContainer.classList.add('mapml-control-summary-container');
         

--- a/src/mapml/utils/Util.js
+++ b/src/mapml/utils/Util.js
@@ -323,7 +323,7 @@ export var Util = {
   },
 
   handleLink: function (link, leafletLayer) {
-    let zoomTo, justPan = false, layer;
+    let zoomTo, justPan = false, layer, opacity;
     if(link.type === "text/html" && link.target !== "_blank"){  // all other target values other than blank behave as _top
       link.target = "_top";
     } else if (link.type !== "text/html" && link.url.includes("#")){
@@ -357,6 +357,7 @@ export var Util = {
           window.location.href = link.url;
           break;
         default:
+          opacity = leafletLayer._layerEl.opacity;
           leafletLayer._layerEl.insertAdjacentElement('beforebegin', layer);
           leafletLayer._map.options.mapEl.removeChild(leafletLayer._layerEl);
           newLayer = true;
@@ -369,7 +370,11 @@ export var Util = {
           else layer.focus();
           L.DomEvent.off(layer, 'extentload', focusOnLoad);
         }
+        if(opacity) layer.opacity = opacity;
       });
-    } else if (zoomTo && !link.inPlace && justPan) leafletLayer._map.options.mapEl.zoomTo(+zoomTo.lat, +zoomTo.lng, +zoomTo.z);
+    } else if (zoomTo && !link.inPlace && justPan){
+      leafletLayer._map.options.mapEl.zoomTo(+zoomTo.lat, +zoomTo.lng, +zoomTo.z);
+      if(opacity) layer.opacity = opacity;
+    }
   },
 };

--- a/test/e2e/core/layerAttributes.test.js
+++ b/test/e2e/core/layerAttributes.test.js
@@ -82,7 +82,6 @@ jest.setTimeout(50000);
           }
         );
 
-
         describe(
           "Disabled attributes test in " + browserType,
           () => {
@@ -96,6 +95,26 @@ jest.setTimeout(50000);
               let disabled = await page.$eval("body > mapml-viewer > layer-",
                 (layer) => layer.hasAttribute("disabled", ""));
               expect(disabled).toEqual(false);
+            });
+          }
+        );
+
+        describe(
+          "Opacity setters & getters test in " + browserType,
+          () => {
+            test("[" + browserType + "]" + " Setting opacity", async () => {
+              await page.reload();
+              await page.$eval("body > mapml-viewer > layer-",
+                (layer) => layer.opacity = 0.4);
+              let value = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > details > details > input[type=range]",
+                (input) => input.value);
+              expect(value).toEqual("0.4");
+            });
+
+            test("[" + browserType + "]" + " Getting appropriate opacity", async () => {
+              let value = await page.$eval("body > mapml-viewer > layer-",
+                (layer) => layer.opacity);
+              expect(value).toEqual("0.4");
             });
           }
         );


### PR DESCRIPTION
Works with _self links, retains it's opacity, although I'm not 100% sure it's appropriate to retain since you're replacing the layer not modifying it.
Closes #393 