### PR TITLE
Small improvements to the `mapml-outline`

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -558,7 +558,7 @@ summary {
 
 .mapml-outline {
   outline-style: auto;
-  outline-offset: -1px;
+  outline-offset: -2px;
   z-index: 1000;
   pointer-events: none;
   position: absolute;

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -564,6 +564,7 @@ summary {
   position: absolute;
   height: 100%;
   width: 100%;
+  color: initial;
 }
  
  /* Force printers to include background-images of controls for printing.


### PR DESCRIPTION
- [x] https://github.com/Maps4HTML/Web-Map-Custom-Element/commit/1a5e3d2a73041f537c5f12cb969ffebbd294c4ab: don't inherit `color` from the map element into the `mapml-outline` (for consistency, and the inheritance only happens because we had to use the `mapml-outline` hack to begin with, i.e. doesn't happen when you change colors of interactive elements):<br>
  **Before:**
  <video src="https://user-images.githubusercontent.com/26493779/140671271-cdd64e8c-175d-4ed9-b490-2e0b7a3e0c3e.mp4"></video>
  **After**:
  <video src="https://user-images.githubusercontent.com/26493779/140671289-6d50a0a1-d2e4-4c01-b428-904d03d52b4c.mp4">
- [x] https://github.com/Maps4HTML/Web-Map-Custom-Element/commit/1020de917f85e649ce67c63d3c7f278ede3170a3: increase visibility of the `mapml-outline` (mostly a https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/551 improvement):<br>
  **Before:**
  <video src="https://user-images.githubusercontent.com/26493779/140671504-71e7a958-6cdb-4d80-ab77-ff5b40cb4e27.mp4"></video>
  **After:**
  <video src="https://user-images.githubusercontent.com/26493779/140671545-0d03520d-163b-4aeb-9198-1f5f82f22f9e.mp4"></video>


  