### PR TITLE
Enable `outline`s for features on `:focus-visible` (keyboard only)

### DIFF
--- a/src/mapml/features/featureRenderer.js
+++ b/src/mapml/features/featureRenderer.js
@@ -43,7 +43,7 @@ export var FeatureRenderer = L.SVG.extend({
     for (let p of layer._parts) {
       if (p.rings){
         this._createPath(p, layer.options.className, layer.featureAttributes['aria-label'], layer.options.interactive, layer.featureAttributes);
-        if(layer.outlinePath) p.path.style.stroke = "none";
+        //if(layer.outlinePath) p.path.style.stroke = "none";
       }
       if (p.subrings) {
         for (let r of p.subrings) {

--- a/src/mapml/layers/FeatureLayer.js
+++ b/src/mapml/layers/FeatureLayer.js
@@ -17,19 +17,28 @@ export var MapMLFeatures = L.FeatureGroup.extend({
         style.innerHTML = `
         g[role="link"]:focus,
         g[role="link"]:hover,
-        g[role="button"]:focus,
-        g[role="button"]:hover,
-        g[role="link"] path:focus,
-        g[role="link"] path:hover,
-        g[role="button"] path:focus,
-        g[role="button"] path:hover,
         g[role="link"]:focus path,
         g[role="link"]:hover path,
+        g[role="link"] path:focus,
+        g[role="link"] path:hover,
+        g[role="button"]:focus,
+        g[role="button"]:hover,
         g[role="button"]:focus path,
-        g[role="button"]:hover path {
-          outline: 0!important;
+        g[role="button"]:hover path,
+        g[role="button"] path:focus,
+        g[role="button"] path:hover,
+        path[tabindex="0"]:focus {
           stroke: #0000EE;
           stroke: LinkText;
+        }
+        g[role="link"]:focus:not(:focus-visible),
+        g[role="link"]:focus:not(:focus-visible) path,
+        g[role="link"] path:focus:not(:focus-visible),
+        g[role="button"]:focus:not(:focus-visible),
+        g[role="button"]:focus:not(:focus-visible) path,
+        g[role="button"] path:focus:not(:focus-visible),
+        path[tabindex="0"]:focus:not(:focus-visible) {
+          outline: 0!important;
         }`;
       }
 


### PR DESCRIPTION
In https://github.com/Maps4HTML/Web-Map-Custom-Element/pull/478 outlines were removed for _both_ pointing device- and keyboard users because we introduced link-like styles for features (using `stroke`). However, because we can't (at least don't, atm) ensure sufficient contrast of strokes I think we should add back (or really _not remove_) outlines for keyboard users (using `focus:not(:focus-visible)`), because currently it can be really hard to track what is being focused. @prushforth had some concerns around this in https://github.com/Maps4HTML/Web-Map-Custom-Element/pull/478#issuecomment-883604702.

These changes makes it easier for keyboard users to identify what they've focused, even if that means setting both `stroke` and `outline` on `:focus-visible` (which wouldn't be desirable in a native implementation - only outline would be visible/change on focus in a standardized map viewer, so unless there's a way to "wrap" outlines to SVG shapes I think we have to go with this for now).

Current styles on master branch:

<table><tr><td width="400"><video src="https://user-images.githubusercontent.com/26493779/127214968-326e01a0-5078-4722-b407-adbb1ba4b90f.mp4"></video></td></tr></table>

With these changes we're now showing outlines on keyboard focus:

<table><tr><td width="400"><video src="https://user-images.githubusercontent.com/26493779/127213916-13cb9729-465a-4aa9-b823-edc62d21cf0c.mp4"></video></td></tr></table>

Although not all focusable paths show an outline, had to remove `if(layer.outlinePath) p.path.style.stroke = "none"`, and add a very generic `path[tabindex="0"]:focus` selector to the feature focus styles.

Final result:

<table><tr><td width="400"><video src="https://user-images.githubusercontent.com/26493779/127213897-90b3c278-3dd9-4ed2-970a-bb3718a9897a.mp4"></video></td></tr></table>




