### PR TITLE
Improved default styling for debug grid in fullscreen mode

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -502,3 +502,8 @@ svg.leaflet-image-layer.leaflet-interactive g {
   pointer-events: visiblePainted; /* IE 9-10 doesn't have auto */
   pointer-events: auto;
 }
+
+:fullscreen .mapml-debug-grid {
+  color: #fff;
+  text-shadow: 1px 1px 1px #000, 1px 1px 1px #000;
+}


### PR DESCRIPTION
Fix #416.

Provides a better default for the debug grid's text in fullscreen mode.

## Preview

<img width="600" src="https://user-images.githubusercontent.com/26493779/115442437-4d9a4900-a212-11eb-894b-f24029622d9a.png" alt>
