### PR TITLE
TAG guidelines doc: Add issue tracking link for Basic Styling

### DIFF
--- a/w3c-tag-guidelines-web-compatible-components.md
+++ b/w3c-tag-guidelines-web-compatible-components.md
@@ -104,7 +104,7 @@ conforms to the W3C <abbr title="Technical Architecture Group">TAG</abbr>'s
     </td>
     <td>
       See the
-      <a href="https://github.com/Maps4HTML/Web-Map-Custom-Element/labels/basic%20styling">basic styling</a>
+      <a href="https://github.com/Maps4HTML/Web-Map-Custom-Element/issues?q=label%3A%22basic+styling%22">basic styling</a>
       label for relevant issues/PRs
     </td>
   </tr>


### PR DESCRIPTION
I've added a new label [basic styling](https://github.com/Maps4HTML/Web-Map-Custom-Element/labels/basic%20styling) (maybe "basic/native styling" is a better name for the label?) to track issues/PRs relevant to this doc as the guidelines recommend only basic styling by default.

Opinionated styles such as large border-radiuses, specific fonts and font-sizes, arbitrary colors, etc. should ideally be left to custom styling.



