### PR TITLE
native-like styles for interactive features

### DIFF
--- a/src/mapml/layers/FeatureLayer.js
+++ b/src/mapml/layers/FeatureLayer.js
@@ -13,16 +13,21 @@ export var MapMLFeatures = L.FeatureGroup.extend({
         // info: https://github.com/Leaflet/Leaflet/pull/4597
         L.DomUtil.addClass(this._container, 'leaflet-pane mapml-vector-container');
         L.setOptions(this.options.renderer, {pane: this._container});
-        let anim = L.DomUtil.create("style", "mapml-feature-animation", this._container);
-        anim.innerHTML = `@keyframes pathSelect {
-          0% {stroke: white;}
-          50% {stroke: black;}
-        }
-        g:focus > path,
-        path:focus {
-          animation-name: pathSelect;
-          animation-duration: 1s;
-          stroke-width: 5;
+        let style = L.DomUtil.create("style", "mapml-feature-style", this._container);
+        style.innerHTML = `
+        .mapml-vector-container g[role="link"]:focus,
+        .mapml-vector-container g[role="link"]:hover,
+        .mapml-vector-container g[role="button"]:focus,
+        .mapml-vector-container g[role="button"]:hover,
+        .mapml-vector-container g[role="link"] path:focus,
+        .mapml-vector-container g[role="link"] path:hover,
+        .mapml-vector-container g[role="button"] path:focus,
+        .mapml-vector-container g[role="button"] path:hover,
+        .mapml-vector-container g[role="link"]:focus path,
+        .mapml-vector-container g[role="link"]:hover path,
+        .mapml-vector-container g[role="button"]:focus path,
+        .mapml-vector-container g[role="button"]:hover path {
+          outline: 0!important;
           stroke: black;
         }`;
       }
@@ -310,7 +315,7 @@ export var MapMLFeatures = L.FeatureGroup.extend({
     _removeCSS: function(){
       let toDelete = this._container.querySelectorAll("link[rel=stylesheet],style");
       for(let i = 0; i < toDelete.length;i++){
-        if(toDelete[i].classList.contains("mapml-feature-animation")) continue;
+        if(toDelete[i].classList.contains("mapml-feature-style")) continue;
         this._container.removeChild(toDelete[i]);
       }
     },

--- a/src/mapml/layers/FeatureLayer.js
+++ b/src/mapml/layers/FeatureLayer.js
@@ -28,7 +28,7 @@ export var MapMLFeatures = L.FeatureGroup.extend({
         g[role="button"]:focus path,
         g[role="button"]:hover path {
           outline: 0!important;
-          stroke: #000;
+          stroke: #0000EE;
           stroke: LinkText;
         }`;
       }

--- a/src/mapml/layers/FeatureLayer.js
+++ b/src/mapml/layers/FeatureLayer.js
@@ -15,18 +15,18 @@ export var MapMLFeatures = L.FeatureGroup.extend({
         L.setOptions(this.options.renderer, {pane: this._container});
         let style = L.DomUtil.create("style", "mapml-feature-style", this._container);
         style.innerHTML = `
-        .mapml-vector-container g[role="link"]:focus,
-        .mapml-vector-container g[role="link"]:hover,
-        .mapml-vector-container g[role="button"]:focus,
-        .mapml-vector-container g[role="button"]:hover,
-        .mapml-vector-container g[role="link"] path:focus,
-        .mapml-vector-container g[role="link"] path:hover,
-        .mapml-vector-container g[role="button"] path:focus,
-        .mapml-vector-container g[role="button"] path:hover,
-        .mapml-vector-container g[role="link"]:focus path,
-        .mapml-vector-container g[role="link"]:hover path,
-        .mapml-vector-container g[role="button"]:focus path,
-        .mapml-vector-container g[role="button"]:hover path {
+        g[role="link"]:focus,
+        g[role="link"]:hover,
+        g[role="button"]:focus,
+        g[role="button"]:hover,
+        g[role="link"] path:focus,
+        g[role="link"] path:hover,
+        g[role="button"] path:focus,
+        g[role="button"] path:hover,
+        g[role="link"]:focus path,
+        g[role="link"]:hover path,
+        g[role="button"]:focus path,
+        g[role="button"]:hover path {
           outline: 0!important;
           stroke: #000;
           stroke: LinkText;

--- a/src/mapml/layers/FeatureLayer.js
+++ b/src/mapml/layers/FeatureLayer.js
@@ -28,7 +28,8 @@ export var MapMLFeatures = L.FeatureGroup.extend({
         .mapml-vector-container g[role="button"]:focus path,
         .mapml-vector-container g[role="button"]:hover path {
           outline: 0!important;
-          stroke: black;
+          stroke: #000;
+          stroke: LinkText;
         }`;
       }
 


### PR DESCRIPTION
- [x] Add `stroke` to interactive features on `:hover` (in conjunction to `:focus`). This enables users to see the entire hit area of the interactive feature that is being hovered.
- [x] Remove the fixed `stroke-width: 5` (currently applied on `:focus`) such that the highlighting inherits (and does not override) the initial stroke-width of a feature.
- [x] Remove `outline` on `:focus` as imposed by our [outline reset](https://github.com/Maps4HTML/Web-Map-Custom-Element/blob/e1264b86b897bbdeb7a3dd2ff7da31c3d53aa313/src/mapml.css#L369-L376) because `stroke` takes care of the highlighting of interactive features, no need to also have an additional outline.
- [x] Remove `stroke` animations. In the spirit of the W3C TAG guidelines for custom components we should keep styles to a bare minimum. If authors want animations they should implement it themselves (even though I'm aware author-provided CSS is not yet supported).

## Comparison
Interaction steps as displayed in the videos below:
1. _Hover_ Norway, Sweden, Finland, Russia with the mouse
2. _Focus_ Russia with the keyboard

<table border="0">
<tr><td width="800"><h3>Before</h3><video src="https://user-images.githubusercontent.com/26493779/123456764-81fbfe00-d5e3-11eb-934d-5ed5beef71bf.mp4"></video></td></tr>
<tr><td width="800"><h3>After</h3><video src="https://user-images.githubusercontent.com/26493779/123456746-7c061d00-d5e3-11eb-9ae2-c2abe4414021.mp4"></video></td></tr>
</table>

Thoughts? Personally, I'm not sure about:
> - [x] Add `stroke` to interactive features on `:hover` (in conjunction to `:focus`). This enables users to see the entire hit area of the interactive feature that is being hovered.

I think it's a nice addition and makes it clear where the clickable area of an interactive feature is, but it may also feel "chatty". Either way, the highlighting of features may be subject to user-preferences: https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/297. 