### PR TITLE
Inherit `text-align` in `.mapml-button`

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -57,8 +57,7 @@
   margin: 0;
   padding: 0;
   overflow: hidden;
-  text-align: left;
-  text-align: inline-start;
+  text-align: inherit;
   text-transform: none;
   -webkit-appearance: none;
      -moz-appearance: none;


### PR DESCRIPTION
Fix RTL issue: "menu items not aligned right-to-left" in #505.