### PR TITLE
Set `role="application"`

### DIFF
--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -219,7 +219,9 @@ export class MapViewer extends HTMLElement {
     
           this.setControls(false,false,true);
           this._crosshair = M.crosshair().addTo(this._map);
-    
+          
+          // https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/274
+          this.setAttribute('role', 'application');
           // Make the Leaflet container element programmatically identifiable
           // (https://github.com/Leaflet/Leaflet/issues/7193).
           this._container.setAttribute('role', 'region');

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -254,6 +254,8 @@ export class WebMap extends HTMLMapElement {
             this.poster.style.display = 'none';
           }
           
+          // https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/274
+          this.setAttribute('role', 'application');
           // Make the Leaflet container element programmatically identifiable
           // (https://github.com/Leaflet/Leaflet/issues/7193).
           this._container.setAttribute('role', 'region');


### PR DESCRIPTION
Set `role="application"` on the map element.

Close https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/274, Close https://github.com/Maps4HTML/Web-Map-Custom-Element/pull/466.

Ideally `role="region"` on the Leaflet container would simply have been replaced by `role="application"`, however doing so results in <q>application</q> not being announced by NVDA.

I've tested numerous combinations, e.g. moving both `aria-label` and `role` to the map element, or only setting `role` on the map element and `aria-label` and/or `aria-roledescription` on the Leaflet container, and vice-versa, etc. This approach seems to be the most consistent one.
