### PR TITLE
Fix link colors

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -35,13 +35,6 @@
   font-size: 12px;
 }
 
-/* Remove opinionated color of links. */
-.leaflet-container a,
-.leaflet-container a.leaflet-popup-close-button,
-.leaflet-container a.leaflet-popup-close-button:hover {
-  color: initial;
-}
-
 /*
  * Controls.
  */
@@ -62,6 +55,23 @@
   -webkit-appearance: none;
      -moz-appearance: none;
           appearance: none;
+}
+
+/* Remove opinionated link colors set by Leaflet. */
+.leaflet-container a {
+  color: revert;
+}
+/* Don't use UA styles for links that are controls
+  (and don't inherit color from map into the reload button for consistency). */
+.mapml-reload-button,
+.leaflet-control-container a,
+.leaflet-container a.leaflet-popup-close-button,
+.leaflet-container a.leaflet-popup-close-button:hover {
+  color: #000;
+}
+/* Revert above `color: #000` for legendlinks. */
+.mapml-layer-item-name a {
+  color: revert;
 }
  
  .leaflet-top .leaflet-control {


### PR DESCRIPTION
Fix https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/553.

## Preview

![popup-link](https://user-images.githubusercontent.com/26493779/139593871-f8b267cb-02ff-4771-bdd8-9abe70f80e36.png)
![legendlink-color](https://user-images.githubusercontent.com/26493779/139593872-06822e78-c1ab-41e6-90c3-9cd708aa7a97.png)
