### PR TITLE
Pre-style to avoid Layout Shift

### DIFF
--- a/index-map-area.html
+++ b/index-map-area.html
@@ -36,6 +36,14 @@
       map[is="web-map"]:not(:defined) > :not(area):not(.mapml-web-map) {
         display: none;
       }
+      
+      /* Pre-style to avoid Layout Shift. */
+      map[is="web-map"]:not(:defined) {
+        display: inline-block;
+        contain: size;
+        contain-intrinsic-size: 304px 154px;
+      }
+      
       /* Ensure inline layer content is hidden if custom/built-in elements isn't
       supported, or if javascript is disabled. This needs to be defined separately
       from the above, because the `:not(:defined)` selector invalidates the entire
@@ -50,6 +58,14 @@
         elements is supported but javascript is disabled. */
         map[is="web-map"]:not(:defined) + img[usemap] {
           display: initial;
+        }
+        
+        /* "Reset" the properties used to pre-style (to avoid Layout Shift) if
+        custom/built-in elements is supported but javascript is disabled. */
+        map[is="web-map"]:not(:defined) {
+          display: initial;
+          contain: initial;
+          contain-intrinsic-size: initial;
         }
       </style>
     </noscript>

--- a/index-mapml-viewer.html
+++ b/index-mapml-viewer.html
@@ -35,6 +35,14 @@
       mapml-viewer:not(:defined) > * {
         display: none;
       }
+      
+      /* Pre-style to avoid Layout Shift. */
+      mapml-viewer:not(:defined) {
+        display: inline-block;
+        contain: size;
+        contain-intrinsic-size: 304px 154px;
+      }
+      
       /* Ensure inline layer content is hidden if custom/built-in elements isn't
       supported, or if javascript is disabled. This needs to be defined separately
       from the above, because the `:not(:defined)` selector invalidates the entire
@@ -49,6 +57,14 @@
         custom/built-in elements is supported but javascript is disabled. */
         mapml-viewer:not(:defined) > :not(layer-) {
           display: initial;
+        }
+        
+        /* "Reset" the properties used to pre-style (to avoid Layout Shift) if
+        custom/built-in elements is supported but javascript is disabled. */
+        mapml-viewer:not(:defined) {
+          display: initial;
+          contain: initial;
+          contain-intrinsic-size: initial;
         }
       </style>
     </noscript>

--- a/index-web-map.html
+++ b/index-web-map.html
@@ -36,6 +36,14 @@
       map[is="web-map"]:not(:defined) > :not(area):not(.mapml-web-map) {
         display: none;
       }
+      
+      /* Pre-style to avoid Layout Shift. */
+      map[is="web-map"]:not(:defined) {
+        display: inline-block;
+        contain: size;
+        contain-intrinsic-size: 304px 154px;
+      }
+      
       /* Ensure inline layer content is hidden if custom/built-in elements isn't
       supported, or if javascript is disabled. This needs to be defined separately
       from the above, because the `:not(:defined)` selector invalidates the entire
@@ -50,6 +58,14 @@
         elements is supported but javascript is disabled. */
         map[is="web-map"]:not(:defined) + img[usemap] {
           display: initial;
+        }
+        
+        /* "Reset" the properties used to pre-style (to avoid Layout Shift) if
+        custom/built-in elements is supported but javascript is disabled. */
+        map[is="web-map"]:not(:defined) {
+          display: initial;
+          contain: initial;
+          contain-intrinsic-size: initial;
         }
       </style>
     </noscript>

--- a/index.html
+++ b/index.html
@@ -35,6 +35,14 @@
        mapml-viewer:not(:defined) > * { 
          display: none; 
        } 
+       
+       /* Pre-style to avoid Layout Shift. */
+       mapml-viewer:not(:defined) {
+         display: inline-block;
+         contain: size;
+         contain-intrinsic-size: 304px 154px;
+       }
+       
        /* Ensure inline layer content is hidden if custom/built-in elements isn't 
        supported, or if javascript is disabled. This needs to be defined separately 
        from the above, because the `:not(:defined)` selector invalidates the entire 
@@ -50,6 +58,14 @@
          mapml-viewer:not(:defined) > :not(layer-) { 
            display: initial; 
          } 
+         
+         /* "Reset" the properties used to pre-style (to avoid Layout Shift) if
+         custom/built-in elements is supported but javascript is disabled. */
+         mapml-viewer:not(:defined) {
+           display: initial;
+           contain: initial;
+           contain-intrinsic-size: initial;
+         }
        </style> 
      </noscript> 
   </head>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,9 @@
           height: 100%;  
           
          /* Remove default (native-like) border. */ 
-         /* border: none; */ 
+         border: none;
+         
+         vertical-align: middle;
        } 
         
        /* Pre-style to avoid FOUC of inline layer- and fallback content. */ 


### PR DESCRIPTION
Fix https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/376.

https://user-images.githubusercontent.com/26493779/126076213-e19fd082-1450-4676-aa8e-df1609facc1d.mp4

I'm only adding these styles to the "main" HTML documents, and not every HTML file in this repo because that's a bit tedious. And these are ("advanced") styles to progressively enhance the map viewer, nothing essential.

How/why to pre-style to avoid Layout Shift is to be documented, per https://github.com/Maps4HTML/web-map-doc/issues/26.
