### PR TITLE
Alignment improvements in the Layer control

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -213,7 +213,8 @@
   display: flex;
 }
 
-.mapml-layer-item-style input {
+.mapml-layer-item-style input,
+.mapml-layer-item-opacity input {
   margin-inline-start: 0;
 }
 

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -385,7 +385,8 @@
 .leaflet-control,
 .mapml-contextmenu,
 .mapml-debug,
-.mapml-focus-buttons {
+.mapml-focus-buttons,
+.mapml-layer-item-settings summary {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -691,11 +692,6 @@ button.mapml-button:disabled,
   padding-block-end: .25rem;
   padding-inline-start: 2rem;
   padding-inline-end: 1rem;
-}
-
-.mapml-layer-item-settings summary {
-  -webkit-user-select: none;
-          user-select: none;
 }
 
 .mapml-layer-item-opacity [type="range"] {

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -203,11 +203,18 @@
   display: inline;
 }
 
-.leaflet-control-layers-overlays > fieldset > .mapml-layer-item-settings > .mapml-control-layers > summary ~ * {
+.mapml-control-layers > :not(summary) {
   display: block;
-  margin-top: 5px;
-  margin-left: 15px;
-  width: calc(100% - 15px);
+  margin-block-start: 5px;
+  width: 100%;
+}
+
+.mapml-layer-item-style > div {
+  display: flex;
+}
+
+.mapml-layer-item-style input {
+  margin-inline-start: 0;
 }
 
 .leaflet-control-layers-list .leaflet-control-layers-overlays > :not(:last-of-type) {
@@ -691,10 +698,4 @@ label.mapml-layer-item-toggle {
   padding-block-end: .25rem;
   padding-inline-start: 2rem;
   padding-inline-end: 1rem;
-}
-
-.mapml-layer-item-opacity [type="range"] {
-  margin-inline-end: 0;
-  margin-inline-start: 0;
-  width: 100%;
 }

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -674,9 +674,9 @@ button.mapml-button:disabled,
   width: 44px;
 }
 
-.mapml-layer-item-toggle{
-  display: inline-flex !important;
-  width: 100%;
+label.mapml-layer-item-toggle {
+  display: inline-flex;
+  align-items: center;
 }
 
 .mapml-layer-item-name {

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -681,7 +681,6 @@ label.mapml-layer-item-toggle {
 
 .mapml-layer-item-name {
   word-break: break-word;
-  text-align: inline-start;
   padding-inline-start: .25rem;
   padding-inline-end: 1rem;
 }

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -206,15 +206,15 @@
 .mapml-control-layers > :not(summary) {
   display: block;
   margin-block-start: 5px;
-  width: 100%;
+  margin-inline-start: 15px;
+  width: calc(100% - 15px);
 }
 
 .mapml-layer-item-style > div {
   display: flex;
 }
 
-.mapml-layer-item-style input,
-.mapml-layer-item-opacity input {
+.mapml-layer-item-style input {
   margin-inline-start: 0;
 }
 

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -689,6 +689,8 @@ label.mapml-layer-item-toggle {
 
 .mapml-layer-item-name {
   word-break: break-word;
+  padding-block-start: .25rem;
+  padding-block-end: .25rem;
   padding-inline-start: .25rem;
   padding-inline-end: 1rem;
 }

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -489,7 +489,7 @@ export var MapMLLayer = L.Layer.extend({
         layerItemSettings = L.DomUtil.create('div', 'mapml-layer-item-settings', fieldset),
         itemToggleLabel = L.DomUtil.create('label', 'mapml-layer-item-toggle', layerItemProperty),
         layerItemControls = L.DomUtil.create('div', 'mapml-layer-item-controls', layerItemProperty),
-        opacityControl = L.DomUtil.create('details', 'mapml-layer-item-opacity', layerItemSettings),
+        opacityControl = L.DomUtil.create('details', 'mapml-layer-item-opacity mapml-control-layers', layerItemSettings),
         opacity = L.DomUtil.create('input'),
         opacityControlSummary = L.DomUtil.create('summary'),
         svgSettingsControlIcon = L.SVG.create('svg'),
@@ -654,7 +654,7 @@ export var MapMLLayer = L.Layer.extend({
                 // don't add it again if it is referenced > once
                 if (mapmlInput.tagName.toLowerCase() === 'map-select' && !frag.querySelector(id)) {
                   // generate a <details><summary></summary><select...></details>
-                  var selectdetails = L.DomUtil.create('details', 'mapml-control-layers', frag),
+                  var selectdetails = L.DomUtil.create('details', 'mapml-layer-item-time mapml-control-layers', frag),
                       selectsummary = L.DomUtil.create('summary'),
                       selectSummaryLabel = L.DomUtil.create('label');
                       selectSummaryLabel.innerText = mapmlInput.getAttribute('name');
@@ -939,7 +939,7 @@ export var MapMLLayer = L.Layer.extend({
                   };
 
                   for (var j=0;j<styleLinks.length;j++) {
-                    var styleOption = document.createElement('span'),
+                    var styleOption = document.createElement('div'),
                     styleOptionInput = styleOption.appendChild(document.createElement('input'));
                     styleOptionInput.setAttribute("type", "radio");
                     styleOptionInput.setAttribute("id", "rad-"+L.stamp(styleOptionInput));
@@ -953,7 +953,7 @@ export var MapMLLayer = L.Layer.extend({
                       styleOptionInput.checked = true;
                     }
                     stylesControl.appendChild(styleOption);
-                    L.DomUtil.addClass(stylesControl,'mapml-control-layers');
+                    L.DomUtil.addClass(stylesControl,'mapml-layer-item-style mapml-control-layers');
                     L.DomEvent.on(styleOptionInput,'click', changeStyle, layer);
                   }
                   layer._styles = stylesControl;


### PR DESCRIPTION
- [x] https://github.com/Maps4HTML/Web-Map-Custom-Element/commit/a056aa0a8f9bf903e89083ceec62cb047feb844f: re-use CSS to avoid duplicating `user-select` styles
- [x] https://github.com/Maps4HTML/Web-Map-Custom-Element/commit/ed8687db9e4438303ad0d1008bb9fe1fa06e895e: align the checkbox with other controls (also removes unnecessary `width` and the need for an `!important` statement)<br>
  **Before:**<!-- ![input-not-aligned](https://user-images.githubusercontent.com/26493779/140652471-c1525cac-9971-455e-99f3-92fa1627376a.png)-->
![input-not-aligned](https://user-images.githubusercontent.com/26493779/141513371-03333d14-d761-4737-b40c-86a00dd89c99.png)
  **After:**<!--![input-aligned](https://user-images.githubusercontent.com/26493779/140652504-2a9c1f10-7aa2-4692-a686-49592b53b6e3.png)-->
![input-aligned](https://user-images.githubusercontent.com/26493779/141513668-b54c5bc0-7e04-4366-9404-e84280ef0343.png)
- [x] https://github.com/Maps4HTML/Web-Map-Custom-Element/commit/b4f5afe1e74c8ec7981a68ca9418ebffdaa42fee: remove `text-align` on the layer name (because it 1: doesn't appear to be needed, and 2: doesn't look good if the map is set to RTL direction but the layer name is in an LTR script)<br>
  **Before:**<!--![rtl-with-text-align](https://user-images.githubusercontent.com/26493779/140652562-dbda9a1a-303b-483d-a480-f406965112ea.png)-->
![rtl-with-text-align](https://user-images.githubusercontent.com/26493779/141512959-aac6d1a4-c45c-4586-abcc-62c1759ac046.png)
  **After:**<!-- ![rtl-without-text-align](https://user-images.githubusercontent.com/26493779/140652608-ac5bdac9-d3ca-4fab-adc8-894f8cdcacaa.png)-->
![rtl-without-text-align](https://user-images.githubusercontent.com/26493779/141513141-9c0b4a53-5451-4c12-92a1-0b3a5889e6e3.png)
(i.e. now looks good independently of the direction of the map and/or the script used in the layer name, tested using [sample arabic text](https://r12a.github.io/scripts/tutorial/summaries/arabic))
- [x] https://github.com/Maps4HTML/Web-Map-Custom-Element/pull/565/commits/c95d4e36fa17f1ef30890f557f07360b1454812f: removes the indentation/margin for better alignment and improves alignment between labels and radio inputs (also fixes an [RTL issue](https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/505))<br>
**Before:**
![controls-alignment-before](https://user-images.githubusercontent.com/26493779/141512596-cd695fe3-28fd-42fa-abae-e02036dc2860.png)
**After:**<!--![controls-aligntment-after-lines](https://user-images.githubusercontent.com/26493779/141512636-95c51af5-1de8-4777-868d-b7c5d9e98a8b.png)-->
![controls-aligntment-after](https://user-images.githubusercontent.com/26493779/141516679-3cd077ab-4fc8-4095-b885-e68924845272.png)
- [x] https://github.com/Maps4HTML/Web-Map-Custom-Element/commit/b6f59f0289f901a3549a73fcc89e54cc01e32c27: add padding to the layer name (see [screenshot](https://github.com/Maps4HTML/Web-Map-Custom-Element/pull/565#issuecomment-968199589) below)

