### PR TITLE
Remove unused `projection` and `zoom` parameters

### DIFF
--- a/debug/cbmt-test.mapml
+++ b/debug/cbmt-test.mapml
@@ -1,7 +1,7 @@
 <mapml xmlns="https://www.w3.org/1999/xhtml/">
     <head>
         <title>Canada Base Map - Transportation (CBMT)</title>
-        <meta http-equiv="Content-Type" content="text/mapml;projection=CBMTILE" />
+        <meta http-equiv="Content-Type" content="text/mapml"/>
         <meta charset="utf-8" />
         <link rel="license" href="https://www.nrcan.gc.ca/earth-sciences/geography/topographic-information/free-data-geogratis/licence/17285" title="Canada Base Map © Natural Resources Canada" />
     </head>

--- a/debug/select-test.mapml
+++ b/debug/select-test.mapml
@@ -1,7 +1,7 @@
 <mapml>
   <head>
     <title>Territorial Evolution 1867-Present</title>
-    <meta http-equiv="Content-Type" content="text/mapml;projection=CBMTILE"/>
+    <meta http-equiv="Content-Type" content="text/mapml"/>
     <meta charset="utf-8"/>
     <link rel="license" href="http://open.canada.ca/en/open-government-licence-canada" title="Open Government Licence - Canada"/>
     <link rel="legend" href="http://s-bsc-geoappint.nrn.nrcan.gc.ca/arcgis/rest/services/ESS/TEByYear/MapServer/legend"/>

--- a/demo/change-projection/zoomin-zoomout/cbmt-changeProjection.mapml
+++ b/demo/change-projection/zoomin-zoomout/cbmt-changeProjection.mapml
@@ -1,7 +1,7 @@
 <mapml xmlns="http://www.w3.org/1999/xhtml/">
   <head>
     <title>Canada Base Map - Transportation (CBMT)</title>
-    <meta http-equiv="Content-Type" content="text/mapml;projection=CBMTILE"/>
+    <meta http-equiv="Content-Type" content="text/mapml"/>
     <meta charset="utf-8"/>
     <link rel="zoomin" href="osm-changeProjection.mapml" type="text/mapml"/> 
     <link rel="zoomout" href="asdi-changeProjection.mapml" type="text/mapml"/> 

--- a/test/e2e/data/tiles/cbmt/alabama_feature.mapml
+++ b/test/e2e/data/tiles/cbmt/alabama_feature.mapml
@@ -1,7 +1,7 @@
 <mapml xmlns="https://www.w3.org/1999/xhtml/">
     <head>
         <title>Natural Resources Canada's CanVec+ 031G - Map Markup Language</title>
-        <meta http-equiv="Content-Type" content="text/mapml;projection=WGS84;zoom=2"/>
+        <meta http-equiv="Content-Type" content="text/mapml"/>
         <link rel="stylesheet" href="canvec_cantopo_svg.css" type="text/css"/>
         <link rel="stylesheet" href="canvec_feature_properties.css" type="text/css"/>
         <style>

--- a/test/e2e/data/tiles/cbmt/cbmt-changeProjection.mapml
+++ b/test/e2e/data/tiles/cbmt/cbmt-changeProjection.mapml
@@ -1,7 +1,7 @@
 <mapml xmlns="http://www.w3.org/1999/xhtml/">
   <head>
     <title>Canada Base Map - Transportation (CBMT)</title>
-    <meta http-equiv="Content-Type" content="text/mapml;projection=CBMTILE"/>
+    <meta http-equiv="Content-Type" content="text/mapml"/>
     <meta charset="utf-8"/>
     <link rel="zoomin" href="osm-changeProjection.mapml" type="text/mapml"/>
   </head>

--- a/test/e2e/data/tiles/cbmt/cbmt.mapml
+++ b/test/e2e/data/tiles/cbmt/cbmt.mapml
@@ -2,7 +2,7 @@
 
   <head>
     <title>Canada Base Map - Transportation (CBMT)</title>
-    <meta http-equiv="Content-Type" content="text/mapml;projection=CBMTILE" />
+    <meta http-equiv="Content-Type" content="text/mapml"/>
     <meta charset="utf-8" />
     <base href="" />
     <link rel="license"

--- a/test/e2e/data/tiles/cbmt/missing_min_max.mapml
+++ b/test/e2e/data/tiles/cbmt/missing_min_max.mapml
@@ -1,7 +1,7 @@
 <mapml>
   <head>
     <title>Canada Base Map - Transportation (CBMT)</title>
-    <meta http-equiv="Content-Type" content="text/mapml;projection=CBMTILE"/>
+    <meta http-equiv="Content-Type" content="text/mapml"/>
     <meta charset="utf-8"/>
     <base href=""/>
     <link rel="license" href="https://www.nrcan.gc.ca/earth-sciences/geography/topographic-information/free-data-geogratis/licence/17285" title="Canada Base Map © Natural Resources Canada"/>


### PR DESCRIPTION
Removes all instances of the `projection` and `zoom` parameters  in `<meta http-equiv="Content-Type" content="...">`.

Closes #436.