### PR TITLE
Inherit `box-sizing` into `<map>`

### DIFF
--- a/src/web-map.js
+++ b/src/web-map.js
@@ -130,6 +130,7 @@ export class WebMap extends HTMLMapElement {
     `width: 300px;` +
     `border-width: 2px;` +
     `border-style: inset;` +
+    `box-sizing: inherit;` + // https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/350#issuecomment-888361985
     `}` +
     `[is="web-map"][frameborder="0"] {` +
   	`border-width: 0;` +


### PR DESCRIPTION
Per https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/350#issuecomment-888361985. Close #350.