### PR TITLE
Keep track of map history in terms of pixels rather than latitude, longitude

### DIFF
--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -513,7 +513,10 @@ export class MapViewer extends HTMLElement {
   }
 
   _addToHistory(){
-    if(this._traversalCall) return;
+    if(this._traversalCall > 0) {
+      this._traversalCall--;
+      return;
+    }
 
     let mapLocation = this._map.getPixelBounds().getCenter();
     let location = {
@@ -533,9 +536,9 @@ export class MapViewer extends HTMLElement {
       this._historyIndex--;
       let prev = history[this._historyIndex];
 
-      this._traversalCall = true;
-
       if(prev.zoom !== curr.zoom){
+        this._traversalCall = 2;
+
         let currScale = this._map.options.crs.scale(curr.zoom);
         let prevScale = this._map.options.crs.scale(prev.zoom);
 
@@ -544,9 +547,9 @@ export class MapViewer extends HTMLElement {
         this._map.panBy([((prev.x * scale) - curr.x), ((prev.y * scale) - curr.y)], {animate: false});
         this._map.setZoom(prev.zoom);
       } else {
+        this._traversalCall = 1;
         this._map.panBy([(prev.x - curr.x), (prev.y - curr.y)]);
       }
-      this._map.once("moveend", () => {this._traversalCall = false})
     }
   }
 
@@ -557,9 +560,9 @@ export class MapViewer extends HTMLElement {
       this._historyIndex++;
       let next = history[this._historyIndex];
 
-      this._traversalCall = true;
-
       if(next.zoom !== curr.zoom){
+        this._traversalCall = 2;
+
         let currScale = this._map.options.crs.scale(curr.zoom);
         let nextScale = this._map.options.crs.scale(next.zoom);
 
@@ -568,10 +571,9 @@ export class MapViewer extends HTMLElement {
         this._map.panBy([((next.x * scale) - curr.x), ((next.y * scale) - curr.y)], {animate: false});
         this._map.setZoom(next.zoom);
       } else {
+        this._traversalCall = 1;
         this._map.panBy([(next.x - curr.x), (next.y - curr.y)]);
       }
-
-      this._map.once("moveend", () => {this._traversalCall = false})
     }
   }
 
@@ -587,17 +589,20 @@ export class MapViewer extends HTMLElement {
     this._history = [initialLocation];
     this._historyIndex = 0;
 
-    this._traversalCall = true;
+    if(initialLocation.zoom !== curr.zoom) {
+      this._traversalCall = 2;
 
-    let currScale = this._map.options.crs.scale(curr.zoom);
-    let initScale = this._map.options.crs.scale(initialLocation.zoom);
+      let currScale = this._map.options.crs.scale(curr.zoom);
+      let initScale = this._map.options.crs.scale(initialLocation.zoom);
 
-    let scale = currScale / initScale;
+      let scale = currScale / initScale;
 
-    this._map.panBy([((initialLocation.x * scale) - curr.x), ((initialLocation.y * scale) - curr.y)], {animate: false});
-    this._map.setZoom(initialLocation.zoom);
-
-    this._map.once("moveend", () => {this._traversalCall = false})
+      this._map.panBy([((initialLocation.x * scale) - curr.x), ((initialLocation.y * scale) - curr.y)], {animate: false});
+      this._map.setZoom(initialLocation.zoom);
+    } else {
+      this._traversalCall = 1;
+      this._map.panBy([(initialLocation.x- curr.x), (initialLocation.y - curr.y)]);
+    }
   }
 
   viewSource(){

--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -512,9 +512,13 @@ export class MapViewer extends HTMLElement {
     this.zoom = this._map.getZoom();
   }
 
+  /**
+   * Adds to the maps history on moveends
+   * @private
+   */
   _addToHistory(){
-    if(this._traversalCall > 0) {
-      this._traversalCall--;
+    if(this._traversalCall > 0) { // this._traversalCall tracks how many consecutive moveends to ignore from history
+      this._traversalCall--;      // this is useful for ignoring moveends corresponding to back, forward and reload
       return;
     }
 
@@ -528,6 +532,9 @@ export class MapViewer extends HTMLElement {
     this._history.splice(this._historyIndex, 0, location);
   }
 
+  /**
+   * Allow user to move back in history
+   */
   back(){
     let history = this._history;
     let curr = history[this._historyIndex];
@@ -537,12 +544,12 @@ export class MapViewer extends HTMLElement {
       let prev = history[this._historyIndex];
 
       if(prev.zoom !== curr.zoom){
-        this._traversalCall = 2;
+        this._traversalCall = 2;  // allows the next 2 moveends to be ignored from history
 
-        let currScale = this._map.options.crs.scale(curr.zoom);
-        let prevScale = this._map.options.crs.scale(prev.zoom);
+        let currScale = this._map.options.crs.scale(curr.zoom); // gets the scale of the current zoom level
+        let prevScale = this._map.options.crs.scale(prev.zoom); // gets the scale of the previous zoom level
 
-        let scale = currScale / prevScale;
+        let scale = currScale / prevScale; // used to convert the previous pixel location to be in terms of the current zoom level
 
         this._map.panBy([((prev.x * scale) - curr.x), ((prev.y * scale) - curr.y)], {animate: false});
         this._map.setZoom(prev.zoom);
@@ -553,6 +560,9 @@ export class MapViewer extends HTMLElement {
     }
   }
 
+  /**
+   * Allows user to move forward in history
+   */
   forward(){
     let history = this._history;
     let curr = history[this._historyIndex];
@@ -561,12 +571,12 @@ export class MapViewer extends HTMLElement {
       let next = history[this._historyIndex];
 
       if(next.zoom !== curr.zoom){
-        this._traversalCall = 2;
+        this._traversalCall = 2; // allows the next 2 moveends to be ignored from history
 
-        let currScale = this._map.options.crs.scale(curr.zoom);
-        let nextScale = this._map.options.crs.scale(next.zoom);
+        let currScale = this._map.options.crs.scale(curr.zoom); // gets the scale of the current zoom level
+        let nextScale = this._map.options.crs.scale(next.zoom); // gets the scale of the next zoom level
 
-        let scale = currScale / nextScale;
+        let scale = currScale / nextScale; // used to convert the next pixel location to be in terms of the current zoom level
 
         this._map.panBy([((next.x * scale) - curr.x), ((next.y * scale) - curr.y)], {animate: false});
         this._map.setZoom(next.zoom);
@@ -577,6 +587,9 @@ export class MapViewer extends HTMLElement {
     }
   }
 
+  /**
+   * Allows the user to reload/reset the map's location to it's initial location
+   */
   reload(){
     let initialLocation = this._history.shift();
     let mapLocation = this._map.getPixelBounds().getCenter();
@@ -590,16 +603,16 @@ export class MapViewer extends HTMLElement {
     this._historyIndex = 0;
 
     if(initialLocation.zoom !== curr.zoom) {
-      this._traversalCall = 2;
+      this._traversalCall = 2; // ignores the next 2 moveend events
 
-      let currScale = this._map.options.crs.scale(curr.zoom);
-      let initScale = this._map.options.crs.scale(initialLocation.zoom);
+      let currScale = this._map.options.crs.scale(curr.zoom); // gets the scale of the current zoom level
+      let initScale = this._map.options.crs.scale(initialLocation.zoom); // gets the scale of the initial location's zoom
 
       let scale = currScale / initScale;
 
       this._map.panBy([((initialLocation.x * scale) - curr.x), ((initialLocation.y * scale) - curr.y)], {animate: false});
       this._map.setZoom(initialLocation.zoom);
-    } else {
+    } else { // if it's on the same zoom level as the initial location, no need to calculate scales
       this._traversalCall = 1;
       this._map.panBy([(initialLocation.x- curr.x), (initialLocation.y - curr.y)]);
     }

--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -516,7 +516,7 @@ export class MapViewer extends HTMLElement {
     if(this._traversalCall) return;
 
     let mapLocation = this._map.getPixelBounds().getCenter();
-    let location ={
+    let location = {
       zoom: this._map.getZoom(),
       x:mapLocation.x,
       y:mapLocation.y,
@@ -534,9 +534,18 @@ export class MapViewer extends HTMLElement {
       let prev = history[this._historyIndex];
 
       this._traversalCall = true;
-      this._map.setZoom(prev.zoom);
-      this._map.panBy([(prev.x - curr.x), (prev.y - curr.y)]);
 
+      if(prev.zoom !== curr.zoom){
+        let currScale = this._map.options.crs.scale(curr.zoom);
+        let prevScale = this._map.options.crs.scale(prev.zoom);
+
+        let scale = currScale / prevScale;
+
+        this._map.panBy([((prev.x * scale) - curr.x), ((prev.y * scale) - curr.y)], {animate: false});
+        this._map.setZoom(prev.zoom);
+      } else {
+        this._map.panBy([(prev.x - curr.x), (prev.y - curr.y)]);
+      }
       this._map.once("moveend", () => {this._traversalCall = false})
     }
   }
@@ -549,8 +558,18 @@ export class MapViewer extends HTMLElement {
       let next = history[this._historyIndex];
 
       this._traversalCall = true;
-      this._map.setZoom(next.zoom);
-      this._map.panBy([(next.x - curr.x), (next.y - curr.y)]);
+
+      if(next.zoom !== curr.zoom){
+        let currScale = this._map.options.crs.scale(curr.zoom);
+        let nextScale = this._map.options.crs.scale(next.zoom);
+
+        let scale = currScale / nextScale;
+
+        this._map.panBy([((next.x * scale) - curr.x), ((next.y * scale) - curr.y)], {animate: false});
+        this._map.setZoom(next.zoom);
+      } else {
+        this._map.panBy([(next.x - curr.x), (next.y - curr.y)]);
+      }
 
       this._map.once("moveend", () => {this._traversalCall = false})
     }
@@ -569,8 +588,14 @@ export class MapViewer extends HTMLElement {
     this._historyIndex = 0;
 
     this._traversalCall = true;
+
+    let currScale = this._map.options.crs.scale(curr.zoom);
+    let initScale = this._map.options.crs.scale(initialLocation.zoom);
+
+    let scale = currScale / initScale;
+
+    this._map.panBy([((initialLocation.x * scale) - curr.x), ((initialLocation.y * scale) - curr.y)], {animate: false});
     this._map.setZoom(initialLocation.zoom);
-    this._map.panBy([(initialLocation.x - curr.x), (initialLocation.y - curr.y)]);
 
     this._map.once("moveend", () => {this._traversalCall = false})
   }

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -549,9 +549,13 @@ export class WebMap extends HTMLMapElement {
     this.zoom = this._map.getZoom();
   }
 
+  /**
+   * Adds to the maps history on moveends
+   * @private
+   */
   _addToHistory(){
-    if(this._traversalCall > 0) {
-      this._traversalCall--;
+    if(this._traversalCall > 0) { // this._traversalCall tracks how many consecutive moveends to ignore from history
+      this._traversalCall--;      // this is useful for ignoring moveends corresponding to back, forward and reload
       return;
     }
 
@@ -565,6 +569,9 @@ export class WebMap extends HTMLMapElement {
     this._history.splice(this._historyIndex, 0, location);
   }
 
+  /**
+   * Allow user to move back in history
+   */
   back(){
     let history = this._history;
     let curr = history[this._historyIndex];
@@ -574,12 +581,12 @@ export class WebMap extends HTMLMapElement {
       let prev = history[this._historyIndex];
 
       if(prev.zoom !== curr.zoom){
-        this._traversalCall = 2;
+        this._traversalCall = 2;  // allows the next 2 moveends to be ignored from history
 
-        let currScale = this._map.options.crs.scale(curr.zoom);
-        let prevScale = this._map.options.crs.scale(prev.zoom);
+        let currScale = this._map.options.crs.scale(curr.zoom); // gets the scale of the current zoom level
+        let prevScale = this._map.options.crs.scale(prev.zoom); // gets the scale of the previous zoom level
 
-        let scale = currScale / prevScale;
+        let scale = currScale / prevScale; // used to convert the previous pixel location to be in terms of the current zoom level
 
         this._map.panBy([((prev.x * scale) - curr.x), ((prev.y * scale) - curr.y)], {animate: false});
         this._map.setZoom(prev.zoom);
@@ -590,6 +597,9 @@ export class WebMap extends HTMLMapElement {
     }
   }
 
+  /**
+   * Allows user to move forward in history
+   */
   forward(){
     let history = this._history;
     let curr = history[this._historyIndex];
@@ -598,12 +608,12 @@ export class WebMap extends HTMLMapElement {
       let next = history[this._historyIndex];
 
       if(next.zoom !== curr.zoom){
-        this._traversalCall = 2;
+        this._traversalCall = 2; // allows the next 2 moveends to be ignored from history
 
-        let currScale = this._map.options.crs.scale(curr.zoom);
-        let nextScale = this._map.options.crs.scale(next.zoom);
+        let currScale = this._map.options.crs.scale(curr.zoom); // gets the scale of the current zoom level
+        let nextScale = this._map.options.crs.scale(next.zoom); // gets the scale of the next zoom level
 
-        let scale = currScale / nextScale;
+        let scale = currScale / nextScale; // used to convert the next pixel location to be in terms of the current zoom level
 
         this._map.panBy([((next.x * scale) - curr.x), ((next.y * scale) - curr.y)], {animate: false});
         this._map.setZoom(next.zoom);
@@ -614,6 +624,9 @@ export class WebMap extends HTMLMapElement {
     }
   }
 
+  /**
+   * Allows the user to reload/reset the map's location to it's initial location
+   */
   reload(){
     let initialLocation = this._history.shift();
     let mapLocation = this._map.getPixelBounds().getCenter();
@@ -627,20 +640,21 @@ export class WebMap extends HTMLMapElement {
     this._historyIndex = 0;
 
     if(initialLocation.zoom !== curr.zoom) {
-      this._traversalCall = 2;
+      this._traversalCall = 2; // ignores the next 2 moveend events
 
-      let currScale = this._map.options.crs.scale(curr.zoom);
-      let initScale = this._map.options.crs.scale(initialLocation.zoom);
+      let currScale = this._map.options.crs.scale(curr.zoom); // gets the scale of the current zoom level
+      let initScale = this._map.options.crs.scale(initialLocation.zoom); // gets the scale of the initial location's zoom
 
       let scale = currScale / initScale;
 
       this._map.panBy([((initialLocation.x * scale) - curr.x), ((initialLocation.y * scale) - curr.y)], {animate: false});
       this._map.setZoom(initialLocation.zoom);
-    } else {
+    } else { // if it's on the same zoom level as the initial location, no need to calculate scales
       this._traversalCall = 1;
       this._map.panBy([(initialLocation.x- curr.x), (initialLocation.y - curr.y)]);
     }
   }
+
   viewSource(){
     let blob = new Blob([this._source],{type:"text/plain"}),
         url = URL.createObjectURL(blob);

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -550,49 +550,66 @@ export class WebMap extends HTMLMapElement {
   }
 
   _addToHistory(){
-    if(this._traversalCall){
-      this._traversalCall = false;
-      return;
-    }
-    let mapLocation = this._map.getCenter();
+    if(this._traversalCall) return;
+
+    let mapLocation = this._map.getPixelBounds().getCenter();
     let location ={
-      zoom:this._map.getZoom(),
-      lat:mapLocation.lat,
-      lng:mapLocation.lng,
+      zoom: this._map.getZoom(),
+      x:mapLocation.x,
+      y:mapLocation.y,
     };
     this._historyIndex++;
-    this._history.push(location);
+    this._history.splice(this._historyIndex, 0, location);
   }
 
   back(){
-    let mapEl = this,
-        history = mapEl._history;
-    if(mapEl._historyIndex > 0){
-      mapEl._historyIndex--;
+    let history = this._history;
+    let curr = history[this._historyIndex];
+
+    if(this._historyIndex > 0){
+      this._historyIndex--;
+      let prev = history[this._historyIndex];
+
+      this._traversalCall = true;
+      this._map.setZoom(prev.zoom);
+      this._map.panBy([(prev.x - curr.x), (prev.y - curr.y)]);
+
+      this._map.once("moveend", () => {this._traversalCall = false})
     }
-    let prev = history[mapEl._historyIndex];
-    mapEl._traversalCall = true;
-    mapEl.zoomTo(prev.lat,prev.lng,prev.zoom);
   }
 
   forward(){
-    let mapEl = this,
-        history = this._history;
-    if(mapEl._historyIndex < history.length -1){
-      mapEl._historyIndex++;
+    let history = this._history;
+    let curr = history[this._historyIndex];
+    if(this._historyIndex < history.length - 1){
+      this._historyIndex++;
+      let next = history[this._historyIndex];
+
+      this._traversalCall = true;
+      this._map.setZoom(next.zoom);
+      this._map.panBy([(next.x - curr.x), (next.y - curr.y)]);
+
+      this._map.once("moveend", () => {this._traversalCall = false})
     }
-    let next = history[this._historyIndex];
-    mapEl._traversalCall = true;
-    mapEl.zoomTo(next.lat,next.lng,next.zoom);
   }
 
   reload(){
-    let mapEl = this,
-        initialLocation = mapEl._history.shift();
-    mapEl._history = [initialLocation];
-    mapEl._historyIndex = 0;
-    mapEl._traversalCall = true;
-    mapEl.zoomTo(initialLocation.lat,initialLocation.lng,initialLocation.zoom);
+    let initialLocation = this._history.shift();
+    let mapLocation = this._map.getPixelBounds().getCenter();
+    let curr = {
+      zoom: this._map.getZoom(),
+      x:mapLocation.x,
+      y:mapLocation.y,
+    };
+
+    this._history = [initialLocation];
+    this._historyIndex = 0;
+
+    this._traversalCall = true;
+    this._map.setZoom(initialLocation.zoom);
+    this._map.panBy([(initialLocation.x - curr.x), (initialLocation.y - curr.y)]);
+
+    this._map.once("moveend", () => {this._traversalCall = false})
   }
 
   viewSource(){

--- a/test/e2e/core/history.test.js
+++ b/test/e2e/core/history.test.js
@@ -1,0 +1,90 @@
+const playwright = require("playwright");
+jest.setTimeout(50000);
+(async () => {
+    for (const browserType of BROWSER) {
+       describe(
+           "History test" + browserType,
+           ()=> {
+               beforeAll(async () => {
+                   browser = await playwright[browserType].launch({
+                       headless: ISHEADLESS,
+                       slowMo: 100,
+                   });
+                   context = await browser.newContext();
+                   page = await context.newPage();
+                   if (browserType === "firefox") {
+                       await page.waitForNavigation();
+                   }
+                   await page.goto(PATH + "mapml-viewer.html");
+               });
+               afterAll(async function () {
+                    await browser.close();
+               });
+
+               test("[" + browserType + "]" + " History values are correct during vertical motion out of projection", async ()=>{
+                    await page.keyboard.press("Tab");
+                    for(let i = 0; i < 3; i++){
+                        await page.keyboard.press("ArrowUp");
+                        await page.waitForTimeout(100);
+                    }
+                    const history = await page.$eval(
+                        "body > mapml-viewer",
+                        (map) => map._history
+                    );
+                    expect(history[2]).toEqual({ zoom: 0, x: 909, y: 870 });
+                    expect(history[3]).toEqual({ zoom: 0, x: 909, y: 790 });
+               });
+
+               test("[" + browserType + "]" + " History across zoom levels", async ()=>{
+                    await page.keyboard.press("Equal");
+                    await page.waitForTimeout(100);
+                    //await page.keyboard.press("Minus");
+                    await page.keyboard.press("ArrowUp");
+                    const history = await page.$eval(
+                        "body > mapml-viewer",
+                        (map) => map._history
+                    );
+                    expect(history[4]).toEqual({ zoom: 1, x: 1436, y: 1378 });
+                    //expect(history[5]).toEqual(history[3]);
+                    expect(history[5]).toEqual({ zoom: 1, x: 1436, y: 1298 });
+
+               });
+
+               test("[" + browserType + "]" + " Back function", async ()=>{
+                   await page.$eval(
+                       "body > mapml-viewer",
+                       (map) => map.back()
+                   );
+                   const history = await page.$eval(
+                       "body > mapml-viewer",
+                       (map) => map._history
+                   );
+                   const location = await page.$eval(
+                       "body > mapml-viewer",
+                       (map) => map._map.getPixelBounds().getCenter()
+                   );
+                   expect(location.x).toEqual(history[4].x);
+                   expect(location.y).toEqual(history[4].y);
+
+               });
+
+               test("[" + browserType + "]" + " Forward function", async ()=>{
+                   await page.$eval(
+                       "body > mapml-viewer",
+                       (map) => map.forward()
+                   );
+                   const history = await page.$eval(
+                       "body > mapml-viewer",
+                       (map) => map._history
+                   );
+                   const location = await page.$eval(
+                       "body > mapml-viewer",
+                       (map) => map._map.getPixelBounds().getCenter()
+                   );
+                   expect(location.x).toEqual(history[5].x);
+                   expect(location.y).toEqual(history[5].y);
+               });
+           }
+       );
+    }
+})();


### PR DESCRIPTION
Rather than keeping track of navigation history in terms of latitude and longitude, this uses tcrs and calculates offsets to navigate history. This also accounts for zoom.

- [x] fix issue inaccurate offset on zoom
- [x] add comments
- [x] add additional tests

Closes #542