### PR TITLE
New layer control icon

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -235,6 +235,11 @@
   border-bottom: 1px solid #e3e3e3;
 }
 
+.leaflet-control .leaflet-control-layers-toggle {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' width='24'%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='m12 18.5-7.4-5.7L3 14.1l9 7 9-7-1.6-1.3-7.4 5.7zm0-2.5 7.4-5.7L21 9l-9-7-9 7 1.6 1.3L12 16z'/%3E%3C/svg%3E");
+  background-size: 34px;
+}
+
 /* Revert Leaflet styles that are causing misalignment. */
 .leaflet-control-layers-selector {
   margin-top: revert;

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -236,7 +236,7 @@
 }
 
 .leaflet-control .leaflet-control-layers-toggle {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' width='24'%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='m11.99 18.54-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' width='24'%3E%3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E%3Cpath d='m11.99 18.54-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16zm0-11.47L17.74 9 12 13.47 6.26 9 12 4.53z'/%3E%3C/svg%3E");
   background-size: 34px;
 }
 

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -236,7 +236,7 @@
 }
 
 .leaflet-control .leaflet-control-layers-toggle {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' width='24'%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='m12 18.5-7.4-5.7L3 14.1l9 7 9-7-1.6-1.3-7.4 5.7zm0-2.5 7.4-5.7L21 9l-9-7-9 7 1.6 1.3L12 16z'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' width='24'%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='m11.99 18.54-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z'/%3E%3C/svg%3E");
   background-size: 34px;
 }
 


### PR DESCRIPTION
This is a proposal to change the icon of the layer control:

<img width="300" src="https://user-images.githubusercontent.com/26493779/139000720-0d435272-0286-44ec-9359-b540137f2bc6.png">

The current one screams "Leaflet!" - which isn't a bad thing - though a new icon may encourage developers to dig into the source code and realize the component is something a little bit different, if they weren't aware already.

I also don't think UA implementations of maps would use such themed/opinionated and dated looking (IMO) icons. And the proposed one looks similar in style to the other controls.

## Preview

<img width="300" src="https://user-images.githubusercontent.com/26493779/139000722-b905fe43-26b2-4376-973b-c35b2b7171ed.png">

(icon source: https://fonts.google.com/icons?selected=Material+Icons&icon.query=layers)
