### PR TITLE
Allow context menu to overflow the map container

### DIFF
--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -116,12 +116,11 @@ export class MapViewer extends HTMLElement {
     mapDefaultCSS.innerHTML =
     `:host {` +
     `all: initial;` + // Reset properties inheritable from html/body, as some inherited styles may cause unexpected issues with the map element's components (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/140).
-    `contain: size;` + // Contain size calculations within the map element.
+    `contain: layout size;` + // Contain layout and size calculations within the map element.
     `display: inline-block;` + // This together with dimension properties is required so that Leaflet isn't working with a height=0 box by default.
-    `overflow: hidden;` + // Make the map element behave and look more like a native element.
     `height: 150px;` + // Provide a "default object size" (https://github.com/Maps4HTML/HTML-Map-Element/issues/31).
     `width: 300px;` +
-    `border-width: 2px;` +
+    `border-width: 2px;` + // Set a default border for contrast, similar to UA default for iframes.
     `border-style: inset;` +
     `}` +
     `:host([frameborder="0"]) {` +
@@ -130,9 +129,6 @@ export class MapViewer extends HTMLElement {
     `:host .mapml-contextmenu,` +
     `:host .leaflet-control-container {` +
     `visibility: hidden!important;` + // Visibility hack to improve percieved performance (mitigate FOUC) – visibility is unset in mapml.css! (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/154).
-    `}` +
-    `:host .leaflet-container {` +
-    `contain: strict;` + // Contain size, layout and paint calculations within the leaflet container element.
     `}`;
     
     // Hide all (light DOM) children of the map element.

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -251,12 +251,13 @@
 
 .mapml-contextmenu {
   display: none;
-  max-width: 100%;
-  -webkit-border-radius: 4px;
-          border-radius: 4px;
+  border-radius: 4px;
   padding: 4px 0;
   background-color: #fff;
   cursor: default;
+  position: absolute;
+  width: 150px;
+  z-index: 10001;
 }
 
 .mapml-contextmenu button.mapml-contextmenu-item {
@@ -281,6 +282,20 @@
 .mapml-contextmenu-separator {
   border-bottom: 1px solid #e3e3e3;
   margin: 5px 0;
+}
+
+.mapml-contextmenu.mapml-submenu {
+  width: 80px;
+  margin-bottom: -2rem;
+}
+
+@supports (contain: layout) {
+  .mapml-contextmenu {
+    position: fixed;
+  }
+  .mapml-contextmenu.mapml-submenu {
+    position: absolute;
+  }
 }
 
 /*

--- a/src/mapml/handlers/ContextMenu.js
+++ b/src/mapml/handlers/ContextMenu.js
@@ -106,20 +106,12 @@ export var ContextMenu = L.Handler.extend({
     this._keyboardEvent = false;
 
     this._container = L.DomUtil.create("div", "mapml-contextmenu", map._container);
-    this._container.style.zIndex = 10001;
-    this._container.style.position = "absolute";
-
-    this._container.style.width = "150px";
     
     for (let i = 0; i < 6; i++) {
       this._items[i].el = this._createItem(this._container, this._items[i]);
     }
 
     this._coordMenu = L.DomUtil.create("div", "mapml-contextmenu mapml-submenu", this._container);
-    this._coordMenu.style.zIndex = 10001;
-    this._coordMenu.style.position = "absolute";
-
-    this._coordMenu.style.width = "80px";
     this._coordMenu.id = "mapml-copy-submenu";
 
     this._clickEvent = null;
@@ -133,9 +125,6 @@ export var ContextMenu = L.Handler.extend({
     this._items[8].el = this._createItem(this._container, this._items[8]);
 
     this._layerMenu = L.DomUtil.create("div", "mapml-contextmenu mapml-layer-menu", map._container);
-    this._layerMenu.style.zIndex = 10001;
-    this._layerMenu.style.position = "absolute";
-    this._layerMenu.style.width = "150px";
     for (let i = 0; i < this._layerItems.length; i++) {
       this._createItem(this._layerMenu, this._layerItems[i]);
     }

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -123,12 +123,11 @@ export class WebMap extends HTMLMapElement {
     mapDefaultCSS.innerHTML =
     `[is="web-map"] {` +
     `all: initial;` + // Reset properties inheritable from html/body, as some inherited styles may cause unexpected issues with the map element's components (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/140).
-    `contain: size;` + // Contain size calculations within the map element.
+    `contain: layout size;` + // Contain layout and size calculations within the map element.
     `display: inline-block;` + // This together with dimension properties is required so that Leaflet isn't working with a height=0 box by default.
-    `overflow: hidden;` + // Make the map element behave and look more like a native element.
     `height: 150px;` + // Provide a "default object size" (https://github.com/Maps4HTML/HTML-Map-Element/issues/31).
     `width: 300px;` +
-    `border-width: 2px;` +
+    `border-width: 2px;` + // Set a default border for contrast, similar to UA default for iframes.
     `border-style: inset;` +
     `}` +
     `[is="web-map"][frameborder="0"] {` +
@@ -143,9 +142,6 @@ export class WebMap extends HTMLMapElement {
     `:host .mapml-contextmenu,` +
     `:host .leaflet-control-container {` +
     `visibility: hidden!important;` + // Visibility hack to improve percieved performance (mitigate FOUC) – visibility is unset in mapml.css! (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/154).
-    `}` +
-    `:host .leaflet-container {` +
-    `contain: strict;` + // Contain size, layout and paint calculations within the leaflet container element.
     `}`;
     
     // Hide all (light DOM) children of the map element except for the


### PR DESCRIPTION
Fixes #509.

Caveats:
1. Removes `overflow: hidden` on the map element. This shouldn't be a problem in terms of elements overflowing the map element because it's not really in use: all light DOM children of the map element except for the shadow host are set to `display: none` anyways, and the leaflet-container - which holds the content of the map - is itself set to `overflow: hidden`.
2. Not possible to use CSS `resize` on the map element as it requires `overflow: hidden` (though `resize` is already problematic https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/262). However I suspect the use of CSS resize on maps in general is very low.
3. Lose performance benefits of [`strict`](https://www.w3.org/TR/css-contain/#valdef-contain-strict) containment on the leaflet-container.

## Preview

![contextmenu-overflowing](https://user-images.githubusercontent.com/26493779/132603217-8f5402cf-db0b-4721-8c18-63a1ec0576c9.png)
