### PR TITLE
ID and Radio Button Fixes in the Layer Control

### DIFF
--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -551,7 +551,7 @@ export var MapMLLayer = L.Layer.extend({
         } else {
           layerItemName.innerHTML = this._title;
         }
-        layerItemName.id = this._title;
+        layerItemName.id = 'mapml-layer-item-name-{' + L.stamp(layerItemName) + '}';
         opacityControlSummary.innerText = 'Opacity';
         opacityControlSummary.id = 'mapml-layer-item-opacity-' + this._title;
         opacityControl.appendChild(opacityControlSummary);
@@ -565,7 +565,7 @@ export var MapMLLayer = L.Layer.extend({
         opacity.value = this._container.style.opacity || '1.0';
 
         fieldset.setAttribute("aria-grabbed", "false");
-        fieldset.setAttribute('aria-labelledby', this._title);
+        fieldset.setAttribute('aria-labelledby', layerItemName.id);
 
         fieldset.onmousedown = (downEvent) => {
           if(downEvent.target.tagName.toLowerCase() === "input" || downEvent.target.tagName.toLowerCase() === "select") return;
@@ -942,12 +942,12 @@ export var MapMLLayer = L.Layer.extend({
                     var styleOption = document.createElement('span'),
                     styleOptionInput = styleOption.appendChild(document.createElement('input'));
                     styleOptionInput.setAttribute("type", "radio");
-                    styleOptionInput.setAttribute("id", "rad"+j);
-                    styleOptionInput.setAttribute("name", "styles");
+                    styleOptionInput.setAttribute("id", "rad-"+L.stamp(styleOptionInput));
+                    styleOptionInput.setAttribute("name", "styles-"+layer._title);
                     styleOptionInput.setAttribute("value", styleLinks[j].getAttribute('title'));
                     styleOptionInput.setAttribute("data-href", new URL(styleLinks[j].getAttribute('href'),base).href);
                     var styleOptionLabel = styleOption.appendChild(document.createElement('label'));
-                    styleOptionLabel.setAttribute("for", "rad"+j);
+                    styleOptionLabel.setAttribute("for", "rad-"+L.stamp(styleOptionInput));
                     styleOptionLabel.innerText = styleLinks[j].getAttribute('title');
                     if (styleLinks[j].getAttribute("rel") === "style self" || styleLinks[j].getAttribute("rel") === "self style") {
                       styleOptionInput.checked = true;


### PR DESCRIPTION
- Fixed the duplicate IDs in the layer style control
- Fixed an issue with the radio button, under the layer styles control, where only one radio button could be selected from all layers
- Removed whitespace from ID in the layer control

Closes #508 