### PR TITLE
Adds quadkey demo

### DIFF
--- a/demo/bingTiles.html
+++ b/demo/bingTiles.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Bing Tiles</title>
+  <script type="module" src="../dist/mapml-viewer.js"></script>
+  <style>
+      html,
+      body {
+          height: 100%;
+      }
+
+      * {
+          margin: 0;
+          padding: 0;
+      }
+
+      /* Specifying the `:defined` selector is recommended to style the map
+         element, such that styles don't apply when fallback content is in use
+         (e.g. when scripting is disabled or when custom/built-in elements isn't
+         supported in the browser). */
+      mapml-viewer:defined {
+          /* Responsive map. */
+          max-width: 100%;
+
+          /* Full viewport. */
+          width: 100%;
+          height: 100%;
+
+          /* Remove default (native-like) border. */
+          /* border: none; */
+      }
+
+      /* Pre-style to avoid FOUC of inline layer- and fallback content. */
+      mapml-viewer:not(:defined)>* {
+          display: none;
+      }
+
+      /* Ensure inline layer content is hidden if custom/built-in elements isn't
+         supported, or if javascript is disabled. This needs to be defined separately
+         from the above, because the `:not(:defined)` selector invalidates the entire
+         declaration in browsers that do not support it. */
+      layer- {
+          display: none;
+      }
+  </style>
+
+</head>
+
+<body>
+<mapml-viewer projection="OSMTILE" zoom="0" lat="45.4069740362364" lon="-75.70155300710053" controls>
+  <layer- label="Custom Bing Tiles" checked>
+    <meta name="zoom" content="min=0,max=23" />
+    <extent units="OSMTILE">
+      <input name="zoomLevel" type="zoom" min="0" max="23" value="1" />
+
+      <input name="row" type="location" axis="row" units="tilematrix" min="0" max="2" />
+      <input name="col" type="location" axis="column" units="tilematrix" min="0" max="2" />
+
+      <link rel='tile' type='text/mapml' title='blank' tref='' />
+
+    </extent>
+  </layer->
+</mapml-viewer>
+<script>
+  function toQuad(x, y, z) {
+    let quadKey = [];
+    for (let i = z; i > 0; i--) {
+      let digit = '0';
+      let mask = 1 << (i - 1);
+      if ((x & mask) != 0) {
+        digit++;
+      }
+      if ((y & mask) != 0) {
+        digit++;
+        digit++;
+      }
+      quadKey.push(digit);
+    }
+    return quadKey.join('');
+  }
+
+  function attachHandler() {
+    document.querySelector('link').addEventListener('tileloadstart', (e)=>{
+      if(e.detail.zoom === 0){
+        let h2 = document.createElement('h2');
+        h2.innerHTML = "This map is created using a webservice that works with Bing Tiles + MapML's tileloadstart event. <br><br> Zoom in to browse.";
+        e.detail.appendTile(h2);
+      } else {
+        let img = document.createElement('img'), quadKey = toQuad(e.detail.x, e.detail.y, e.detail.zoom);
+        img.width = 256;
+        img.height = 256;
+        img.src = `http://quadproxy.ahmadayubi.com/${quadKey}`;
+        e.detail.appendTile(img);
+      }
+    });
+  }
+  attachHandler();
+</script>
+</body>
+
+</html>


### PR DESCRIPTION
The demo file uses mapml's tileloadstart event and returns and `<img>` with a source that points to a url that accepts quadkeys and appends it to the tile.

https://user-images.githubusercontent.com/55214462/115423476-db9f1100-a1cb-11eb-8e26-f88e5aeebd08.mp4

