### PR TITLE
Fix select in Firefox

### DIFF
--- a/src/mapml/layers/ControlLayer.js
+++ b/src/mapml/layers/ControlLayer.js
@@ -107,11 +107,16 @@ export var MapMLLayerControl = L.Control.Layers.extend({
 
     //overrides collapse and conditionally collapses the panel
     collapse: function(e){
-      if(e.target.tagName === "SELECT" || (e.relatedTarget && e.relatedTarget.parentElement &&
-          (e.relatedTarget.className === "mapml-contextmenu mapml-layer-menu" || 
-          e.relatedTarget.parentElement.className === "mapml-contextmenu mapml-layer-menu") ||
-          (this._map && this._map.contextMenu._layerMenu.style.display === "block")))
-       return this;
+      if (
+        e.target.tagName === "SELECT" ||
+        e.relatedTarget &&
+        e.relatedTarget.parentElement &&
+        (
+          e.relatedTarget.className === "mapml-contextmenu mapml-layer-menu" ||
+          e.relatedTarget.parentElement.className === "mapml-contextmenu mapml-layer-menu"
+        ) ||
+        (this._map && this._map.contextMenu._layerMenu.style.display === "block")
+      ) return this;
 
       L.DomUtil.removeClass(this._container, 'leaflet-control-layers-expanded');
 		  return this;

--- a/src/mapml/layers/ControlLayer.js
+++ b/src/mapml/layers/ControlLayer.js
@@ -107,10 +107,10 @@ export var MapMLLayerControl = L.Control.Layers.extend({
 
     //overrides collapse and conditionally collapses the panel
     collapse: function(e){
-      if(e.relatedTarget && e.relatedTarget.parentElement && 
+      if(e.target.tagName === "SELECT" || (e.relatedTarget && e.relatedTarget.parentElement &&
           (e.relatedTarget.className === "mapml-contextmenu mapml-layer-menu" || 
           e.relatedTarget.parentElement.className === "mapml-contextmenu mapml-layer-menu") ||
-          (this._map && this._map.contextMenu._layerMenu.style.display === "block"))
+          (this._map && this._map.contextMenu._layerMenu.style.display === "block")))
        return this;
 
       L.DomUtil.removeClass(this._container, 'leaflet-control-layers-expanded');


### PR DESCRIPTION
Allows users to use `select` elements in the layer controls in Firefox.

On a somewhat related note, I noticed the `select` element isn't actually visible when screen recording Firefox, but is visible in Chrome. 

Closes #572 