### PR TITLE
Add `<featurecaption>`s to `us_pop_density.mapml`

### DIFF
--- a/test/e2e/data/tiles/cbmt/us_pop_density.mapml
+++ b/test/e2e/data/tiles/cbmt/us_pop_density.mapml
@@ -13,6 +13,9 @@
   </head>
   <body>
     <feature class="all  _50-100">
+      <featurecaption>
+        Alabama
+      </featurecaption>
       <properties>
         <h1>Alabama</h1>
       </properties>
@@ -23,6 +26,9 @@
       </geometry>
     </feature>
     <feature class="all  _0-10">
+      <featurecaption>
+        Alaska
+      </featurecaption>
       <properties>
         <h1>Alaska</h1>
       </properties>
@@ -163,6 +169,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _50-100">
+      <featurecaption>
+        Arizona
+      </featurecaption>
       <properties>
         <h1>Arizona</h1>
       </properties>
@@ -173,6 +182,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _50-100">
+      <featurecaption>
+        Arkansas
+      </featurecaption>
       <properties>
         <h1>Arkansas</h1>
       </properties>
@@ -183,6 +195,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _200-500">
+      <featurecaption>
+        California
+      </featurecaption>
       <properties>
         <h1>California</h1>
       </properties>
@@ -195,6 +210,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _20-50">
+      <featurecaption>
+        Colorado
+      </featurecaption>
       <properties>
         <h1>Colorado</h1>
       </properties>
@@ -205,6 +223,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _500-1000">
+      <featurecaption>
+        Connecticut
+      </featurecaption>
       <properties>
         <h1>Connecticut</h1>
       </properties>
@@ -215,6 +236,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _200-500">
+      <featurecaption>
+        Delaware
+      </featurecaption>
       <properties>
         <h1>Delaware</h1>
       </properties>
@@ -225,6 +249,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _1000plus">
+      <featurecaption>
+        District of Columbia
+      </featurecaption>
       <properties>
         <h1>District of Columbia</h1>
       </properties>
@@ -235,6 +262,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _200-500">
+      <featurecaption>
+        Florida
+      </featurecaption>
       <properties>
         <h1>Florida</h1>
       </properties>
@@ -246,6 +276,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _100-200">
+      <featurecaption>
+        Georgia
+      </featurecaption>
       <properties>
         <h1>Georgia</h1>
       </properties>
@@ -257,6 +290,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _200-500">
+      <featurecaption>
+        Hawaii
+      </featurecaption>
       <properties>
         <h1>Hawaii</h1>
       </properties>
@@ -281,6 +317,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _10-20">
+      <featurecaption>
+        Idaho
+      </featurecaption>
       <properties>
         <h1>Idaho</h1>
       </properties>
@@ -292,6 +331,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _200-500">
+      <featurecaption>
+        Illinois
+      </featurecaption>
       <properties>
         <h1>Illinois</h1>
       </properties>
@@ -303,6 +345,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _100-200">
+      <featurecaption>
+        Indiana
+      </featurecaption>
       <properties>
         <h1>Indiana</h1>
       </properties>
@@ -313,6 +358,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _50-100">
+      <featurecaption>
+        Iowa
+      </featurecaption>
       <properties>
         <h1>Iowa</h1>
       </properties>
@@ -324,6 +372,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _20-50">
+      <featurecaption>
+        Kansas
+      </featurecaption>
       <properties>
         <h1>Kansas</h1>
       </properties>
@@ -334,6 +385,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _100-200">
+      <featurecaption>
+        Kentucky
+      </featurecaption>
       <properties>
         <h1>Kentucky</h1>
       </properties>
@@ -345,6 +399,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _100-200">
+      <featurecaption>
+        Louisiana
+      </featurecaption>
       <properties>
         <h1>Louisiana</h1>
       </properties>
@@ -356,6 +413,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _20-50">
+      <featurecaption>
+        Maine
+      </featurecaption>
       <properties>
         <h1>Maine</h1>
       </properties>
@@ -367,6 +427,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _500-1000">
+      <featurecaption>
+        Maryland
+      </featurecaption>
       <properties>
         <h1>Maryland</h1>
       </properties>
@@ -383,6 +446,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _500-1000">
+      <featurecaption>
+        Massachusetts
+      </featurecaption>
       <properties>
         <h1>Massachusetts</h1>
       </properties>
@@ -393,6 +459,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _100-200">
+      <featurecaption>
+        Michigan
+      </featurecaption>
       <properties>
         <h1>Michigan</h1>
       </properties>
@@ -416,6 +485,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _50-100">
+      <featurecaption>
+        Minnesota
+      </featurecaption>
       <properties>
         <h1>Minnesota</h1>
       </properties>
@@ -427,6 +499,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _50-100">
+      <featurecaption>
+        Mississippi
+      </featurecaption>
       <properties>
         <h1>Mississippi</h1>
       </properties>
@@ -437,6 +512,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _50-100">
+      <featurecaption>
+        Missouri
+      </featurecaption>
       <properties>
         <h1>Missouri</h1>
       </properties>
@@ -448,6 +526,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _0-10">
+      <featurecaption>
+        Montana
+      </featurecaption>
       <properties>
         <h1>Montana</h1>
       </properties>
@@ -459,6 +540,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _20-50">
+      <featurecaption>
+        Nebraska
+      </featurecaption>
       <properties>
         <h1>Nebraska</h1>
       </properties>
@@ -469,6 +553,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _20-50">
+      <featurecaption>
+        Nevada
+      </featurecaption>
       <properties>
         <h1>Nevada</h1>
       </properties>
@@ -479,6 +566,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _100-200">
+      <featurecaption>
+        New Hampshire
+      </featurecaption>
       <properties>
         <h1>New Hampshire</h1>
       </properties>
@@ -489,6 +579,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _1000plus">
+      <featurecaption>
+        New Jersey
+      </featurecaption>
       <properties>
         <h1>New Jersey</h1>
       </properties>
@@ -499,6 +592,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _10-20">
+      <featurecaption>
+        New Mexico
+      </featurecaption>
       <properties>
         <h1>New Mexico</h1>
       </properties>
@@ -509,6 +605,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _200-500">
+      <featurecaption>
+        New York
+      </featurecaption>
       <properties>
         <h1>New York</h1>
       </properties>
@@ -520,6 +619,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _100-200">
+      <featurecaption>
+        North Carolina
+      </featurecaption>
       <properties>
         <h1>North Carolina</h1>
       </properties>
@@ -531,6 +633,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _0-10">
+      <featurecaption>
+        North Dakota
+      </featurecaption>
       <properties>
         <h1>North Dakota</h1>
       </properties>
@@ -541,6 +646,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _200-500">
+      <featurecaption>
+        Ohio
+      </featurecaption>
       <properties>
         <h1>Ohio</h1>
       </properties>
@@ -552,6 +660,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _50-100">
+      <featurecaption>
+        Oklahoma
+      </featurecaption>
       <properties>
         <h1>Oklahoma</h1>
       </properties>
@@ -562,6 +673,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _20-50">
+      <featurecaption>
+        Oregon
+      </featurecaption>
       <properties>
         <h1>Oregon</h1>
       </properties>
@@ -573,6 +687,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _200-500">
+      <featurecaption>
+        Pennsylvania
+      </featurecaption>
       <properties>
         <h1>Pennsylvania</h1>
       </properties>
@@ -583,6 +700,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _1000plus">
+      <featurecaption>
+        Rhode Island
+      </featurecaption>
       <properties>
         <h1>Rhode Island</h1>
       </properties>
@@ -598,6 +718,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _100-200">
+      <featurecaption>
+        South Carolina
+      </featurecaption>
       <properties>
         <h1>South Carolina</h1>
       </properties>
@@ -608,6 +731,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _50-100">
+      <featurecaption>
+        South Dakota
+      </featurecaption>
       <properties>
         <h1>South Dakota</h1>
       </properties>
@@ -618,6 +744,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _50-100">
+      <featurecaption>
+        Tennessee
+      </featurecaption>
       <properties>
         <h1>Tennessee</h1>
       </properties>
@@ -628,6 +757,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _50-100">
+      <featurecaption>
+        Texas
+      </featurecaption>
       <properties>
         <h1>Texas</h1>
       </properties>
@@ -641,6 +773,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _20-50">
+      <featurecaption>
+        Utah
+      </featurecaption>
       <properties>
         <h1>Utah</h1>
       </properties>
@@ -651,6 +786,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _50-100">
+      <featurecaption>
+        Vermont
+      </featurecaption>
       <properties>
         <h1>Vermont</h1>
       </properties>
@@ -661,6 +799,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _200-500">
+      <featurecaption>
+        Virginia
+      </featurecaption>
       <properties>
         <h1>Virginia</h1>
       </properties>
@@ -680,6 +821,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _100-200">
+      <featurecaption>
+        Washington
+      </featurecaption>
       <properties>
         <h1>Washington</h1>
       </properties>
@@ -699,6 +843,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _50-100">
+      <featurecaption>
+        West Virginia
+      </featurecaption>
       <properties>
         <h1>West Virginia</h1>
       </properties>
@@ -710,6 +857,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _100-200">
+      <featurecaption>
+        Wisconsin
+      </featurecaption>
       <properties>
         <h1>Wisconsin</h1>
       </properties>
@@ -721,6 +871,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _0-10">
+      <featurecaption>
+        Wyoming
+      </featurecaption>
       <properties>
         <h1>Wyoming</h1>
       </properties>
@@ -731,6 +884,9 @@
       </geometry>
     </feature>
     <feature zoom="0" class="all  _1000plus">
+      <featurecaption>
+        Puerto Rico
+      </featurecaption>
       <properties>
         <h1>Puerto Rico</h1>
       </properties>


### PR DESCRIPTION
Not sure this is useful to anyone else, but I like to inspect/learn from the test files, and missing `<featurecaption>`s results in everything defaulting to "Feature" which isn't ideal.

There is a [similar file in the demo folder](https://github.com/Maps4HTML/Web-Map-Custom-Element/blob/master/demo/us_pop_density.mapml), which I have not updated because I don't think that's used anywhere. I don't mind updating that as well if it is to be used (or is used elsewhere).

There are many other mapml files that could need some `<featurecaption>` love, may fix in separate PRs if desired.