### PR TITLE
Add TAG best practices checklists

### DIFF
--- a/w3c-tag-advice-for-polyfill-authors.md
+++ b/w3c-tag-advice-for-polyfill-authors.md
@@ -1,0 +1,94 @@
+# TAG Advice for polyfill authors
+
+The table below is to document the extent of which the MapML polyfill
+conforms to the W3C <abbr title="Technical Architecture Group">TAG</abbr>'s
+[Advice for polyfill authors](https://www.w3.org/2001/tag/doc/polyfills/#advice-for-polyfill-authors).
+
+<table>
+  <tr>
+    <th scope="col">TAG Advice</th>
+    <th scope="col">Conforms</th>
+    <th scope="col">Note</th>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+      <a href="https://www.w3.org/2001/tag/doc/polyfills/#encapsulate-as-a-module-or-umd">
+      3.1 Encapsulate as a module or UMD
+      </a>
+    </th>
+    <td align="center">
+      <ul><li>- [x] </li></ul>
+    </td>
+    <td>
+      ES Module
+    </td>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+      <a href="https://www.w3.org/2001/tag/doc/polyfills/#use-smart-distribution">
+      3.2 Use smart distribution
+      </a>
+    </th>
+    <td align="center">
+      <ul><li>- [x] </li></ul>
+    </td>
+    <td>
+      <a href="https://www.npmjs.com/package/@maps4html/web-map-custom-element">Published to npm</a>
+      and
+      <a href="https://unpkg.com/@maps4html/web-map-custom-element@latest/dist/mapml-viewer.js">hosted on the UNPKG CDN</a>
+    </td>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+      <a href="https://www.w3.org/2001/tag/doc/polyfills/#don-t-squat-on-proposed-names-in-speculative-polyfills">
+      3.3 Don't squat on proposed names in speculative polyfills
+      </a>
+    </th>
+    <td align="center">
+      <ul><li>- [ ] </li></ul>
+    </td>
+    <td>
+      TBD
+    </td>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+      <a href="https://www.w3.org/2001/tag/doc/polyfills/#pass-web-platform-tests-if-they-exist">
+      3.4 Pass web platform tests, if they exist
+      </a>
+    </th>
+    <td align="center">
+      <ul><li>- [ ] </li></ul>
+    </td>
+    <td>
+      On the backlog of the
+      <a href="https://github.com/Maps4HTML/Web-Map-Custom-Element/projects/2#card-43799737">Road Map</a> project
+    </td>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+      <a href="https://www.w3.org/2001/tag/doc/polyfills/#detect-and-defer-to-native-implementations">
+      3.5 Detect and defer to native implementations
+      </a>
+    </th>
+    <td align="center">
+      <ul><li>- [ ] </li></ul>
+    </td>
+    <td>
+      TBD
+    </td>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+      <a href="https://www.w3.org/2001/tag/doc/polyfills/#work-with-spec-editors">
+      3.6 Work with spec editors
+      </a>
+    </th>
+    <td align="center">
+      <ul><li>- [ ] </li></ul>
+    </td>
+    <td>
+      TBD
+    </td>
+  </tr>
+</table>

--- a/w3c-tag-guidelines-web-compatible-components.md
+++ b/w3c-tag-guidelines-web-compatible-components.md
@@ -1,0 +1,153 @@
+# TAG Guidelines for creating web platform compatible components
+
+The table below is to document the extent of which the MapML polyfill
+conforms to the W3C <abbr title="Technical Architecture Group">TAG</abbr>'s
+[Guidelines for creating web platform compatible components](https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/).
+
+<table>
+  <tr>
+    <th scope="col">TAG Guideline</th>
+    <th scope="col">Conforms</th>
+    <th scope="col">Note</th>
+  </tr>
+  <tr>
+    <th colspan="3" align="left">
+      1.1 Native HTML elements
+    </th>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+      <a href="https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/#:~:text=Elements%20don%E2%80%99t%20throw%20errors%20when%20used%20declaratively">
+      1. Elements don’t throw errors when used declaratively
+      </a>
+    </th>
+    <td align="center">
+      <ul><li>- [ ] </li></ul>
+    </td>
+    <td>
+      TBD
+    </td>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+    <a href="https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/#:~:text=Elements%20are%20self-contained">
+    2. Elements are self-contained
+    </a>
+    </th>
+    <td align="center">
+      <ul><li>- [ ] </li></ul>
+    </td>
+    <td>
+      TBD
+    </td>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+      <a href="https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/#:~:text=Use%20events%20to%20pass%20data%20to%20the%20outside%20world">
+      3. Use events to pass data to the outside world
+      </a>
+    </th>
+    <td align="center">
+      <ul><li>- [ ] </li></ul>
+    </td>
+    <td>
+      TBD
+    </td>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+      <a href="https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/#:~:text=Use%20attributes%20to%20receive%20non-complex%20data">
+      4. Use attributes to receive non-complex data
+      </a>
+    </th>
+    <td align="center">
+      <ul><li>- [ ] </li></ul>
+    </td>
+    <td>
+      TBD
+    </td>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+      <a href="https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/#:~:text=Interactive%20elements%20are%20focusable">
+      5. Interactive elements are focusable
+      </a>
+    </th>
+    <td align="center">
+      <ul><li>- [ ] </li></ul>
+    </td>
+    <td>
+      TBD
+    </td>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+      <a href="https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/#:~:text=Elements%20can%20be%20instantiated%20without%20being%20part%20of%20the%20document">
+      6. Elements can be instantiated without being part of the document
+      </a>
+    </th>
+    <td align="center">
+      <ul><li>- [ ] </li></ul>
+    </td>
+    <td>
+      TBD
+    </td>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+      <a href="https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/#:~:text=Elements%20should%20only%20have%20basic%20styling">
+      7. Elements should only have basic styling
+      </a>
+    </th>
+    <td align="center">
+      <ul><li>- [ ] </li></ul>
+    </td>
+    <td>
+      TBD
+    </td>
+  </tr>
+  <tr>
+    <th colspan="3" align="left">
+      1.2 Other considerations
+    </th>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+      <a href="https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/#:~:text=Don%E2%80%99t%20enforce%20unnecessary%20child/parent%20relationships">
+      1. Don’t enforce unnecessary child/parent relationships
+      </a>
+    </th>
+    <td align="center">
+      <ul><li>- [ ] </li></ul>
+    </td>
+    <td>
+      TBD
+    </td>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+      <a href="https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/#:~:text=Avoid%20using%20callbacks">
+      2. Avoid using callbacks
+      </a>
+    </th>
+    <td align="center">
+      <ul><li>- [ ] </li></ul>
+    </td>
+    <td>
+      TBD
+    </td>
+  </tr>
+  <tr>
+    <th scope="row" align="left">
+      <a href="https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/#:~:text=Harmonize%20declarative%20(HTML)%20and%20imperative%20(JavaScript)%20APIs">
+      3. Harmonize declarative (HTML) and imperative (JavaScript) APIs
+      </a>
+    </th>
+    <td align="center">
+      <ul><li>- [ ] </li></ul>
+    </td>
+    <td>
+      TBD
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
Close #176.

I've converted TAGs [Advice for polyfill authors](https://www.w3.org/2001/tag/doc/polyfills/#advice-for-polyfill-authors) and [Guidelines for creating web platform compatible components](https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/) into markdown checklists so that we can track progress/conformance.

I've only started to fill in things in the 'Advice for polyfill authors' document, so there are still things to do, but they serve as reminders for us to adhere to best practices as well as show reviewers that we take this polyfill seriously. I considered adding these to the MapML-Proposal repo but I think this is a better place, at least for now.

(If this is merged I'll add a note in https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/177 that these checklists will need a final review for the [v1.0.0 milestone](https://github.com/Maps4HTML/Web-Map-Custom-Element/milestone/3), so that we have references to these documents.)