### PR TITLE
Allow linked feature's stroke to be customized, change linked feature style once visited.

### DIFF
--- a/src/mapml/features/feature.js
+++ b/src/mapml/features/feature.js
@@ -60,6 +60,7 @@ export var Feature = L.Path.extend({
     container.classList.add('mapml-link-preview');
     container.appendChild(p);
     elem.classList.add('map-a');
+    if (link.visited) elem.classList.add("map-a-visited");
     L.DomEvent.on(elem, 'mousedown', e => dragStart = {x:e.clientX, y:e.clientY}, this);
     L.DomEvent.on(elem, "mouseup", (e) => {
       let onTop = true, nextLayer = this.options._leafletLayer._layerEl.nextElementSibling;
@@ -71,13 +72,22 @@ export var Feature = L.Path.extend({
       if(onTop && dragStart) {
         L.DomEvent.stop(e);
         let dist = Math.sqrt(Math.pow(dragStart.x - e.clientX, 2) + Math.pow(dragStart.y - e.clientY, 2));
-        if (dist <= 5) M.handleLink(link, leafletLayer);
+        if (dist <= 5){
+          link.visited = true;
+          elem.setAttribute("stroke", "#6c00a2");
+          elem.classList.add("map-a-visited");
+          M.handleLink(link, leafletLayer);
+        }
       }
     }, this);
     L.DomEvent.on(elem, "keypress", (e) => {
       L.DomEvent.stop(e);
-      if(e.keyCode === 13 || e.keyCode === 32)
+      if(e.keyCode === 13 || e.keyCode === 32) {
+        link.visited = true;
+        elem.setAttribute("stroke", "#6c00a2");
+        elem.classList.add("map-a-visited");
         M.handleLink(link, leafletLayer);
+      }
     }, this);
     L.DomEvent.on(elem, 'mouseenter keyup', (e) => {
       if(e.target !== e.currentTarget) return;

--- a/src/mapml/features/featureRenderer.js
+++ b/src/mapml/features/featureRenderer.js
@@ -187,13 +187,6 @@ export var FeatureRenderer = L.SVG.extend({
     if (!path || !layer) { return; }
     let options = layer.options, isClosed = layer.isClosed;
     if ((options.stroke && (!isClosed || isOutline)) || (isMain && !layer.outlinePath)) {
-      if (options.link){
-        path.style.stroke = "#0000EE";
-        path.style.strokeOpacity = "1";
-        path.style.strokeWidth = "1px";
-        path.style.strokeDasharray = "none";
-
-      }
       path.setAttribute('stroke', options.color);
       path.setAttribute('stroke-opacity', options.opacity);
       path.setAttribute('stroke-width', options.weight);
@@ -210,6 +203,13 @@ export var FeatureRenderer = L.SVG.extend({
         path.setAttribute('stroke-dashoffset', options.dashOffset);
       } else {
         path.removeAttribute('stroke-dashoffset');
+      }
+
+      if (options.link){
+        path.setAttribute("stroke", options.link.visited?"#6c00a2":"#0000EE");
+        path.setAttribute("stroke-opacity", "1");
+        path.setAttribute("stroke-width", "1px");
+        path.setAttribute("stroke-dasharray", "none");
       }
     } else {
       path.setAttribute('stroke', 'none');


### PR DESCRIPTION
https://user-images.githubusercontent.com/55214462/116460742-610e6b00-a835-11eb-8f5e-fd3d9b9e4341.mp4

When a feature is visited it is tagged with a `map-a-visited` class. The first example is the default styling, the second is the an example of custom styling of links before and after being clicked.
Closes #431 