### PR TITLE
Correct HTML namespaces

### DIFF
--- a/debug/cbmt-test.mapml
+++ b/debug/cbmt-test.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>Canada Base Map - Transportation (CBMT)</title>
         <meta http-equiv="Content-Type" content="text/mapml"/>

--- a/demo/arctic-sdi.mapml
+++ b/demo/arctic-sdi.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="http://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <meta charset="utf-8" />
         <title>Arctic SDI for Canada</title>

--- a/demo/restaurants.mapml
+++ b/demo/restaurants.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="http://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>Restaurants</title>
         <meta charset="utf-8" />

--- a/demo/us_pop_density.mapml
+++ b/demo/us_pop_density.mapml
@@ -1,4 +1,4 @@
-<mapml  xmlns="http://www.w3.org/1999/xhtml/">
+<mapml  xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>US Population Density</title>
     <meta http-equiv="Content-Type" content="text/mapml"/>

--- a/test/e2e/data/tiles/cbmt/alabama_feature.mapml
+++ b/test/e2e/data/tiles/cbmt/alabama_feature.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>Natural Resources Canada's CanVec+ 031G - Map Markup Language</title>
         <meta http-equiv="Content-Type" content="text/mapml"/>

--- a/test/e2e/data/tiles/cbmt/cbmt-changeProjection.mapml
+++ b/test/e2e/data/tiles/cbmt/cbmt-changeProjection.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="http://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>Canada Base Map - Transportation (CBMT)</title>
     <meta http-equiv="Content-Type" content="text/mapml"/>

--- a/test/e2e/data/tiles/cbmt/cbmt.mapml
+++ b/test/e2e/data/tiles/cbmt/cbmt.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
 
   <head>
     <title>Canada Base Map - Transportation (CBMT)</title>

--- a/test/e2e/data/tiles/cbmt/osm-changeProjection.mapml
+++ b/test/e2e/data/tiles/cbmt/osm-changeProjection.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="http://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta charset="utf-8"/>
     <title>OpenStreetMap</title>

--- a/test/e2e/data/tiles/cbmt/templatedImage.mapml
+++ b/test/e2e/data/tiles/cbmt/templatedImage.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>Toporama</title>
     <meta charset="utf-8"/>

--- a/test/e2e/data/tiles/cbmt/us_map_query.mapml
+++ b/test/e2e/data/tiles/cbmt/us_map_query.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>US Population Density + Random</title>
     <meta http-equiv="Content-Type" content="text/mapml"/>

--- a/test/e2e/data/tiles/cbmt/us_pop_density.mapml
+++ b/test/e2e/data/tiles/cbmt/us_pop_density.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>US Population Density</title>
     <meta http-equiv="Content-Type" content="text/mapml"/>

--- a/test/e2e/data/tiles/wgs84/0/r0_c0.mapml
+++ b/test/e2e/data/tiles/wgs84/0/r0_c0.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 
@@ -2176,15 +2176,15 @@
                   <tr><th scope="row">subunit</th><td itemprop="subunit">Ivory Coast</td></tr>
                   <tr><th scope="row">su_a3</th><td itemprop="su_a3">CIV</td></tr>
                   <tr><th scope="row">brk_diff</th><td itemprop="brk_diff">0</td></tr>
-                  <tr><th scope="row">name</th><td itemprop="name">Côte d'Ivoire</td></tr>
-                  <tr><th scope="row">name_long</th><td itemprop="name_long">Côte d'Ivoire</td></tr>
+                  <tr><th scope="row">name</th><td itemprop="name">Cï¿½te d'Ivoire</td></tr>
+                  <tr><th scope="row">name_long</th><td itemprop="name_long">Cï¿½te d'Ivoire</td></tr>
                   <tr><th scope="row">brk_a3</th><td itemprop="brk_a3">CIV</td></tr>
-                  <tr><th scope="row">brk_name</th><td itemprop="brk_name">Côte d'Ivoire</td></tr>
+                  <tr><th scope="row">brk_name</th><td itemprop="brk_name">Cï¿½te d'Ivoire</td></tr>
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">I.C.</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">CI</td></tr>
                   <tr><th scope="row">formal_en</th><td itemprop="formal_en">Republic of Ivory Coast</td></tr>
                   <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Republic of Cote D'Ivoire</td></tr>
-                  <tr><th scope="row">name_sort</th><td itemprop="name_sort">Côte d'Ivoire</td></tr>
+                  <tr><th scope="row">name_sort</th><td itemprop="name_sort">Cï¿½te d'Ivoire</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">4</td></tr>
                   <tr><th scope="row">mapcolor8</th><td itemprop="mapcolor8">6</td></tr>
                   <tr><th scope="row">mapcolor9</th><td itemprop="mapcolor9">3</td></tr>
@@ -2637,7 +2637,7 @@
                   <tr><th scope="row">brk_name</th><td itemprop="brk_name">Faeroe Islands</td></tr>
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Faeroe Is.</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">FO</td></tr>
-                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Føroyar Is. (Faeroe Is.)</td></tr>
+                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Fï¿½royar Is. (Faeroe Is.)</td></tr>
                   <tr><th scope="row">note_adm0</th><td itemprop="note_adm0">Den.</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Faeroe Islands</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">4</td></tr>
@@ -4526,7 +4526,7 @@
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Togo</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">TG</td></tr>
                   <tr><th scope="row">formal_en</th><td itemprop="formal_en">Togolese Republic</td></tr>
-                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">République Togolaise</td></tr>
+                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Rï¿½publique Togolaise</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Togo</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">3</td></tr>
                   <tr><th scope="row">mapcolor8</th><td itemprop="mapcolor8">1</td></tr>
@@ -4673,7 +4673,7 @@
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Ven.</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">VE</td></tr>
                   <tr><th scope="row">formal_en</th><td itemprop="formal_en">Bolivarian Republic of Venezuela</td></tr>
-                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">República Bolivariana de Venezuela</td></tr>
+                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Repï¿½blica Bolivariana de Venezuela</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Venezuela, RB</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">1</td></tr>
                   <tr><th scope="row">mapcolor8</th><td itemprop="mapcolor8">3</td></tr>

--- a/test/e2e/data/tiles/wgs84/0/r0_c1.mapml
+++ b/test/e2e/data/tiles/wgs84/0/r0_c1.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 
@@ -2466,7 +2466,7 @@
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">New C.</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">NC</td></tr>
                   <tr><th scope="row">formal_en</th><td itemprop="formal_en">New Caledonia</td></tr>
-                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Nouvelle-Calédonie</td></tr>
+                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Nouvelle-Calï¿½donie</td></tr>
                   <tr><th scope="row">note_adm0</th><td itemprop="note_adm0">Fr.</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">New Caledonia</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">7</td></tr>
@@ -3689,7 +3689,7 @@
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Togo</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">TG</td></tr>
                   <tr><th scope="row">formal_en</th><td itemprop="formal_en">Togolese Republic</td></tr>
-                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">République Togolaise</td></tr>
+                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Rï¿½publique Togolaise</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Togo</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">3</td></tr>
                   <tr><th scope="row">mapcolor8</th><td itemprop="mapcolor8">1</td></tr>
@@ -3908,7 +3908,7 @@
                   <tr><th scope="row">brk_name</th><td itemprop="brk_name">Aland</td></tr>
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Aland</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">AI</td></tr>
-                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Åland Islands</td></tr>
+                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">ï¿½land Islands</td></tr>
                   <tr><th scope="row">note_adm0</th><td itemprop="note_adm0">Fin.</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Aland</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">4</td></tr>

--- a/test/e2e/data/tiles/wgs84/1/r0_c0.mapml
+++ b/test/e2e/data/tiles/wgs84/1/r0_c0.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/1/r0_c1.mapml
+++ b/test/e2e/data/tiles/wgs84/1/r0_c1.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 
@@ -1049,15 +1049,15 @@
                   <tr><th scope="row">subunit</th><td itemprop="subunit">Ivory Coast</td></tr>
                   <tr><th scope="row">su_a3</th><td itemprop="su_a3">CIV</td></tr>
                   <tr><th scope="row">brk_diff</th><td itemprop="brk_diff">0</td></tr>
-                  <tr><th scope="row">name</th><td itemprop="name">Côte d'Ivoire</td></tr>
-                  <tr><th scope="row">name_long</th><td itemprop="name_long">Côte d'Ivoire</td></tr>
+                  <tr><th scope="row">name</th><td itemprop="name">Cï¿½te d'Ivoire</td></tr>
+                  <tr><th scope="row">name_long</th><td itemprop="name_long">Cï¿½te d'Ivoire</td></tr>
                   <tr><th scope="row">brk_a3</th><td itemprop="brk_a3">CIV</td></tr>
-                  <tr><th scope="row">brk_name</th><td itemprop="brk_name">Côte d'Ivoire</td></tr>
+                  <tr><th scope="row">brk_name</th><td itemprop="brk_name">Cï¿½te d'Ivoire</td></tr>
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">I.C.</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">CI</td></tr>
                   <tr><th scope="row">formal_en</th><td itemprop="formal_en">Republic of Ivory Coast</td></tr>
                   <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Republic of Cote D'Ivoire</td></tr>
-                  <tr><th scope="row">name_sort</th><td itemprop="name_sort">Côte d'Ivoire</td></tr>
+                  <tr><th scope="row">name_sort</th><td itemprop="name_sort">Cï¿½te d'Ivoire</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">4</td></tr>
                   <tr><th scope="row">mapcolor8</th><td itemprop="mapcolor8">6</td></tr>
                   <tr><th scope="row">mapcolor9</th><td itemprop="mapcolor9">3</td></tr>
@@ -1510,7 +1510,7 @@
                   <tr><th scope="row">brk_name</th><td itemprop="brk_name">Faeroe Islands</td></tr>
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Faeroe Is.</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">FO</td></tr>
-                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Føroyar Is. (Faeroe Is.)</td></tr>
+                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Fï¿½royar Is. (Faeroe Is.)</td></tr>
                   <tr><th scope="row">note_adm0</th><td itemprop="note_adm0">Den.</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Faeroe Islands</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">4</td></tr>
@@ -3401,7 +3401,7 @@
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Togo</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">TG</td></tr>
                   <tr><th scope="row">formal_en</th><td itemprop="formal_en">Togolese Republic</td></tr>
-                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">République Togolaise</td></tr>
+                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Rï¿½publique Togolaise</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Togo</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">3</td></tr>
                   <tr><th scope="row">mapcolor8</th><td itemprop="mapcolor8">1</td></tr>
@@ -3548,7 +3548,7 @@
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Ven.</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">VE</td></tr>
                   <tr><th scope="row">formal_en</th><td itemprop="formal_en">Bolivarian Republic of Venezuela</td></tr>
-                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">República Bolivariana de Venezuela</td></tr>
+                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Repï¿½blica Bolivariana de Venezuela</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Venezuela, RB</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">1</td></tr>
                   <tr><th scope="row">mapcolor8</th><td itemprop="mapcolor8">3</td></tr>

--- a/test/e2e/data/tiles/wgs84/1/r0_c2.mapml
+++ b/test/e2e/data/tiles/wgs84/1/r0_c2.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 
@@ -1418,7 +1418,7 @@
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Togo</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">TG</td></tr>
                   <tr><th scope="row">formal_en</th><td itemprop="formal_en">Togolese Republic</td></tr>
-                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">République Togolaise</td></tr>
+                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Rï¿½publique Togolaise</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Togo</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">3</td></tr>
                   <tr><th scope="row">mapcolor8</th><td itemprop="mapcolor8">1</td></tr>
@@ -1637,7 +1637,7 @@
                   <tr><th scope="row">brk_name</th><td itemprop="brk_name">Aland</td></tr>
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Aland</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">AI</td></tr>
-                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Åland Islands</td></tr>
+                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">ï¿½land Islands</td></tr>
                   <tr><th scope="row">note_adm0</th><td itemprop="note_adm0">Fin.</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Aland</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">4</td></tr>

--- a/test/e2e/data/tiles/wgs84/1/r0_c3.mapml
+++ b/test/e2e/data/tiles/wgs84/1/r0_c3.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/1/r1_c0.mapml
+++ b/test/e2e/data/tiles/wgs84/1/r1_c0.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/1/r1_c1.mapml
+++ b/test/e2e/data/tiles/wgs84/1/r1_c1.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/1/r1_c2.mapml
+++ b/test/e2e/data/tiles/wgs84/1/r1_c2.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/1/r1_c3.mapml
+++ b/test/e2e/data/tiles/wgs84/1/r1_c3.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 
@@ -564,7 +564,7 @@
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">New C.</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">NC</td></tr>
                   <tr><th scope="row">formal_en</th><td itemprop="formal_en">New Caledonia</td></tr>
-                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Nouvelle-Calédonie</td></tr>
+                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Nouvelle-Calï¿½donie</td></tr>
                   <tr><th scope="row">note_adm0</th><td itemprop="note_adm0">Fr.</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">New Caledonia</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">7</td></tr>

--- a/test/e2e/data/tiles/wgs84/2/r0_c0.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r0_c0.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r0_c1.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r0_c1.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r0_c2.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r0_c2.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 
@@ -556,7 +556,7 @@
                   <tr><th scope="row">brk_name</th><td itemprop="brk_name">Faeroe Islands</td></tr>
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Faeroe Is.</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">FO</td></tr>
-                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Føroyar Is. (Faeroe Is.)</td></tr>
+                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Fï¿½royar Is. (Faeroe Is.)</td></tr>
                   <tr><th scope="row">note_adm0</th><td itemprop="note_adm0">Den.</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Faeroe Islands</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">4</td></tr>

--- a/test/e2e/data/tiles/wgs84/2/r0_c3.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r0_c3.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 
@@ -556,7 +556,7 @@
                   <tr><th scope="row">brk_name</th><td itemprop="brk_name">Faeroe Islands</td></tr>
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Faeroe Is.</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">FO</td></tr>
-                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Føroyar Is. (Faeroe Is.)</td></tr>
+                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Fï¿½royar Is. (Faeroe Is.)</td></tr>
                   <tr><th scope="row">note_adm0</th><td itemprop="note_adm0">Den.</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Faeroe Islands</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">4</td></tr>

--- a/test/e2e/data/tiles/wgs84/2/r0_c4.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r0_c4.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 
@@ -681,7 +681,7 @@
                   <tr><th scope="row">brk_name</th><td itemprop="brk_name">Aland</td></tr>
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Aland</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">AI</td></tr>
-                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Åland Islands</td></tr>
+                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">ï¿½land Islands</td></tr>
                   <tr><th scope="row">note_adm0</th><td itemprop="note_adm0">Fin.</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Aland</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">4</td></tr>

--- a/test/e2e/data/tiles/wgs84/2/r0_c5.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r0_c5.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 
@@ -681,7 +681,7 @@
                   <tr><th scope="row">brk_name</th><td itemprop="brk_name">Aland</td></tr>
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Aland</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">AI</td></tr>
-                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Åland Islands</td></tr>
+                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">ï¿½land Islands</td></tr>
                   <tr><th scope="row">note_adm0</th><td itemprop="note_adm0">Fin.</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Aland</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">4</td></tr>

--- a/test/e2e/data/tiles/wgs84/2/r0_c6.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r0_c6.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r0_c7.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r0_c7.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r1_c0.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r1_c0.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r1_c1.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r1_c1.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r1_c2.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r1_c2.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 
@@ -1223,24 +1223,24 @@
                   <tr><th scope="row">adm0_dif</th><td itemprop="adm0_dif">1</td></tr>
                   <tr><th scope="row">level</th><td itemprop="level">2</td></tr>
                   <tr><th scope="row">type</th><td itemprop="type">Country</td></tr>
-                  <tr><th scope="row">admin</th><td itemprop="admin">Curaçao</td></tr>
+                  <tr><th scope="row">admin</th><td itemprop="admin">Curaï¿½ao</td></tr>
                   <tr><th scope="row">adm0_a3</th><td itemprop="adm0_a3">CUW</td></tr>
                   <tr><th scope="row">geou_dif</th><td itemprop="geou_dif">0</td></tr>
-                  <tr><th scope="row">geounit</th><td itemprop="geounit">Curaçao</td></tr>
+                  <tr><th scope="row">geounit</th><td itemprop="geounit">Curaï¿½ao</td></tr>
                   <tr><th scope="row">gu_a3</th><td itemprop="gu_a3">CUW</td></tr>
                   <tr><th scope="row">su_dif</th><td itemprop="su_dif">0</td></tr>
-                  <tr><th scope="row">subunit</th><td itemprop="subunit">Curaçao</td></tr>
+                  <tr><th scope="row">subunit</th><td itemprop="subunit">Curaï¿½ao</td></tr>
                   <tr><th scope="row">su_a3</th><td itemprop="su_a3">CUW</td></tr>
                   <tr><th scope="row">brk_diff</th><td itemprop="brk_diff">0</td></tr>
-                  <tr><th scope="row">name</th><td itemprop="name">Curaçao</td></tr>
-                  <tr><th scope="row">name_long</th><td itemprop="name_long">Curaçao</td></tr>
+                  <tr><th scope="row">name</th><td itemprop="name">Curaï¿½ao</td></tr>
+                  <tr><th scope="row">name_long</th><td itemprop="name_long">Curaï¿½ao</td></tr>
                   <tr><th scope="row">brk_a3</th><td itemprop="brk_a3">CUW</td></tr>
-                  <tr><th scope="row">brk_name</th><td itemprop="brk_name">Curaçao</td></tr>
+                  <tr><th scope="row">brk_name</th><td itemprop="brk_name">Curaï¿½ao</td></tr>
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Cur.</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">CW</td></tr>
-                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Curaçao</td></tr>
+                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Curaï¿½ao</td></tr>
                   <tr><th scope="row">note_adm0</th><td itemprop="note_adm0">Neth.</td></tr>
-                  <tr><th scope="row">name_sort</th><td itemprop="name_sort">Curaçao</td></tr>
+                  <tr><th scope="row">name_sort</th><td itemprop="name_sort">Curaï¿½ao</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">4</td></tr>
                   <tr><th scope="row">mapcolor8</th><td itemprop="mapcolor8">2</td></tr>
                   <tr><th scope="row">mapcolor9</th><td itemprop="mapcolor9">2</td></tr>
@@ -2282,7 +2282,7 @@
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Ven.</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">VE</td></tr>
                   <tr><th scope="row">formal_en</th><td itemprop="formal_en">Bolivarian Republic of Venezuela</td></tr>
-                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">República Bolivariana de Venezuela</td></tr>
+                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Repï¿½blica Bolivariana de Venezuela</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Venezuela, RB</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">1</td></tr>
                   <tr><th scope="row">mapcolor8</th><td itemprop="mapcolor8">3</td></tr>

--- a/test/e2e/data/tiles/wgs84/2/r1_c3.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r1_c3.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 
@@ -192,15 +192,15 @@
                   <tr><th scope="row">subunit</th><td itemprop="subunit">Ivory Coast</td></tr>
                   <tr><th scope="row">su_a3</th><td itemprop="su_a3">CIV</td></tr>
                   <tr><th scope="row">brk_diff</th><td itemprop="brk_diff">0</td></tr>
-                  <tr><th scope="row">name</th><td itemprop="name">Côte d'Ivoire</td></tr>
-                  <tr><th scope="row">name_long</th><td itemprop="name_long">Côte d'Ivoire</td></tr>
+                  <tr><th scope="row">name</th><td itemprop="name">Cï¿½te d'Ivoire</td></tr>
+                  <tr><th scope="row">name_long</th><td itemprop="name_long">Cï¿½te d'Ivoire</td></tr>
                   <tr><th scope="row">brk_a3</th><td itemprop="brk_a3">CIV</td></tr>
-                  <tr><th scope="row">brk_name</th><td itemprop="brk_name">Côte d'Ivoire</td></tr>
+                  <tr><th scope="row">brk_name</th><td itemprop="brk_name">Cï¿½te d'Ivoire</td></tr>
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">I.C.</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">CI</td></tr>
                   <tr><th scope="row">formal_en</th><td itemprop="formal_en">Republic of Ivory Coast</td></tr>
                   <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Republic of Cote D'Ivoire</td></tr>
-                  <tr><th scope="row">name_sort</th><td itemprop="name_sort">Côte d'Ivoire</td></tr>
+                  <tr><th scope="row">name_sort</th><td itemprop="name_sort">Cï¿½te d'Ivoire</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">4</td></tr>
                   <tr><th scope="row">mapcolor8</th><td itemprop="mapcolor8">6</td></tr>
                   <tr><th scope="row">mapcolor9</th><td itemprop="mapcolor9">3</td></tr>
@@ -1443,7 +1443,7 @@
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Togo</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">TG</td></tr>
                   <tr><th scope="row">formal_en</th><td itemprop="formal_en">Togolese Republic</td></tr>
-                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">République Togolaise</td></tr>
+                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Rï¿½publique Togolaise</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Togo</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">3</td></tr>
                   <tr><th scope="row">mapcolor8</th><td itemprop="mapcolor8">1</td></tr>

--- a/test/e2e/data/tiles/wgs84/2/r1_c4.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r1_c4.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 
@@ -1106,7 +1106,7 @@
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">Togo</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">TG</td></tr>
                   <tr><th scope="row">formal_en</th><td itemprop="formal_en">Togolese Republic</td></tr>
-                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">République Togolaise</td></tr>
+                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Rï¿½publique Togolaise</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">Togo</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">3</td></tr>
                   <tr><th scope="row">mapcolor8</th><td itemprop="mapcolor8">1</td></tr>
@@ -4267,14 +4267,14 @@
                   <tr><th scope="row">subunit</th><td itemprop="subunit">Sao Tome and Principe</td></tr>
                   <tr><th scope="row">su_a3</th><td itemprop="su_a3">STP</td></tr>
                   <tr><th scope="row">brk_diff</th><td itemprop="brk_diff">0</td></tr>
-                  <tr><th scope="row">name</th><td itemprop="name">São Tomé and Principe</td></tr>
-                  <tr><th scope="row">name_long</th><td itemprop="name_long">São Tomé and Principe</td></tr>
+                  <tr><th scope="row">name</th><td itemprop="name">Sï¿½o Tomï¿½ and Principe</td></tr>
+                  <tr><th scope="row">name_long</th><td itemprop="name_long">Sï¿½o Tomï¿½ and Principe</td></tr>
                   <tr><th scope="row">brk_a3</th><td itemprop="brk_a3">STP</td></tr>
                   <tr><th scope="row">brk_name</th><td itemprop="brk_name">Sao Tome and Principe</td></tr>
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">S.T.P.</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">ST</td></tr>
-                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Democratic Republic of São Tomé and Principe</td></tr>
-                  <tr><th scope="row">name_sort</th><td itemprop="name_sort">São Tomé and Principe</td></tr>
+                  <tr><th scope="row">formal_en</th><td itemprop="formal_en">Democratic Republic of Sï¿½o Tomï¿½ and Principe</td></tr>
+                  <tr><th scope="row">name_sort</th><td itemprop="name_sort">Sï¿½o Tomï¿½ and Principe</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">1</td></tr>
                   <tr><th scope="row">mapcolor8</th><td itemprop="mapcolor8">6</td></tr>
                   <tr><th scope="row">mapcolor9</th><td itemprop="mapcolor9">1</td></tr>

--- a/test/e2e/data/tiles/wgs84/2/r1_c5.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r1_c5.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r1_c6.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r1_c6.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r1_c7.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r1_c7.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r2_c0.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r2_c0.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r2_c1.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r2_c1.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r2_c2.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r2_c2.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r2_c3.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r2_c3.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r2_c4.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r2_c4.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r2_c5.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r2_c5.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r2_c6.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r2_c6.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r2_c7.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r2_c7.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 
@@ -411,7 +411,7 @@
                   <tr><th scope="row">abbrev</th><td itemprop="abbrev">New C.</td></tr>
                   <tr><th scope="row">postal</th><td itemprop="postal">NC</td></tr>
                   <tr><th scope="row">formal_en</th><td itemprop="formal_en">New Caledonia</td></tr>
-                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Nouvelle-Calédonie</td></tr>
+                  <tr><th scope="row">formal_fr</th><td itemprop="formal_fr">Nouvelle-Calï¿½donie</td></tr>
                   <tr><th scope="row">note_adm0</th><td itemprop="note_adm0">Fr.</td></tr>
                   <tr><th scope="row">name_sort</th><td itemprop="name_sort">New Caledonia</td></tr>
                   <tr><th scope="row">mapcolor7</th><td itemprop="mapcolor7">7</td></tr>

--- a/test/e2e/data/tiles/wgs84/2/r3_c0.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r3_c0.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r3_c1.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r3_c1.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r3_c2.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r3_c2.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r3_c3.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r3_c3.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r3_c4.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r3_c4.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r3_c5.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r3_c5.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r3_c6.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r3_c6.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/2/r3_c7.mapml
+++ b/test/e2e/data/tiles/wgs84/2/r3_c7.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>ne_10m_admin_0_countries</title>
 

--- a/test/e2e/data/tiles/wgs84/vector-tile-test.mapml
+++ b/test/e2e/data/tiles/wgs84/vector-tile-test.mapml
@@ -1,4 +1,4 @@
-<mapml xmlns="https://www.w3.org/1999/xhtml/">
+<mapml xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>World Countries - WGS84</title>
         <meta charset="utf-8" />


### PR DESCRIPTION
(See https://github.com/Maps4HTML/MapML/pull/198)

@prushforth This PR only corrects current namespace declarations, but there are quite a few .mapml files that have `<mapml>` elements without a namespace declaration. Should I fix that before we proceed to merge this PR?