### PR TITLE
Set inner `role="document"` in popups

### DIFF
--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -1184,6 +1184,7 @@ export var MapMLLayer = L.Layer.extend({
 
       popup._container.setAttribute("role", "dialog");
       content.setAttribute("tabindex", "-1");
+      // https://github.com/Maps4HTML/Web-Map-Custom-Element/pull/467#issuecomment-844307818
       content.setAttribute("role", "document");
       popup._count = 0; // used for feature pagination
 

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -1184,6 +1184,7 @@ export var MapMLLayer = L.Layer.extend({
 
       popup._container.setAttribute("role", "dialog");
       content.setAttribute("tabindex", "-1");
+      content.setAttribute("role", "document");
       popup._count = 0; // used for feature pagination
 
       if(popup._source._eventParents){ // check if the popup is for a feature or query


### PR DESCRIPTION
Fixes issue with popups not being announced after https://github.com/Maps4HTML/Web-Map-Custom-Element/pull/467.

Edit: To clarify, [`role="document"`](https://www.w3.org/TR/wai-aria-1.2/#document) is used to escape the `role="application"`s behavior.