### PR TITLE
Test refactor, making them faster

### DIFF
--- a/jest-playwright.config.js
+++ b/jest-playwright.config.js
@@ -1,7 +1,12 @@
 module.exports = {
-    server: {
+    serverOptions: {
         command: 'node test/server.js',
         port: 30001,
         launchTimeout: 10000,
     },
+    launchOptions: {
+        headless: true,
+        slowMo: 250,
+    },
+    browsers: ["chromium"],
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,8 +10,6 @@ module.exports = {
       preset: "jest-playwright-preset",
       globals: {
         PATH: "http://localhost:30001/",
-        BROWSER: ["chromium"],
-        ISHEADLESS: true
       },
       testMatch: ["**/test/e2e/**/*.test.js"]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -349,43 +349,19 @@
         "minimist": "^1.2.0"
       }
     },
-    "@hapi/address": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
-      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
-      "dev": true
-    },
-    "@hapi/bourne": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
-      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
-      "dev": true
-    },
     "@hapi/hoek": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
-      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
       "dev": true
-    },
-    "@hapi/joi": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
-      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
-      "dev": true,
-      "requires": {
-        "@hapi/address": "2.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/topo": "3.x.x"
-      }
     },
     "@hapi/topo": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
-      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "^8.3.0"
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -1007,6 +983,27 @@
         }
       }
     },
+    "@sideway/address": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
+      "integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "dev": true
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -1130,6 +1127,15 @@
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
     },
+    "@types/wait-on": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@types/wait-on/-/wait-on-5.3.1.tgz",
+      "integrity": "sha512-2FFOKCF/YydrMUaqg+fkk49qf0e5rDgwt6aQsMzFQzbS419h2gNOXyiwp/o2yYy27bi/C1z+HgfncryjGzlvgQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "15.0.5",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
@@ -1219,6 +1225,24 @@
         }
       }
     },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        }
+      }
+    },
     "ajv": {
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
@@ -1278,6 +1302,21 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "append-transform": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "^3.0.0"
+      }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -1400,6 +1439,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
     },
     "babel-jest": {
       "version": "26.1.0",
@@ -1741,6 +1789,18 @@
         "unset-value": "^1.0.0"
       }
     },
+    "caching-transform": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+      "dev": true,
+      "requires": {
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1823,6 +1883,12 @@
           }
         }
       }
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
     },
     "cli": {
       "version": "1.0.1",
@@ -1918,6 +1984,12 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
       "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "component-emitter": {
@@ -2025,12 +2097,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-      "dev": true
-    },
-    "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
       "dev": true
     },
     "core-util-is": {
@@ -2164,6 +2230,23 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
+    },
+    "default-require-extensions": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
+      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+      "dev": true,
+      "requires": {
+        "strip-bom": "^4.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+          "dev": true
+        }
+      }
     },
     "define-property": {
       "version": "2.0.2",
@@ -2369,6 +2452,12 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2561,13 +2650,10 @@
       }
     },
     "expect-playwright": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/expect-playwright/-/expect-playwright-0.2.5.tgz",
-      "integrity": "sha512-H7S4+ZG9ziYTnHU23YbnEJ5KLzjnFdNx1UN78to+SDiXufoeXS/ddMOkxHruo/wqeGhjFD3gslfmunWjdG4RFQ==",
-      "dev": true,
-      "requires": {
-        "playwright-core": "^1.2.1"
-      }
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/expect-playwright/-/expect-playwright-0.7.2.tgz",
+      "integrity": "sha512-5o9si+8SUi68QVI0CRVv8tvTjZinpJWRSfQ3GP6v0DvlK55lDgFvD79r6A/NU+EUawrBc62qP30MxzOUnXNJZQ==",
+      "dev": true
     },
     "express": {
       "version": "4.17.1",
@@ -2868,6 +2954,17 @@
         }
       }
     },
+    "find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      }
+    },
     "find-file-up": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
@@ -2888,30 +2985,79 @@
       }
     },
     "find-process": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.3.tgz",
-      "integrity": "sha512-+IA+AUsQCf3uucawyTwMWcY+2M3FXq3BRvw3S+j5Jvydjk31f/+NPWpYZOJs+JUs2GvxH4Yfr6Wham0ZtRLlPA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.5.tgz",
+      "integrity": "sha512-v11rJYYISUWn+s8qZzgGnBvlzRKf3bOtlGFM8H0kw56lGQtOmLuLCzuclA5kehA2j7S5sioOWdI4woT3jDavAw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "commander": "^2.11.0",
-        "debug": "^2.6.8"
+        "chalk": "^4.0.0",
+        "commander": "^5.1.0",
+        "debug": "^4.1.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "color-convert": "^2.0.1"
           }
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
+        },
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
@@ -2979,6 +3125,12 @@
       "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+      "dev": true
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2992,6 +3144,59 @@
       "dev": true,
       "requires": {
         "for-in": "^1.0.1"
+      }
+    },
+    "foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "forever-agent": {
@@ -3030,6 +3235,12 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
       "dev": true
     },
     "fs-exists-sync": {
@@ -3694,6 +3905,24 @@
         }
       }
     },
+    "hasha": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "dev": true,
+      "requires": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+          "dev": true
+        }
+      }
+    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -3868,6 +4097,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
     },
     "ip-regex": {
@@ -4136,6 +4371,15 @@
       "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
       "dev": true
     },
+    "istanbul-lib-hook": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+      "dev": true,
+      "requires": {
+        "append-transform": "^2.0.0"
+      }
+    },
     "istanbul-lib-instrument": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
@@ -4153,6 +4397,79 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
+        }
+      }
+    },
+    "istanbul-lib-processinfo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
+      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "cross-spawn": "^7.0.0",
+        "istanbul-lib-coverage": "^3.0.0-alpha.1",
+        "make-dir": "^3.0.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^3.3.3"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
@@ -4441,73 +4758,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "jest-dev-server": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-4.4.0.tgz",
-      "integrity": "sha512-STEHJ3iPSC8HbrQ3TME0ozGX2KT28lbT4XopPxUm2WimsX3fcB3YOptRh12YphQisMhfqNSNTZUmWyT3HEXS2A==",
-      "dev": true,
-      "requires": {
-        "chalk": "^3.0.0",
-        "cwd": "^0.10.0",
-        "find-process": "^1.4.3",
-        "prompts": "^2.3.0",
-        "spawnd": "^4.4.0",
-        "tree-kill": "^1.2.2",
-        "wait-on": "^3.3.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -4978,13 +5228,34 @@
       }
     },
     "jest-playwright-preset": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/jest-playwright-preset/-/jest-playwright-preset-0.1.3.tgz",
-      "integrity": "sha512-7MdWx+qUWJC92FwhcYOoogC3EJ/fuadz63aCtp1P3911GPCIWZy/gscxeqzCW/mTaV6o7v+v0A5P0hICHPU1gg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/jest-playwright-preset/-/jest-playwright-preset-1.7.0.tgz",
+      "integrity": "sha512-G25Nik+By0SNniMDdkouDL/yA1LdqjzsXNSVU4xnRX1typjXRmzRE0aSgqxas2sRi8cwG3M1ioHdkLLsp6sang==",
       "dev": true,
       "requires": {
-        "expect-playwright": "^0.2.1",
-        "jest-dev-server": "^4.4.0"
+        "expect-playwright": "^0.7.0",
+        "jest-process-manager": "^0.3.1",
+        "nyc": "^15.1.0",
+        "playwright-core": ">=1.2.0",
+        "rimraf": "^3.0.2",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "jest-pnp-resolver": {
@@ -4992,6 +5263,85 @@
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
       "dev": true
+    },
+    "jest-process-manager": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/jest-process-manager/-/jest-process-manager-0.3.1.tgz",
+      "integrity": "sha512-x9W54UgZ7IkzUHgXtnI1x4GKOVjxtwW0CA/7yGbTHtT/YhENO0Lic2yfVyC/gekn7OIEMcQmy0L1r9WLQABfqw==",
+      "dev": true,
+      "requires": {
+        "@types/wait-on": "^5.2.0",
+        "chalk": "^4.1.0",
+        "cwd": "^0.10.0",
+        "exit": "^0.1.2",
+        "find-process": "^1.4.4",
+        "prompts": "^2.4.1",
+        "signal-exit": "^3.0.3",
+        "spawnd": "^5.0.0",
+        "tree-kill": "^1.2.2",
+        "wait-on": "^5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "prompts": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+          "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+          "dev": true,
+          "requires": {
+            "kleur": "^3.0.3",
+            "sisteransi": "^1.0.5"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -5628,6 +5978,19 @@
         }
       }
     },
+    "joi": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
+      "integrity": "sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "jpeg-js": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz",
@@ -5912,6 +6275,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
     "lodash.sortby": {
@@ -6247,6 +6616,15 @@
         }
       }
     },
+    "node-preload": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+      "dev": true,
+      "requires": {
+        "process-on-spawn": "^1.0.0"
+      }
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -6288,6 +6666,68 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
+    },
+    "nyc": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^2.0.0",
+        "get-package-type": "^0.1.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.1",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "yargs": "^15.0.2"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -6480,11 +6920,32 @@
         "p-limit": "^2.2.0"
       }
     },
+    "p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
+    },
+    "package-hash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^5.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      }
     },
     "pako": {
       "version": "0.2.9",
@@ -6735,38 +7196,55 @@
       }
     },
     "playwright-core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.2.1.tgz",
-      "integrity": "sha512-mpDr/Tllr1aGN2Q9FtsxsFOwBHBvwRjoIHafMKhdiq/F3UE52ra2HU4CYB0WdDpPIQqFV2zB+BZwNeAC/nc9Pw==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.16.3.tgz",
+      "integrity": "sha512-16hF27IvQheJee+DbhC941AUZLjbJgfZFWi9YPS4LKEk/lKFhZI+9TiFD0sboYqb9eaEWvul47uR5xxTVbE4iw==",
       "dev": true,
       "requires": {
-        "commander": "^5.1.0",
+        "commander": "^8.2.0",
         "debug": "^4.1.1",
-        "extract-zip": "^2.0.0",
+        "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.0",
-        "jpeg-js": "^0.3.7",
-        "mime": "^2.4.4",
+        "jpeg-js": "^0.4.2",
+        "mime": "^2.4.6",
         "pngjs": "^5.0.0",
         "progress": "^2.0.3",
+        "proper-lockfile": "^4.1.1",
         "proxy-from-env": "^1.1.0",
         "rimraf": "^3.0.2",
-        "ws": "^6.1.0"
+        "socks-proxy-agent": "^6.1.0",
+        "stack-utils": "^2.0.3",
+        "ws": "^7.4.6",
+        "yauzl": "^2.10.0",
+        "yazl": "^2.5.1"
       },
       "dependencies": {
         "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
           "dev": true
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
+        },
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        },
+        "jpeg-js": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz",
+          "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==",
+          "dev": true
         },
         "rimraf": {
           "version": "3.0.2",
@@ -6777,13 +7255,13 @@
             "glob": "^7.1.3"
           }
         },
-        "ws": {
-          "version": "6.2.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-          "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+        "stack-utils": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
+          "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
           "dev": true,
           "requires": {
-            "async-limiter": "~1.0.0"
+            "escape-string-regexp": "^2.0.0"
           }
         }
       }
@@ -6873,6 +7351,15 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "process-on-spawn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+      "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+      "dev": true,
+      "requires": {
+        "fromentries": "^1.2.0"
+      }
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -6906,6 +7393,17 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.4"
+      }
+    },
+    "proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "proxy-addr": {
@@ -7034,6 +7532,15 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
+      }
+    },
+    "release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "dev": true,
+      "requires": {
+        "es6-error": "^4.0.1"
       }
     },
     "remove-trailing-separator": {
@@ -7205,6 +7712,12 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -7229,11 +7742,14 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
     },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-      "dev": true
+    "rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -7575,6 +8091,12 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -7703,6 +8225,47 @@
         }
       }
     },
+    "socks": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
+      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "dev": true,
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.1.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz",
+      "integrity": "sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.1",
+        "socks": "^2.6.1"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "dev": true,
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -7746,16 +8309,50 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "spawn-wrap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+      "dev": true,
+      "requires": {
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "spawnd": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-4.4.0.tgz",
-      "integrity": "sha512-jLPOfB6QOEgMOQY15Z6+lwZEhH3F5ncXxIaZ7WHPIapwNNLyjrs61okj3VJ3K6tmP5TZ6cO0VAu9rEY4MD4YQg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-5.0.0.tgz",
+      "integrity": "sha512-28+AJr82moMVWolQvlAIv3JcYDkjkFTEmfDc503wxrF5l2rQ3dFz6DpbXp3kD4zmgGGldfM4xM4v1sFj/ZaIOA==",
       "dev": true,
       "requires": {
         "exit": "^0.1.2",
-        "signal-exit": "^3.0.2",
+        "signal-exit": "^3.0.3",
         "tree-kill": "^1.2.2",
-        "wait-port": "^0.2.7"
+        "wait-port": "^0.2.9"
       }
     },
     "spdx-correct": {
@@ -8164,6 +8761,12 @@
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
+    "tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -8478,16 +9081,16 @@
       }
     },
     "wait-on": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-3.3.0.tgz",
-      "integrity": "sha512-97dEuUapx4+Y12aknWZn7D25kkjMk16PbWoYzpSdA8bYpVfS6hpl2a2pOWZ3c+Tyt3/i4/pglyZctG3J4V1hWQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-5.3.0.tgz",
+      "integrity": "sha512-DwrHrnTK+/0QFaB9a8Ol5Lna3k7WvUR4jzSKmz0YaPBpuN2sACyiPVKVfj6ejnjcajAcvn3wlbTyMIn9AZouOg==",
       "dev": true,
       "requires": {
-        "@hapi/joi": "^15.0.3",
-        "core-js": "^2.6.5",
-        "minimist": "^1.2.0",
-        "request": "^2.88.0",
-        "rx": "^4.1.0"
+        "axios": "^0.21.1",
+        "joi": "^17.3.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.5",
+        "rxjs": "^6.6.3"
       }
     },
     "wait-port": {
@@ -8508,12 +9111,12 @@
           "dev": true
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         }
       }
@@ -8775,6 +9378,15 @@
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     }
   ],
   "scripts": {
-    "test": "jest --detectOpenHandles --verbose --noStackTrace",
+    "test": "jest --verbose --noStackTrace",
     "test:watch": "jest --detectOpenHandles --watch"
   },
   "dependencies": {},
@@ -48,7 +48,7 @@
     "grunt-html": "~9.3.0",
     "grunt-rollup": "^11.3.0",
     "jest": "^26.1.0",
-    "jest-playwright-preset": "^0.1.3",
+    "jest-playwright-preset": "^1.7.0",
     "leaflet": "^1.7.1",
     "path": "^0.12.7",
     "playwright": "^1.2.1",

--- a/test/e2e/core/axisInferring.test.js
+++ b/test/e2e/core/axisInferring.test.js
@@ -1,62 +1,47 @@
-const playwright = require("playwright");
-jest.setTimeout(30000);
-(async () => {
-  for (const browserType of BROWSER) {
-    let page, browser, context;
-    describe("UI Drag&Drop Test in " + browserType, () => {
-      beforeEach(async () => {
-        browser = await playwright[browserType].launch({
-          headless: ISHEADLESS,
-        });
-        context = await browser.newContext();
-        page = await context.newPage();
-        if (browserType === "firefox") {
-          await page.waitForNavigation();
-        }
-        await page.goto(PATH + "axisInferring.html");
-      });
+describe("UI Drag&Drop Test", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "axisInferring.html");
+  });
 
-      afterEach(async function () {
-        await browser.close();
-      });
+  afterAll(async function () {
+    await context.close();
+  });
 
-      test("[" + browserType + "]" + " TileMatrix inferring", async () => {
-        const layerExtent = await page.$eval(
-          "body > map > layer-:nth-child(1)",
-          (layer) => layer.extent
-        );
+  test("TileMatrix inferring", async () => {
+    const layerExtent = await page.$eval(
+      "body > map > layer-:nth-child(1)",
+      (layer) => layer.extent
+    );
 
-        expect(layerExtent.topLeft.tilematrix[0]).toEqual({ horizontal: 0, vertical: 1 });
-        expect(layerExtent.bottomRight.tilematrix[0]).toEqual({ horizontal: 4, vertical: 5 });
-      });
+    expect(layerExtent.topLeft.tilematrix[0]).toEqual({ horizontal: 0, vertical: 1 });
+    expect(layerExtent.bottomRight.tilematrix[0]).toEqual({ horizontal: 4, vertical: 5 });
+  });
 
-      test("[" + browserType + "]" + " TCRS inferring", async () => {
-        const layerExtent = await page.$eval(
-          "body > map > layer-:nth-child(2)",
-          (layer) => layer.extent
-        );
+  test("TCRS inferring", async () => {
+    const layerExtent = await page.$eval(
+      "body > map > layer-:nth-child(2)",
+      (layer) => layer.extent
+    );
 
-        expect(layerExtent.topLeft.tcrs[0]).toEqual({ horizontal: 0, vertical: 256 });
-        expect(layerExtent.bottomRight.tcrs[0]).toEqual({ horizontal: 256, vertical: 512 });
-      });
+    expect(layerExtent.topLeft.tcrs[0]).toEqual({ horizontal: 0, vertical: 256 });
+    expect(layerExtent.bottomRight.tcrs[0]).toEqual({ horizontal: 256, vertical: 512 });
+  });
 
-      test("[" + browserType + "]" + " PCRS inferring", async () => {
-        const layerExtent = await page.$eval(
-          "body > map > layer-:nth-child(3)",
-          (layer) => layer.extent
-        );
-        expect(layerExtent.topLeft.pcrs).toEqual({ horizontal: 100, vertical: 600 });
-        expect(layerExtent.bottomRight.pcrs).toEqual({ horizontal: 500, vertical: 150 });
-      });
+  test("PCRS inferring", async () => {
+    const layerExtent = await page.$eval(
+      "body > map > layer-:nth-child(3)",
+      (layer) => layer.extent
+    );
+    expect(layerExtent.topLeft.pcrs).toEqual({ horizontal: 100, vertical: 600 });
+    expect(layerExtent.bottomRight.pcrs).toEqual({ horizontal: 500, vertical: 150 });
+  });
 
-      test("[" + browserType + "]" + " GCRS inferring", async () => {
-        const layerExtent = await page.$eval(
-          "body > map > layer-:nth-child(4)",
-          (layer) => layer.extent
-        );
-        expect(layerExtent.topLeft.gcrs).toEqual({ horizontal: -92, vertical: 52.999999999993484 });
-        expect(layerExtent.bottomRight.gcrs).toEqual({ horizontal: -62, vertical: 33.99999999999964 });
-      });
-    });
-  }
-})();
+  test("GCRS inferring", async () => {
+    const layerExtent = await page.$eval(
+      "body > map > layer-:nth-child(4)",
+      (layer) => layer.extent
+    );
+    expect(layerExtent.topLeft.gcrs).toEqual({ horizontal: -92, vertical: 52.999999999993484 });
+    expect(layerExtent.bottomRight.gcrs).toEqual({ horizontal: -62, vertical: 33.99999999999964 });
+  });
+});

--- a/test/e2e/core/debugMode.test.js
+++ b/test/e2e/core/debugMode.test.js
@@ -1,187 +1,168 @@
-const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
+describe("Playwright Map Element Tests", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "debugMode.html");
+  });
 
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright Map Element Tests in " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-            slowMo: 50,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "debugMode.html");
-        });
-
-        afterAll(async function () {
-          await browser.close();
-        });
+  afterAll(async function () {
+    await context.close();
+  });
 
 
-        test("[" + browserType + "]" + " Debug elements added to map", async () => {
-          await page.$eval(
-            "body > mapml-viewer",
-            (map) => map.toggleDebug()
-          );
-
-          const panel = await page.$eval(
-            "div > table.mapml-debug > tbody.mapml-debug-panel",
-            (panelElem) => panelElem.childElementCount
-          );
-
-          const banner = await page.$eval(
-            "div > table.mapml-debug > caption.mapml-debug-banner",
-            (bannerElem) => bannerElem.innerText
-          );
-
-          const grid = await page.$eval(
-            "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid",
-            (gridElem) => gridElem.childElementCount
-          )
-
-          expect(panel).toEqual(6);
-          expect(banner).toEqual("DEBUG MODE");
-          expect(grid).toEqual(1);
-
-        });
-
-        test("[" + browserType + "]" + " Reasonable debug layer extent created", async () => {
-          const feature = await page.$eval(
-            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(2)",
-            (tile) => tile.getAttribute("d")
-          );
-          expect(feature).toEqual("M82.51724137931035 332.27586206896535L347.34482758620686 332.27586206896535L347.34482758620686 -38.48275862068965L82.51724137931035 -38.48275862068965z");
-        });
-
-        test("[" + browserType + "]" + " Large debug layer extent created", async () => {
-          const feature = await page.$eval(
-            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(3)",
-            (tile) => tile.getAttribute("d")
-          );
-          expect(feature).toEqual("M-659 500L365 500L365 -780L-659 -780z");
-        });
-
-        test("[" + browserType + "]" + " Debug layer extent beyond ((0,0), (5,5))  created", async () => {
-          const feature = await page.$eval(
-            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(4)",
-            (tile) => tile.getAttribute("d")
-          );
-          expect(feature).toEqual("M-1683 1268L1133 1268L1133 -1292L-1683 -1292z");
-        });
-
-        test("[" + browserType + "]" + " Accurate debug coordinates", async () => {
-          await page.hover("body > mapml-viewer");
-          const tile = await page.$eval(
-            "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(1)",
-            (tileElem) => tileElem.innerText
-          );
-          const matrix = await page.$eval(
-            "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(2)",
-            (matrixElem) => matrixElem.innerText
-          );
-          const map = await page.$eval(
-            "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(3)",
-            (mapElem) => mapElem.innerText
-          );
-          const tcrs = await page.$eval(
-            "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(4)",
-            (tcrsElem) => tcrsElem.innerText
-          );
-          const pcrs = await page.$eval(
-            "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(5)",
-            (pcrsElem) => pcrsElem.innerText
-          );
-          const gcrs = await page.$eval(
-            "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(6)",
-            (gcrsElem) => gcrsElem.innerText
-          );
-
-          expect(tile).toEqual("tile: i: 141, j: 6");
-          expect(matrix).toEqual("tilematrix: column: 3, row: 4");
-          expect(map).toEqual("map: i: 250, j: 250");
-          expect(tcrs).toEqual("tcrs: x: 909, y: 1030");
-          expect(pcrs).toEqual("pcrs: easting: 217676.00, northing: -205599.86");
-          expect(gcrs).toEqual("gcrs: lon: -92.152897, lat: 47.114275");
-        });
-
-        test("[" + browserType + "]" + " Layer disabled attribute update when controls are toggled off", async () => {
-          await page.$eval(
-            "body > mapml-viewer",
-            (map) => map.toggleDebug()
-          );
-
-          await page.$eval(
-            "body > mapml-viewer",
-            (map) => map.zoomTo(-51, 170, 0)
-          );
-
-          await page.waitForTimeout(1000);
-
-          const layer = await page.$eval(
-            "body > mapml-viewer > layer-:nth-child(1)",
-            (elem) => elem.hasAttribute("disabled")
-          );
-
-          expect(layer).toEqual(true);
-        });
-
-        test("[" + browserType + "]" + " Debug mode correctly re-enabled after disabling", async () => {
-          await page.$eval(
-            "body > mapml-viewer",
-            (map) => map.back()
-          );
-          await page.$eval(
-            "body > mapml-viewer",
-            (map) => map.toggleDebug()
-          );
-
-          const panel = await page.$eval(
-            "div > table.mapml-debug > tbody.mapml-debug-panel",
-            (panelElem) => panelElem.childElementCount
-          );
-
-          const banner = await page.$eval(
-            "div > table.mapml-debug > caption.mapml-debug-banner",
-            (bannerElem) => bannerElem.innerText
-          );
-
-          const grid = await page.$eval(
-            "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid",
-            (gridElem) => gridElem.childElementCount
-          )
-
-          expect(panel).toEqual(6);
-          expect(banner).toEqual("DEBUG MODE");
-          expect(grid).toEqual(1);
-
-        });
-
-        test("[" + browserType + "]" + " Layer deselected then reselected", async () => {
-          await page.hover(".leaflet-top.leaflet-right");
-          await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > div:nth-child(1) > label > span");
-          const feature = await page.$eval(
-            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g",
-            (tile) => tile.childElementCount
-          );
-          expect(feature).toEqual(3);
-        });
-
-        test("[" + browserType + "]" + " Layer deselected then reselected", async () => {
-          await page.hover(".leaflet-top.leaflet-right");
-          await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > div:nth-child(1) > label > span");
-          const feature = await page.$eval(
-            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(4)",
-            (tile) => tile.getAttribute("d")
-          );
-          expect(feature).toEqual("M82.51724137931035 332.27586206896535L347.34482758620686 332.27586206896535L347.34482758620686 -38.48275862068965L82.51724137931035 -38.48275862068965z");
-        });
-      }
+  test("Debug elements added to map", async () => {
+    await page.$eval(
+      "body > mapml-viewer",
+      (map) => map.toggleDebug()
     );
-  }
-})();
+
+    const panel = await page.$eval(
+      "div > table.mapml-debug > tbody.mapml-debug-panel",
+      (panelElem) => panelElem.childElementCount
+    );
+
+    const banner = await page.$eval(
+      "div > table.mapml-debug > caption.mapml-debug-banner",
+      (bannerElem) => bannerElem.innerText
+    );
+
+    const grid = await page.$eval(
+      "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid",
+      (gridElem) => gridElem.childElementCount
+    )
+
+    expect(panel).toEqual(6);
+    expect(banner).toEqual("DEBUG MODE");
+    expect(grid).toEqual(1);
+
+  });
+
+  test("Reasonable debug layer extent created", async () => {
+    const feature = await page.$eval(
+      "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(2)",
+      (tile) => tile.getAttribute("d")
+    );
+    expect(feature).toEqual("M82.51724137931035 332.27586206896535L347.34482758620686 332.27586206896535L347.34482758620686 -38.48275862068965L82.51724137931035 -38.48275862068965z");
+  });
+
+  test("Large debug layer extent created", async () => {
+    const feature = await page.$eval(
+      "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(3)",
+      (tile) => tile.getAttribute("d")
+    );
+    expect(feature).toEqual("M-659 500L365 500L365 -780L-659 -780z");
+  });
+
+  test("Debug layer extent beyond ((0,0), (5,5))  created", async () => {
+    const feature = await page.$eval(
+      "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(4)",
+      (tile) => tile.getAttribute("d")
+    );
+    expect(feature).toEqual("M-1683 1268L1133 1268L1133 -1292L-1683 -1292z");
+  });
+
+  test("Accurate debug coordinates", async () => {
+    await page.hover("body > mapml-viewer");
+    const tile = await page.$eval(
+      "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(1)",
+      (tileElem) => tileElem.innerText
+    );
+    const matrix = await page.$eval(
+      "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(2)",
+      (matrixElem) => matrixElem.innerText
+    );
+    const map = await page.$eval(
+      "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(3)",
+      (mapElem) => mapElem.innerText
+    );
+    const tcrs = await page.$eval(
+      "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(4)",
+      (tcrsElem) => tcrsElem.innerText
+    );
+    const pcrs = await page.$eval(
+      "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(5)",
+      (pcrsElem) => pcrsElem.innerText
+    );
+    const gcrs = await page.$eval(
+      "div > table.mapml-debug > tbody.mapml-debug-panel > tr:nth-child(6)",
+      (gcrsElem) => gcrsElem.innerText
+    );
+
+    expect(tile).toEqual("tile: i: 141, j: 6");
+    expect(matrix).toEqual("tilematrix: column: 3, row: 4");
+    expect(map).toEqual("map: i: 250, j: 250");
+    expect(tcrs).toEqual("tcrs: x: 909, y: 1030");
+    expect(pcrs).toEqual("pcrs: easting: 217676.00, northing: -205599.86");
+    expect(gcrs).toEqual("gcrs: lon: -92.152897, lat: 47.114275");
+  });
+
+  test("Layer disabled attribute update when controls are toggled off", async () => {
+    await page.$eval(
+      "body > mapml-viewer",
+      (map) => map.toggleDebug()
+    );
+
+    await page.$eval(
+      "body > mapml-viewer",
+      (map) => map.zoomTo(-51, 170, 0)
+    );
+
+    await page.waitForTimeout(1000);
+
+    const layer = await page.$eval(
+      "body > mapml-viewer > layer-:nth-child(1)",
+      (elem) => elem.hasAttribute("disabled")
+    );
+
+    expect(layer).toEqual(true);
+  });
+
+  test("Debug mode correctly re-enabled after disabling", async () => {
+    await page.$eval(
+      "body > mapml-viewer",
+      (map) => map.back()
+    );
+    await page.$eval(
+      "body > mapml-viewer",
+      (map) => map.toggleDebug()
+    );
+
+    const panel = await page.$eval(
+      "div > table.mapml-debug > tbody.mapml-debug-panel",
+      (panelElem) => panelElem.childElementCount
+    );
+
+    const banner = await page.$eval(
+      "div > table.mapml-debug > caption.mapml-debug-banner",
+      (bannerElem) => bannerElem.innerText
+    );
+
+    const grid = await page.$eval(
+      "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid",
+      (gridElem) => gridElem.childElementCount
+    )
+
+    expect(panel).toEqual(6);
+    expect(banner).toEqual("DEBUG MODE");
+    expect(grid).toEqual(1);
+
+  });
+
+  test("Layer deselected then reselected", async () => {
+    await page.hover(".leaflet-top.leaflet-right");
+    await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > div:nth-child(1) > label > span");
+    const feature = await page.$eval(
+      "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g",
+      (tile) => tile.childElementCount
+    );
+    expect(feature).toEqual(3);
+  });
+
+  test("Layer deselected then reselected", async () => {
+    await page.hover(".leaflet-top.leaflet-right");
+    await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > div:nth-child(1) > label > span");
+    const feature = await page.$eval(
+      "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(4)",
+      (tile) => tile.getAttribute("d")
+    );
+    expect(feature).toEqual("M82.51724137931035 332.27586206896535L347.34482758620686 332.27586206896535L347.34482758620686 -38.48275862068965L82.51724137931035 -38.48275862068965z");
+  });
+});

--- a/test/e2e/core/drag.test.js
+++ b/test/e2e/core/drag.test.js
@@ -1,111 +1,97 @@
-const playwright = require("playwright");
-jest.setTimeout(30000);
-(async () => {
-  for (const browserType of BROWSER) {
-    let page, browser, context;
-    describe("UI Drag&Drop Test in " + browserType, () => {
-      beforeEach(async () => {
-        browser = await playwright[browserType].launch({
-          headless: ISHEADLESS,
-          slowMo: 50,
-        });
-        context = await browser.newContext();
-        page = await context.newPage();
-        if (browserType === "firefox") {
-          await page.waitForNavigation();
-        }
-        await page.goto(PATH + "drag.html");
-      });
+let page;
+describe("UI Drag&Drop Test", () => {
+  beforeEach(async () => {
+    page = await context.newPage();
+    await page.goto(PATH + "drag.html");
+  });
 
-      afterEach(async function () {
-        await browser.close();
-      });
+  afterAll(async function () {
+    await context.close();
+  });
 
-      test("[" + browserType + "]" + " Drag and drop of invalid HTML page", async () => {
-        const dataTransfer = await page.evaluateHandle(() =>
-          new DataTransfer().setData("text/uri-list", "http://example.com")
-        );
-        await page.dispatchEvent(".leaflet-control-zoom-in", "dragstart", {
-          dataTransfer,
-        });
-
-        await page.dispatchEvent("xpath=//html/body/map", "drop", {
-          dataTransfer,
-        });
-        await page.hover(".leaflet-top.leaflet-right");
-        let vars = await page.$$("xpath=//html/body/map >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset");
-        expect(vars.length).toBe(3);
-      });
-
-      test("[" + browserType + "]" + " Drag and drop of layers", async () => {
-        await page.hover(".leaflet-top.leaflet-right");
-        let control = await page.$("xpath=//html/body/map >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1)");
-        let controlBBox = await control.boundingBox();
-        await page.mouse.move(controlBBox.x + controlBBox.width / 2, controlBBox.y + controlBBox.height / 2);
-        await page.mouse.down();
-        await page.mouse.move(50, 50);
-        await page.mouse.up();
-        await page.hover(".leaflet-top.leaflet-right");
-        let vars = await page.$$("xpath=//html/body/map >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset");
-        expect(vars.length).toBe(3);
-      });
-
-      test("[" + browserType + "]" + " Moving layer down one in control overlay", async () => {
-        await page.hover(".leaflet-top.leaflet-right");
-        let control = await page.$("xpath=//html/body/map >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1)");
-        let controlBBox = await control.boundingBox();
-        await page.mouse.move(controlBBox.x + controlBBox.width / 2, controlBBox.y + controlBBox.height / 2);
-        await page.mouse.down();
-        await page.mouse.move(controlBBox.x + controlBBox.width / 2, (controlBBox.y + controlBBox.height / 2) + 48);
-        await page.mouse.up();
-        await page.hover(".leaflet-top.leaflet-right");
-
-        const controlText = await page.$eval(
-          "xpath=//html/body/map >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(2) > div:nth-child(1) > label > span",
-          (span) => span.innerText
-        );
-        const layerIndex = await page.$eval(
-          "xpath=//html/body/map >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1)",
-          (div) => div.style.zIndex
-        );
-        const domLayer = await page.$eval(
-          "body > map > layer-:nth-child(4)",
-          (div) => div.label
-        );
-
-        expect(controlText.toLowerCase()).toContain(domLayer.toLowerCase());
-        expect(layerIndex).toEqual("2");
-        expect(controlText).toBe("Canada Base Map - Transportation (CBMT)");
-      });
-
-      test("[" + browserType + "]" + " Moving layer up one in control overlay", async () => {
-        await page.hover(".leaflet-top.leaflet-right");
-        let control = await page.$("xpath=//html/body/map >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(2)");
-        let controlBBox = await control.boundingBox();
-        await page.mouse.move(controlBBox.x + controlBBox.width / 2, controlBBox.y + controlBBox.height / 2);
-        await page.mouse.down();
-        await page.mouse.move(controlBBox.x + controlBBox.width / 2, (controlBBox.y + controlBBox.height / 2) - 48);
-        await page.mouse.up();
-        await page.hover(".leaflet-top.leaflet-right");
-
-        const controlText = await page.$eval(
-          "xpath=//html/body/map >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > div:nth-child(1) > label > span",
-          (span) => span.innerText
-        );
-        const layerIndex = await page.$eval(
-          "xpath=//html/body/map >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2)",
-          (div) => div.style.zIndex
-        );
-        const domLayer = await page.$eval(
-          "body > map > layer-:nth-child(3)",
-          (div) => div.label
-        );
-
-        expect(controlText.toLowerCase()).toContain(domLayer.toLowerCase());
-        expect(layerIndex).toEqual("1");
-        expect(controlText).toBe("Static MapML With Tiles");
-      });
-
+  test("Drag and drop of invalid HTML page", async () => {
+    const dataTransfer = await page.evaluateHandle(() =>
+      new DataTransfer().setData("text/uri-list", "http://example.com")
+    );
+    await page.dispatchEvent(".leaflet-control-zoom-in", "dragstart", {
+      dataTransfer,
     });
-  }
-})();
+
+    await page.dispatchEvent("xpath=//html/body/map", "drop", {
+      dataTransfer,
+    });
+    await page.hover(".leaflet-top.leaflet-right");
+    let vars = await page.$$("xpath=//html/body/map >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset");
+    expect(vars.length).toBe(3);
+  });
+
+  test("Drag and drop of layers", async () => {
+    await page.hover(".leaflet-top.leaflet-right");
+    let control = await page.$("xpath=//html/body/map >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1)");
+    let controlBBox = await control.boundingBox();
+    await page.mouse.move(controlBBox.x + controlBBox.width / 2, controlBBox.y + controlBBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(50, 50);
+    await page.mouse.up();
+    await page.hover(".leaflet-top.leaflet-right");
+    let vars = await page.$$("xpath=//html/body/map >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset");
+    expect(vars.length).toBe(3);
+  });
+
+  test("Moving layer down one in control overlay", async () => {
+    await page.hover(".leaflet-top.leaflet-right");
+    let control = await page.$("xpath=//html/body/map >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1)");
+    let controlBBox = await control.boundingBox();
+    await page.mouse.move(controlBBox.x + controlBBox.width / 2, controlBBox.y + controlBBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(controlBBox.x + controlBBox.width / 2, (controlBBox.y + controlBBox.height / 2) + 48);
+    await page.mouse.up();
+    await page.hover(".leaflet-top.leaflet-right");
+
+    const controlText = await page.$eval(
+      "xpath=//html/body/map >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(2) > div:nth-child(1) > label > span",
+      (span) => span.innerText
+    );
+    const layerIndex = await page.$eval(
+      "xpath=//html/body/map >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1)",
+      (div) => div.style.zIndex
+    );
+    const domLayer = await page.$eval(
+      "body > map > layer-:nth-child(4)",
+      (div) => div.label
+    );
+
+    expect(controlText.toLowerCase()).toContain(domLayer.toLowerCase());
+    expect(layerIndex).toEqual("2");
+    expect(controlText).toBe("Canada Base Map - Transportation (CBMT)");
+  });
+
+  test("Moving layer up one in control overlay", async () => {
+    await page.hover(".leaflet-top.leaflet-right");
+    let control = await page.$("xpath=//html/body/map >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(2)");
+    let controlBBox = await control.boundingBox();
+    await page.mouse.move(controlBBox.x + controlBBox.width / 2, controlBBox.y + controlBBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(controlBBox.x + controlBBox.width / 2, (controlBBox.y + controlBBox.height / 2) - 48);
+    await page.mouse.up();
+    await page.hover(".leaflet-top.leaflet-right");
+
+    const controlText = await page.$eval(
+      "xpath=//html/body/map >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > div:nth-child(1) > label > span",
+      (span) => span.innerText
+    );
+    const layerIndex = await page.$eval(
+      "xpath=//html/body/map >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2)",
+      (div) => div.style.zIndex
+    );
+    const domLayer = await page.$eval(
+      "body > map > layer-:nth-child(3)",
+      (div) => div.label
+    );
+
+    expect(controlText.toLowerCase()).toContain(domLayer.toLowerCase());
+    expect(layerIndex).toEqual("1");
+    expect(controlText).toBe("Static MapML With Tiles");
+  });
+
+});

--- a/test/e2e/core/featureLinks.test.js
+++ b/test/e2e/core/featureLinks.test.js
@@ -1,147 +1,144 @@
-const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright Feature Links Tests " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-            slowMo: 100,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "featureLinks.html");
-        });
+describe("Playwright Feature Links Tests", () => {
+    beforeAll(async () => {
+      await page.goto(PATH + "featureLinks.html");
+    });
 
-        afterAll(async function () {
-          await browser.close();
-        });
-        describe("Sub Part Link Tests in " + browserType, () => {
-          test("[" + browserType + "]" + " Sub-point link adds new layer", async () => {
-            for(let i = 0; i < 4; i++)
-              await page.keyboard.press("Tab");
-            await page.keyboard.press("Enter");
-            await page.waitForTimeout(1000);
-            const layers = await page.$eval(
-              "body > map",
-              (map) => map.childElementCount
-            );
-            expect(layers).toEqual(4);
-          });
+    afterAll(async function () {
+      await context.close();
+    });
 
-          test("[" + browserType + "]" + " Sub-point inplace link adds new layer, parent feature has separate link", async () => {
-            await page.hover(".leaflet-top.leaflet-right");
-            await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(2) > div:nth-child(1) > div > button:nth-child(1)");
-            await page.click("body > map");
-            for(let i = 0; i < 6; i++)
-              await page.keyboard.press("Tab");
-            const extentBeforeLink = await page.$eval(
-              "body > map",
-              (map) => map.extent
-            );
-            await page.keyboard.press("Enter");
-            const layers = await page.$eval(
-              "body > map",
-              (map) => map.childElementCount
-            );
-            await page.waitForTimeout(1000);
-            const layerName = await page.$eval(
-              "//html/body/map/layer-[2]",
-              (layer) => layer.label
-            )
-            const extentAfterLink = await page.$eval(
-              "body > map",
-              (map) => map.extent
-            );
+    describe("Sub Part Link Tests", () => {
+      test("Sub-point link adds new layer", async () => {
+        for(let i = 0; i < 4; i++) {
+          await page.keyboard.press("Tab");
+          await page.waitForTimeout(200);
+        }
+        await page.keyboard.press("Enter");
+        await page.waitForTimeout(1000);
+        const layers = await page.$eval(
+          "body > map",
+          (map) => map.childElementCount
+        );
+        expect(layers).toEqual(4);
+      });
 
-            expect(extentAfterLink.topLeft.gcrs).toEqual(extentBeforeLink.topLeft.gcrs);
-            expect(extentAfterLink.bottomRight.gcrs).toEqual(extentBeforeLink.bottomRight.gcrs);
-            expect(layers).toEqual(4);
-            expect(layerName).toEqual("Fire Danger (forecast)");
-          });
-        });
-        describe("Main Part Link Tests in " + browserType, () => {
-          test("[" + browserType + "]" + " Main part adds new layer", async () => {
-            await page.hover(".leaflet-top.leaflet-right");
-            await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(2) > div:nth-child(1) > div > button:nth-child(1)");
-            await page.click("body > map");
-            for(let i = 0; i < 5; i++)
-              await page.keyboard.press("Tab");
-            await page.keyboard.press("Enter");
-            const layers = await page.$eval(
-              "body > map",
-              (map) => map.childElementCount
-            );
-            await page.waitForTimeout(1000);
-            const layerName = await page.$eval(
-              "//html/body/map/layer-[2]",
-              (layer) => layer.label
-            )
-            const extent = await page.$eval(
-              "body > map",
-              (map) => map.extent
-            );
+      test("Sub-point inplace link adds new layer, parent feature has separate link", async () => {
+        await page.hover(".leaflet-top.leaflet-right");
+        await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(2) > div:nth-child(1) > div > button:nth-child(1)");
+        await page.click("body > map");
+        for(let i = 0; i < 6; i++) {
+          await page.keyboard.press("Tab");
+          await page.waitForTimeout(200);
+        }
+        const extentBeforeLink = await page.$eval(
+          "body > map",
+          (map) => map.extent
+        );
+        await page.keyboard.press("Enter");
+        const layers = await page.$eval(
+          "body > map",
+          (map) => map.childElementCount
+        );
+        await page.waitForTimeout(1000);
+        const layerName = await page.$eval(
+          "//html/body/map/layer-[2]",
+          (layer) => layer.label
+        )
+        const extentAfterLink = await page.$eval(
+          "body > map",
+          (map) => map.extent
+        );
 
-            expect(extent.topLeft.gcrs).toEqual({horizontal:-129.071567338887, vertical:36.4112695268206});
-            expect(extent.bottomRight.gcrs).toEqual({horizontal:26.18468754289824, vertical:2.850936151427951});
-            expect(layers).toEqual(4);
-            expect(layerName).toEqual("Canada Base Map - Geometry");
-          });
-        });
-        describe("HTML Link Type Tests in " + browserType, () => {
-          test("[" + browserType + "]" + " HTML _self target navigates to new page", async () => {
-            await page.click("body > map");
-            for(let i = 0; i < 7; i++)
-              await page.keyboard.press("Tab");
-            await page.keyboard.press("Enter");
-            await page.waitForTimeout(1000);
-            const url = await page.url();
-            expect(url).toEqual("http://geogratis.gc.ca/mapml/en/cbmtile/cbmtgeom/");
-          });
-          test("[" + browserType + "]" + " HTML _top target point navigates to new page", async () => {
-            await page.goBack();
-            await page.waitForTimeout(1000);
-            await page.click("body > map");
-            for(let i = 0; i < 8; i++)
-              await page.keyboard.press("Tab");
-            await page.keyboard.press("Enter");
-            await page.waitForTimeout(1000);
-            const url = await page.url();
-            expect(url).toEqual("http://geogratis.gc.ca/mapml/en/cbmtile/fdi/");
-          });
-          test("[" + browserType + "]" + " HTML _parent target point navigates to new page", async () => {
-            await page.goBack();
-            await page.waitForTimeout(1000);
-            await page.click("body > map");
-            for(let i = 0; i < 9; i++)
-              await page.keyboard.press("Tab");
-            await page.keyboard.press("Enter");
-            await page.waitForTimeout(1000);
-            const url = await page.url();
-            expect(url).toEqual("http://geogratis.gc.ca/mapml/en/cbmtile/cbmtgeom/");
-          });
-          test("[" + browserType + "]" + " HTML _blank target projection negotiation with hash", async () => {
-            await page.goBack();
-            await page.waitForTimeout(1000);
-            await page.click("body > map");
-            for(let i = 0; i < 11; i++)
-              await page.keyboard.press("Tab");
-            await page.keyboard.press("Enter");
-            await page.waitForTimeout(1000);
-            const extent = await page.$eval(
-              "body > map",
-              (map) => map.extent
-            );
-            expect(extent.topLeft.gcrs).toEqual({horizontal:-118.38250407225894, vertical:54.364895138267244});
-            expect(extent.bottomRight.gcrs).toEqual({horizontal:-41.67362559864071, vertical:7.463862967414659});
-          });
-        });
-      }
-    );
-  }
-})();
+        expect(extentAfterLink.topLeft.gcrs).toEqual(extentBeforeLink.topLeft.gcrs);
+        expect(extentAfterLink.bottomRight.gcrs).toEqual(extentBeforeLink.bottomRight.gcrs);
+        expect(layers).toEqual(4);
+        expect(layerName).toEqual("Fire Danger (forecast)");
+      });
+    });
+    describe("Main Part Link Tests", () => {
+      test("Main part adds new layer", async () => {
+        await page.hover(".leaflet-top.leaflet-right");
+        await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(2) > div:nth-child(1) > div > button:nth-child(1)");
+        await page.click("body > map");
+        for(let i = 0; i < 5; i++) {
+          await page.keyboard.press("Tab");
+          await page.waitForTimeout(200);
+        }
+        await page.keyboard.press("Enter");
+        const layers = await page.$eval(
+          "body > map",
+          (map) => map.childElementCount
+        );
+        await page.waitForTimeout(1000);
+        const layerName = await page.$eval(
+          "//html/body/map/layer-[2]",
+          (layer) => layer.label
+        )
+        const extent = await page.$eval(
+          "body > map",
+          (map) => map.extent
+        );
+
+        expect(extent.topLeft.gcrs).toEqual({horizontal:-129.071567338887, vertical:36.4112695268206});
+        expect(extent.bottomRight.gcrs).toEqual({horizontal:26.18468754289824, vertical:2.850936151427951});
+        expect(layers).toEqual(4);
+        expect(layerName).toEqual("Canada Base Map - Geometry");
+      });
+    });
+    describe("HTML Link Type Tests", () => {
+      test("HTML _self target navigates to new page", async () => {
+        await page.click("body > map");
+        for(let i = 0; i < 7; i++) {
+          await page.keyboard.press("Tab");
+          await page.waitForTimeout(200);
+        }
+        await page.keyboard.press("Enter");
+        await page.waitForTimeout(1000);
+        const url = await page.url();
+        expect(url).toEqual("http://geogratis.gc.ca/mapml/en/cbmtile/cbmtgeom/");
+      });
+      test("HTML _top target point navigates to new page", async () => {
+        await page.goBack();
+        await page.waitForTimeout(1000);
+        await page.click("body > map");
+        for(let i = 0; i < 8; i++) {
+          await page.keyboard.press("Tab");
+          await page.waitForTimeout(200);
+        }
+        await page.keyboard.press("Enter");
+        await page.waitForTimeout(1000);
+        const url = await page.url();
+        expect(url).toEqual("http://geogratis.gc.ca/mapml/en/cbmtile/fdi/");
+      });
+      test("HTML _parent target point navigates to new page", async () => {
+        await page.goBack();
+        await page.waitForTimeout(1000);
+        await page.click("body > map");
+        for(let i = 0; i < 9; i++) {
+          await page.keyboard.press("Tab");
+          await page.waitForTimeout(200);
+        }
+        await page.keyboard.press("Enter");
+        await page.waitForTimeout(1000);
+        const url = await page.url();
+        expect(url).toEqual("http://geogratis.gc.ca/mapml/en/cbmtile/cbmtgeom/");
+      });
+      test("HTML _blank target projection negotiation with hash", async () => {
+        await page.goBack();
+        await page.waitForTimeout(1000);
+        await page.click("body > map");
+        for(let i = 0; i < 11; i++) {
+          await page.keyboard.press("Tab");
+          await page.waitForTimeout(200);
+        }
+        await page.keyboard.press("Enter");
+        await page.waitForTimeout(1000);
+        const extent = await page.$eval(
+          "body > map",
+          (map) => map.extent
+        );
+        expect(extent.topLeft.gcrs).toEqual({horizontal:-118.38250407225894, vertical:54.364895138267244});
+        expect(extent.bottomRight.gcrs).toEqual({horizontal:-41.67362559864071, vertical:7.463862967414659});
+      });
+    });
+  });

--- a/test/e2e/core/history.test.js
+++ b/test/e2e/core/history.test.js
@@ -1,102 +1,89 @@
-const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
-    for (const browserType of BROWSER) {
-       describe(
-           "History test" + browserType,
-           ()=> {
-               beforeAll(async () => {
-                   browser = await playwright[browserType].launch({
-                       headless: ISHEADLESS,
-                       slowMo: 100,
-                   });
-                   context = await browser.newContext();
-                   page = await context.newPage();
-                   if (browserType === "firefox") {
-                       await page.waitForNavigation();
-                   }
-                   await page.goto(PATH + "mapml-viewer.html");
-               });
-               afterAll(async function () {
-                    await browser.close();
-               });
+describe("History test", ()=> {
+    beforeAll(async () => {
+      await page.goto(PATH + "mapml-viewer.html");
+    });
 
-               //https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/550
-               test("[" + browserType + "]" + " History does not get added to when trying to zoom out at min zoom level", async ()=>{
-                   await page.keyboard.press("Tab");
-                   await page.keyboard.press("Minus");
-                   await page.waitForTimeout(100);
+    afterAll(async function () {
+      await browser.close();
+    });
 
-                   const history = await page.$eval(
-                       "body > mapml-viewer",
-                       (map) => map._history
-                   );
-                   expect(history.length).toEqual(1);
-               });
+    //https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/550
+    test("History does not get added to when trying to zoom out at min zoom level", async ()=>{
+      await page.keyboard.press("Tab");
+      await page.keyboard.press("Minus");
+      await page.waitForTimeout(500);
 
-               test("[" + browserType + "]" + " History values are correct during vertical motion out of projection", async ()=>{
-                    for(let i = 0; i < 3; i++){
-                        await page.keyboard.press("ArrowUp");
-                        await page.waitForTimeout(100);
-                    }
-                    const history = await page.$eval(
-                        "body > mapml-viewer",
-                        (map) => map._history
-                    );
-                    expect(history[2]).toEqual({ zoom: 0, x: 909, y: 870 });
-                    expect(history[3]).toEqual({ zoom: 0, x: 909, y: 790 });
-               });
+      const history = await page.$eval(
+        "body > mapml-viewer",
+        (map) => map._history
+      );
+      expect(history.length).toEqual(1);
+    });
 
-               test("[" + browserType + "]" + " History across zoom levels", async ()=>{
-                    await page.keyboard.press("Equal");
-                    await page.waitForTimeout(100);
-                    //await page.keyboard.press("Minus");
-                    await page.keyboard.press("ArrowUp");
-                    const history = await page.$eval(
-                        "body > mapml-viewer",
-                        (map) => map._history
-                    );
-                    expect(history[4]).toEqual({ zoom: 1, x: 1436, y: 1378 });
-                    //expect(history[5]).toEqual(history[3]);
-                    expect(history[5]).toEqual({ zoom: 1, x: 1436, y: 1298 });
+    test("History values are correct during vertical motion out of projection", async ()=>{
+      for(let i = 0; i < 3; i++){
+        await page.keyboard.press("ArrowUp");
+        await page.waitForTimeout(500);
+      }
+      const history = await page.$eval(
+        "body > mapml-viewer",
+        (map) => map._history
+      );
+      console.log(history)
+      expect(history[2]).toEqual({ zoom: 0, x: 909, y: 870 });
+      expect(history[3]).toEqual({ zoom: 0, x: 909, y: 790 });
+    });
 
-               });
+    test("History across zoom levels", async ()=>{
+      await page.keyboard.press("Equal");
+      await page.waitForTimeout(500);
+      //await page.keyboard.press("Minus");
+      await page.keyboard.press("ArrowUp");
+      await page.waitForTimeout(500);
+      const history = await page.$eval(
+        "body > mapml-viewer",
+        (map) => map._history
+      );
+      expect(history[4]).toEqual({ zoom: 1, x: 1436, y: 1378 });
+      //expect(history[5]).toEqual(history[3]);
+      expect(history[5]).toEqual({ zoom: 1, x: 1436, y: 1298 });
 
-               test("[" + browserType + "]" + " Back function", async ()=>{
-                   await page.$eval(
-                       "body > mapml-viewer",
-                       (map) => map.back()
-                   );
-                   const history = await page.$eval(
-                       "body > mapml-viewer",
-                       (map) => map._history
-                   );
-                   const location = await page.$eval(
-                       "body > mapml-viewer",
-                       (map) => map._map.getPixelBounds().getCenter()
-                   );
-                   expect(location.x).toEqual(history[4].x);
-                   expect(location.y).toEqual(history[4].y);
+    });
 
-               });
+    test("Back function", async ()=>{
+      await page.$eval(
+        "body > mapml-viewer",
+        (map) => map.back()
+      );
+      await page.waitForTimeout(500);
+      const history = await page.$eval(
+        "body > mapml-viewer",
+        (map) => map._history
+      );
+      const location = await page.$eval(
+        "body > mapml-viewer",
+        (map) => map._map.getPixelBounds().getCenter()
+      );
+      expect(location.x).toEqual(history[4].x);
+      expect(location.y).toEqual(history[4].y);
 
-               test("[" + browserType + "]" + " Forward function", async ()=>{
-                   await page.$eval(
-                       "body > mapml-viewer",
-                       (map) => map.forward()
-                   );
-                   const history = await page.$eval(
-                       "body > mapml-viewer",
-                       (map) => map._history
-                   );
-                   const location = await page.$eval(
-                       "body > mapml-viewer",
-                       (map) => map._map.getPixelBounds().getCenter()
-                   );
-                   expect(location.x).toEqual(history[5].x);
-                   expect(location.y).toEqual(history[5].y);
-               });
-           }
-       );
-    }
-})();
+    });
+
+    test("Forward function", async ()=>{
+      await page.$eval(
+        "body > mapml-viewer",
+        (map) => map.forward()
+      );
+      await page.waitForTimeout(500);
+      const history = await page.$eval(
+        "body > mapml-viewer",
+        (map) => map._history
+      );
+      const location = await page.$eval(
+        "body > mapml-viewer",
+        (map) => map._map.getPixelBounds().getCenter()
+      );
+      expect(location.x).toEqual(history[5].x);
+      expect(location.y).toEqual(history[5].y);
+    });
+  });

--- a/test/e2e/core/history.test.js
+++ b/test/e2e/core/history.test.js
@@ -4,7 +4,7 @@ describe("History test", ()=> {
     });
 
     afterAll(async function () {
-      await browser.close();
+      await context.close();
     });
 
     //https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/550
@@ -29,7 +29,7 @@ describe("History test", ()=> {
         "body > mapml-viewer",
         (map) => map._history
       );
-      console.log(history)
+
       expect(history[2]).toEqual({ zoom: 0, x: 909, y: 870 });
       expect(history[3]).toEqual({ zoom: 0, x: 909, y: 790 });
     });

--- a/test/e2e/core/keyboardInteraction.test.js
+++ b/test/e2e/core/keyboardInteraction.test.js
@@ -1,270 +1,267 @@
-const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright Keyboard Navigation + Query Layer Tests in " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-            slowMo: 50,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "keyboardInteraction.html");
-        });
+describe("Playwright Keyboard Navigation + Query Layer Tests" , () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "keyboardInteraction.html");
+  });
 
-        afterAll(async function () {
-          await browser.close();
-        });
-        describe("Crosshair Tests in " + browserType, () => {
-          test("[" + browserType + "]" + " Crosshair hidden onload, shows on focus", async () => {
-            const beforeTabHidden = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
-            await page.keyboard.press("Tab");
-            const afterTab = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
-            expect(beforeTabHidden).toEqual("hidden");
-            expect(afterTab).toEqual("");
-          });
+  afterAll(async function () {
+    await context.close();
+  });
 
-          test("[" + browserType + "]" + " Crosshair remains on map move with arrow keys", async () => {
-            await page.keyboard.press("ArrowUp");
-            await page.waitForTimeout(1000);
-            await page.keyboard.press("ArrowDown");
-            await page.waitForTimeout(1000);
-            await page.keyboard.press("ArrowLeft");
-            await page.waitForTimeout(1000);
-            await page.keyboard.press("ArrowRight");
-            await page.waitForTimeout(1000);
-            const afterMove = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
-            expect(afterMove).toEqual("");
-          });
+  describe("Crosshair Tests", () => {
+    test("Crosshair hidden onload, shows on focus", async () => {
+      const beforeTabHidden = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
+      await page.keyboard.press("Tab");
+      const afterTab = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
+      expect(beforeTabHidden).toEqual("hidden");
+      expect(afterTab).toEqual("");
+    });
 
-          test("[" + browserType + "]" + " Crosshair shows on esc but hidden on tab out", async () => {
-            await page.keyboard.press("Escape");
-            const afterEsc = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
-            await page.click("body");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("ArrowUp");
+    test("Crosshair remains on map move with arrow keys", async () => {
+      await page.keyboard.press("ArrowUp");
+      await page.waitForTimeout(1000);
+      await page.keyboard.press("ArrowDown");
+      await page.waitForTimeout(1000);
+      await page.keyboard.press("ArrowLeft");
+      await page.waitForTimeout(1000);
+      await page.keyboard.press("ArrowRight");
+      await page.waitForTimeout(1000);
+      const afterMove = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
+      expect(afterMove).toEqual("");
+    });
 
-            await page.keyboard.press("Tab");
-            const afterTab = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
+    test("Crosshair shows on esc but hidden on tab out", async () => {
+      await page.keyboard.press("Escape");
+      const afterEsc = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
+      await page.click("body");
+      await page.keyboard.press("Tab");
+      await page.keyboard.press("ArrowUp");
 
-            expect(afterEsc).toEqual("");
-            expect(afterTab).toEqual("hidden");
-          });
+      await page.keyboard.press("Tab");
+      const afterTab = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
 
-          test("[" + browserType + "]" + " Crosshair hidden when queryable layer is unselected, shows on reselect", async () => {
-            await page.click("body");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("ArrowUp");
-            await page.evaluateHandle(() => document.querySelector("layer-").removeAttribute("checked"));
-            const afterUncheck = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
+      expect(afterEsc).toEqual("");
+      expect(afterTab).toEqual("hidden");
+    });
 
-            await page.evaluateHandle(() => document.querySelector("layer-").setAttribute("checked", ""));
-            const afterCheck = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
+    test("Crosshair hidden when queryable layer is unselected, shows on reselect", async () => {
+      await page.click("body");
+      await page.keyboard.press("Tab");
+      await page.keyboard.press("ArrowUp");
+      await page.evaluateHandle(() => document.querySelector("layer-").removeAttribute("checked"));
+      const afterUncheck = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
 
-            expect(afterUncheck).toEqual("hidden");
-            expect(afterCheck).toEqual("");
-          });
-        });
-        describe("Tab Navigable Tests in " + browserType, () => {
-          test("[" + browserType + "]" + " Tab focuses inline features", async () => {
-            await page.click("body");
-            await page.keyboard.press("Tab");
+      await page.evaluateHandle(() => document.querySelector("layer-").setAttribute("checked", ""));
+      const afterCheck = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
 
-            await page.keyboard.press("Tab");
-            const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
-            const resultHandle = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nextHandle);
-            const focused = await (await page.evaluateHandle(elem => elem.getAttribute("d"), resultHandle)).jsonValue();
+      expect(afterUncheck).toEqual("hidden");
+      expect(afterCheck).toEqual("");
+    });
+  });
+  describe("Tab Navigable Tests", () => {
+    test("Tab focuses inline features", async () => {
+      await page.click("body");
+      await page.keyboard.press("Tab");
+      await page.waitForTimeout(500);
+      await page.keyboard.press("Tab");
+      await page.waitForTimeout(500);
+      const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
+      const resultHandle = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nextHandle);
+      const focused = await (await page.evaluateHandle(elem => elem.getAttribute("d"), resultHandle)).jsonValue();
 
-            let tooltipCount = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-tooltip-pane", div => div.childElementCount);
+      let tooltipCount = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-tooltip-pane", div => div.childElementCount);
 
-            await page.keyboard.press("Tab");
-            const aHandleNext = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nextHandleNext = await page.evaluateHandle(doc => doc.shadowRoot, aHandleNext);
-            const resultHandleNext = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nextHandleNext);
-            const focusedNext = await (await page.evaluateHandle(elem => elem.getAttribute("d"), resultHandleNext)).jsonValue();
+      await page.keyboard.press("Tab");
+      await page.waitForTimeout(500);
+      const aHandleNext = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nextHandleNext = await page.evaluateHandle(doc => doc.shadowRoot, aHandleNext);
+      const resultHandleNext = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nextHandleNext);
+      const focusedNext = await (await page.evaluateHandle(elem => elem.getAttribute("d"), resultHandleNext)).jsonValue();
 
-            let tooltipCountNext = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-tooltip-pane", div => div.childElementCount);
+      let tooltipCountNext = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-tooltip-pane", div => div.childElementCount);
 
-            expect(tooltipCount).toEqual(1);
-            expect(tooltipCountNext).toEqual(1);
-            expect(focused).toEqual("M330 83L586 83L586 339L330 339z");
-            expect(focusedNext).toEqual("M153 508L113 146L-161 220L-107 436z");
-          });
+      expect(tooltipCount).toEqual(1);
+      expect(tooltipCountNext).toEqual(1);
+      expect(focused).toEqual("M330 83L586 83L586 339L330 339z");
+      expect(focusedNext).toEqual("M153 508L113 146L-161 220L-107 436z");
+    });
 
-          test("[" + browserType + "]" + " Tab focuses fetched features", async () => {
-            await page.evaluateHandle(() => document.getElementById("vector").setAttribute("checked", ""));
-            await page.click("body");
-            await page.keyboard.press("Tab");
+    test("Tab focuses fetched features", async () => {
+      await page.evaluateHandle(() => document.getElementById("vector").setAttribute("checked", ""));
+      await page.click("body");
+      await page.keyboard.press("Tab");
 
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Tab");
-            const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
-            const resultHandle = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nextHandle);
-            const focused = await (await page.evaluateHandle(elem => elem.getAttribute("d"), resultHandle)).jsonValue();
+      await page.keyboard.press("Tab");
+      await page.keyboard.press("Tab");
+      await page.keyboard.press("Tab");
+      await page.keyboard.press("Tab");
+      const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
+      const resultHandle = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nextHandle);
+      const focused = await (await page.evaluateHandle(elem => elem.getAttribute("d"), resultHandle)).jsonValue();
 
-            await page.keyboard.press("Tab");
-            const aHandleNext = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nextHandleNext = await page.evaluateHandle(doc => doc.shadowRoot, aHandleNext);
-            const resultHandleNext = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nextHandleNext);
-            const focusedNext = await (await page.evaluateHandle(elem => elem.getAttribute("d"), resultHandleNext)).jsonValue();
+      await page.keyboard.press("Tab");
+      const aHandleNext = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nextHandleNext = await page.evaluateHandle(doc => doc.shadowRoot, aHandleNext);
+      const resultHandleNext = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nextHandleNext);
+      const focusedNext = await (await page.evaluateHandle(elem => elem.getAttribute("d"), resultHandleNext)).jsonValue();
 
-            expect(focused).toEqual("M190 357L203 355L206 363L209 374L211 376L212 377L212 378L213 379L211 380L212 381L211 383L212 386L212 388L213 391L210 391L193 393L193 395L195 396L195 398L195 398L194 400L193 400L191 399L191 397L190 397L189 398L189 400L187 400L185 386L185 368L185 358L184 357L190 357z");
-            expect(focusedNext).toEqual("M-30 139L-29 138L-29 139L-30 140L-31 140L-30 139z");
-          });
-        });
+      expect(focused).toEqual("M190 357L203 355L206 363L209 374L211 376L212 377L212 378L213 379L211 380L212 381L211 383L212 386L212 388L213 391L210 391L193 393L193 395L195 396L195 398L195 398L194 400L193 400L191 399L191 397L190 397L189 398L189 400L187 400L185 386L185 368L185 358L184 357L190 357z");
+      expect(focusedNext).toEqual("M-30 139L-29 138L-29 139L-30 140L-31 140L-30 139z");
+    });
+  });
 
-        describe("Feature Popup Tab Navigation Tests in " + browserType, () => {
-          test("[" + browserType + "]" + " Inline features popup focus order", async () => {
-            await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.mapml-reload-button.leaflet-bar.leaflet-control > button");
-            await page.evaluateHandle(() => document.getElementById("vector").removeAttribute("checked"));
-            await page.evaluateHandle(() => document.getElementById("query").removeAttribute("checked"));
-            await page.click("body");
-            await page.keyboard.press("Tab");
+  describe("Feature Popup Tab Navigation Tests", () => {
+    test("Inline features popup focus order", async () => {
+      await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.mapml-reload-button.leaflet-bar.leaflet-control > button");
+      await page.evaluateHandle(() => document.getElementById("vector").removeAttribute("checked"));
+      await page.evaluateHandle(() => document.getElementById("query").removeAttribute("checked"));
+      await page.click("body");
+      await page.keyboard.press("Tab");
 
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Enter");
-            const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
-            const rh = await page.evaluateHandle(root => root.activeElement, nh);
-            const f = await (await page.evaluateHandle(elem => elem.className, rh)).jsonValue();
+      await page.keyboard.press("Tab");
+      await page.keyboard.press("Enter");
+      const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
+      const rh = await page.evaluateHandle(root => root.activeElement, nh);
+      const f = await (await page.evaluateHandle(elem => elem.className, rh)).jsonValue();
 
-            await page.keyboard.press("Tab");
-            const h2 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nh2 = await page.evaluateHandle(doc => doc.shadowRoot, h2);
-            const rh2 = await page.evaluateHandle(root => root.activeElement, nh2);
-            const f2 = await (await page.evaluateHandle(elem => elem.tagName, rh2)).jsonValue();
+      await page.keyboard.press("Tab");
+      const h2 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nh2 = await page.evaluateHandle(doc => doc.shadowRoot, h2);
+      const rh2 = await page.evaluateHandle(root => root.activeElement, nh2);
+      const f2 = await (await page.evaluateHandle(elem => elem.tagName, rh2)).jsonValue();
 
-            await page.keyboard.press("Tab");
-            const h3 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nh3 = await page.evaluateHandle(doc => doc.shadowRoot, h3);
-            const rh3 = await page.evaluateHandle(root => root.activeElement, nh3);
-            const f3 = await (await page.evaluateHandle(elem => elem.title, rh3)).jsonValue();
+      await page.keyboard.press("Tab");
+      const h3 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nh3 = await page.evaluateHandle(doc => doc.shadowRoot, h3);
+      const rh3 = await page.evaluateHandle(root => root.activeElement, nh3);
+      const f3 = await (await page.evaluateHandle(elem => elem.title, rh3)).jsonValue();
 
-            await page.keyboard.press("Tab");
-            const h4 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nh4 = await page.evaluateHandle(doc => doc.shadowRoot, h4);
-            const rh4 = await page.evaluateHandle(root => root.activeElement, nh4);
-            const f4 = await (await page.evaluateHandle(elem => elem.title, rh4)).jsonValue();
+      await page.keyboard.press("Tab");
+      const h4 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nh4 = await page.evaluateHandle(doc => doc.shadowRoot, h4);
+      const rh4 = await page.evaluateHandle(root => root.activeElement, nh4);
+      const f4 = await (await page.evaluateHandle(elem => elem.title, rh4)).jsonValue();
 
-            await page.keyboard.press("Tab");
-            const h5 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nh5 = await page.evaluateHandle(doc => doc.shadowRoot, h5);
-            const rh5 = await page.evaluateHandle(root => root.activeElement, nh5);
-            const f5 = await (await page.evaluateHandle(elem => elem.title, rh5)).jsonValue();
+      await page.keyboard.press("Tab");
+      const h5 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nh5 = await page.evaluateHandle(doc => doc.shadowRoot, h5);
+      const rh5 = await page.evaluateHandle(root => root.activeElement, nh5);
+      const f5 = await (await page.evaluateHandle(elem => elem.title, rh5)).jsonValue();
 
-            await page.keyboard.press("Tab");
-            const h6 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nh6 = await page.evaluateHandle(doc => doc.shadowRoot, h6);
-            const rh6 = await page.evaluateHandle(root => root.activeElement, nh6);
-            const f6 = await (await page.evaluateHandle(elem => elem.title, rh6)).jsonValue();
+      await page.keyboard.press("Tab");
+      const h6 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nh6 = await page.evaluateHandle(doc => doc.shadowRoot, h6);
+      const rh6 = await page.evaluateHandle(root => root.activeElement, nh6);
+      const f6 = await (await page.evaluateHandle(elem => elem.title, rh6)).jsonValue();
 
-            await page.keyboard.press("Tab");
-            const h7 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nh7 = await page.evaluateHandle(doc => doc.shadowRoot, h7);
-            const rh7 = await page.evaluateHandle(root => root.activeElement, nh7);
-            const f7 = await (await page.evaluateHandle(elem => elem.className, rh7)).jsonValue();
+      await page.keyboard.press("Tab");
+      const h7 = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nh7 = await page.evaluateHandle(doc => doc.shadowRoot, h7);
+      const rh7 = await page.evaluateHandle(root => root.activeElement, nh7);
+      const f7 = await (await page.evaluateHandle(elem => elem.className, rh7)).jsonValue();
 
-            expect(f).toEqual("mapml-popup-content");
-            expect(f2.toUpperCase()).toEqual("A");
-            expect(f3).toEqual("Focus Map");
-            expect(f4).toEqual("Previous Feature");
-            expect(f5).toEqual("Next Feature");
-            expect(f6).toEqual("Focus Controls");
-            expect(f7).toEqual("leaflet-popup-close-button");
-          });
+      expect(f).toEqual("mapml-popup-content");
+      expect(f2.toUpperCase()).toEqual("A");
+      expect(f3).toEqual("Focus Map");
+      expect(f4).toEqual("Previous Feature");
+      expect(f5).toEqual("Next Feature");
+      expect(f6).toEqual("Focus Controls");
+      expect(f7).toEqual("leaflet-popup-close-button");
+    });
 
-          test("[" + browserType + "]" + " Tab to next feature after tabbing out of popup", async () => {
-            await page.keyboard.press("Tab");
+    test("Tab to next feature after tabbing out of popup", async () => {
+      await page.keyboard.press("Tab");
+      await page.waitForTimeout(500);
 
-            const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
-            const rh = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nh);
-            const f = await (await page.evaluateHandle(elem => elem.getAttribute("d"), rh)).jsonValue();
+      const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
+      const rh = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nh);
+      const f = await (await page.evaluateHandle(elem => elem.getAttribute("d"), rh)).jsonValue();
 
-            let tooltipCount = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-tooltip-pane", div => div.childElementCount);
+      let tooltipCount = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-tooltip-pane", div => div.childElementCount);
 
-            expect(tooltipCount).toEqual(1);
-            expect(f).toEqual("M153 508L113 146L-161 220L-107 436z");
-          });
+      expect(tooltipCount).toEqual(1);
+      expect(f).toEqual("M153 508L113 146L-161 220L-107 436z");
+    });
 
-          test("[" + browserType + "]" + " Shift + Tab to current feature while popup open", async () => {
-            await page.keyboard.press("Enter");
-            await page.keyboard.press("Shift+Tab");
+    test("Shift + Tab to current feature while popup open", async () => {
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(500);
+      await page.keyboard.press("Shift+Tab");
+      await page.waitForTimeout(500);
 
-            const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
-            const rh = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nh);
-            const f = await (await page.evaluateHandle(elem => elem.getAttribute("d"), rh)).jsonValue();
+      const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
+      const rh = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nh);
+      const f = await (await page.evaluateHandle(elem => elem.getAttribute("d"), rh)).jsonValue();
 
-            let tooltipCount = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-tooltip-pane", div => div.childElementCount);
+      let tooltipCount = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-tooltip-pane", div => div.childElementCount);
 
-            expect(tooltipCount).toEqual(1);
-            expect(f).toEqual("M153 508L113 146L-161 220L-107 436z");
-          });
+      expect(tooltipCount).toEqual(1);
+      expect(f).toEqual("M153 508L113 146L-161 220L-107 436z");
+    });
 
-          test("[" + browserType + "]" + " Previous feature button focuses previous feature", async () => {
-            await page.keyboard.press("Enter");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Enter");
-            const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
-            const rh = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nh);
-            const f = await (await page.evaluateHandle(elem => elem.getAttribute("d"), rh)).jsonValue();
+    test("Previous feature button focuses previous feature", async () => {
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(500);
+      await page.keyboard.press("Tab");
+      await page.waitForTimeout(500);
+      await page.keyboard.press("Tab");
+      await page.waitForTimeout(500);
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(500);
+      const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
+      const rh = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nh);
+      const f = await (await page.evaluateHandle(elem => elem.getAttribute("d"), rh)).jsonValue();
 
-            let tooltipCount = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-tooltip-pane", div => div.childElementCount);
+      let tooltipCount = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-tooltip-pane", div => div.childElementCount);
 
-            expect(tooltipCount).toEqual(1);
-            expect(f).toEqual("M330 83L586 83L586 339L330 339z");
-          });
+      expect(tooltipCount).toEqual(1);
+      expect(f).toEqual("M330 83L586 83L586 339L330 339z");
+    });
 
-          test("[" + browserType + "]" + " Next feature button focuses next feature", async () => {
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Enter");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Enter");
-            const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
-            const rh = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nh);
-            const f = await (await page.evaluateHandle(elem => elem.getAttribute("d"), rh)).jsonValue();
+    test("Next feature button focuses next feature", async () => {
+      await page.keyboard.press("Tab");
+      await page.waitForTimeout(500);
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(500);
+      await page.keyboard.press("Tab");
+      await page.waitForTimeout(500);
+      await page.keyboard.press("Tab");
+      await page.waitForTimeout(500);
+      await page.keyboard.press("Tab");
+      await page.waitForTimeout(500);
+      await page.keyboard.press("Enter");
+      const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
+      const rh = await page.evaluateHandle(root => root.activeElement.querySelector(".leaflet-interactive"), nh);
+      const f = await (await page.evaluateHandle(elem => elem.getAttribute("d"), rh)).jsonValue();
 
-            let tooltipCount = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-tooltip-pane", div => div.childElementCount);
+      let tooltipCount = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-tooltip-pane", div => div.childElementCount);
 
-            expect(tooltipCount).toEqual(1);
-            expect(f).toEqual("M285 373L460 380L468 477L329 459z");
-          });
+      expect(tooltipCount).toEqual(1);
+      expect(f).toEqual("M285 373L460 380L468 477L329 459z");
+    });
 
-          test("[" + browserType + "]" + " Focus Controls focuses the first <button> child in control div", async () => {
-            await page.click("body > mapml-viewer");
-            await page.keyboard.press("Shift+F10");
-            await page.keyboard.press("t");
-            await page.click("body");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Tab");
-            await page.keyboard.press("Enter");
-            for (let i = 0; i < 5; i++)
-              await page.keyboard.press("Tab");
-            await page.keyboard.press("Enter");
-            const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-            const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
-            const rh = await page.evaluateHandle(root => root.activeElement, nh);
-            const f = await (await page.evaluateHandle(elem => elem.innerText, rh)).jsonValue();
-            expect(f).toEqual("Maps4HTML");
-          });
-        });
-      }
-    );
-  }
-})();
+    test("Focus Controls focuses the first <button> child in control div", async () => {
+      await page.click("body > mapml-viewer");
+      await page.keyboard.press("Shift+F10");
+      await page.keyboard.press("t");
+      await page.click("body");
+      await page.keyboard.press("Tab");
+      await page.keyboard.press("Tab");
+      await page.keyboard.press("Enter");
+      for (let i = 0; i < 5; i++)
+        await page.keyboard.press("Tab");
+      await page.keyboard.press("Enter");
+      const h = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+      const nh = await page.evaluateHandle(doc => doc.shadowRoot, h);
+      const rh = await page.evaluateHandle(root => root.activeElement, nh);
+      const f = await (await page.evaluateHandle(elem => elem.innerText, rh)).jsonValue();
+      expect(f).toEqual("Maps4HTML");
+    });
+  });
+});

--- a/test/e2e/core/layerAttributes.test.js
+++ b/test/e2e/core/layerAttributes.test.js
@@ -1,124 +1,101 @@
-const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright Checked Attribute Tests in " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-            slowMo: 50,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "mapml-viewer.html");
-        });
+describe("Playwright Checked Attribute Tests", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "mapml-viewer.html");
+  });
 
-        afterAll(async function () {
-          await browser.close();
-        });
+  afterAll(async function () {
+    await context.close();
+  });
 
-        test("[" + browserType + "]" + " Check attribute removed", async () => {
-          await page.$eval("body > mapml-viewer > layer-",
-            (layer) => layer.removeAttribute("checked"));
-          await page.hover('div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > a');
-          const layerController = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div > label > input",
-            (controller) => controller.checked);
+  test("Check attribute removed", async () => {
+    await page.$eval("body > mapml-viewer > layer-",
+      (layer) => layer.removeAttribute("checked"));
+    await page.hover('div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > a');
+    const layerController = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div > label > input",
+      (controller) => controller.checked);
 
-          expect(layerController).toEqual(false);
-        });
-        test("[" + browserType + "]" + " Check attribute added", async () => {
-          await page.$eval("body > mapml-viewer > layer-",
-            (layer) => layer.setAttribute("checked", ""));
-          const layerController = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div > label > input",
-            (controller) => controller.checked);
+    expect(layerController).toEqual(false);
+  });
+  test("Check attribute added", async () => {
+    await page.$eval("body > mapml-viewer > layer-",
+      (layer) => layer.setAttribute("checked", ""));
+    const layerController = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div > label > input",
+      (controller) => controller.checked);
 
-          expect(layerController).toEqual(true);
-        });
+    expect(layerController).toEqual(true);
+  });
 
-        describe(
-          "Hidden attribute tests in " + browserType,
-          () => {
-            test("[" + browserType + "]" + " Control panel hidden when no layers/all layers hidden", async () => {
-              await page.$eval("body > mapml-viewer > layer-",
-                (layer) => layer.setAttribute("hidden", ""));
-              const controlsHidden = await page.$eval(
-                "css=body > mapml-viewer:nth-child(1) >> css=div > div.leaflet-control-container >> .leaflet-control-layers.leaflet-control",
-                (elem) => elem.hasAttribute("hidden")
-              );
-              expect(controlsHidden).toEqual(true);
-            });
-            test("[" + browserType + "]" + " Control panel unhidden when at least one layer with no hidden attribute", async () => {
-              await page.$eval("body > mapml-viewer > layer-",
-                (layer) => layer.setAttribute("hidden", ""));
-              // there's a single layer in the mapml-viewer.html page, so the layer control
-              // should disappear (is hidden) when the last layer in it is hidden
-              let controlsHidden = await page.$eval(
-                "css=body > mapml-viewer:nth-child(1) >> css=div > div.leaflet-control-container >> .leaflet-control-layers.leaflet-control",
-                (elem) => elem.hasAttribute("hidden")
-              );
-              expect(controlsHidden).toEqual(true);
-              // so far so good
-              await page.$eval("body > mapml-viewer > layer-",
-                (layer) => layer.removeAttribute("hidden"));
-              controlsHidden = await page.$eval(
-                "css=body > mapml-viewer:nth-child(1) >> css=div > div.leaflet-control-container >> .leaflet-control-layers.leaflet-control",
-                (elem) => elem.hasAttribute("hidden")
-              );
-              expect(controlsHidden).toEqual(false);
-            });
-            //        test("[" + browserType + "]" + " Initial map element extent", async () => {
-            //          await page.$eval("body > mapml-viewer > layer-",
-            //            (layer) => layer.setAttribute("checked", ""));
-            //          const layerController = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > details > summary > div > label > input",
-            //            (controller) => controller.checked);
-            //
-            //          expect(layerController).toEqual(true);
-            //        });
-          }
+  describe(
+    "Hidden attribute tests", () => {
+      test("Control panel hidden when no layers/all layers hidden", async () => {
+        await page.$eval("body > mapml-viewer > layer-",
+          (layer) => layer.setAttribute("hidden", ""));
+        const controlsHidden = await page.$eval(
+          "css=body > mapml-viewer:nth-child(1) >> css=div > div.leaflet-control-container >> .leaflet-control-layers.leaflet-control",
+          (elem) => elem.hasAttribute("hidden")
         );
-
-        describe(
-          "Disabled attributes test in " + browserType,
-          () => {
-            test("[" + browserType + "]" + " Setting disabled, attribute reset on update/move", async () => {
-              await page.$eval("body > mapml-viewer > layer-",
-                (layer) => layer.setAttribute("disabled", ""));
-
-              await page.$eval("body > mapml-viewer",
-                (map) => map.zoomTo(47, -92, 0));
-
-              let disabled = await page.$eval("body > mapml-viewer > layer-",
-                (layer) => layer.hasAttribute("disabled", ""));
-              expect(disabled).toEqual(false);
-            });
-          }
+        expect(controlsHidden).toEqual(true);
+      });
+      test("Control panel unhidden when at least one layer with no hidden attribute", async () => {
+        await page.$eval("body > mapml-viewer > layer-",
+          (layer) => layer.setAttribute("hidden", ""));
+        // there's a single layer in the mapml-viewer.html page, so the layer control
+        // should disappear (is hidden) when the last layer in it is hidden
+        let controlsHidden = await page.$eval(
+          "css=body > mapml-viewer:nth-child(1) >> css=div > div.leaflet-control-container >> .leaflet-control-layers.leaflet-control",
+          (elem) => elem.hasAttribute("hidden")
         );
-
-        describe(
-          "Opacity setters & getters test in " + browserType,
-          () => {
-            test("[" + browserType + "]" + " Setting opacity", async () => {
-              await page.reload();
-              await page.$eval("body > mapml-viewer > layer-",
-                (layer) => layer.opacity = 0.4);
-              let value = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details > input[type=range]",
-                (input) => input.value);
-              expect(value).toEqual("0.4");
-            });
-
-            test("[" + browserType + "]" + " Getting appropriate opacity", async () => {
-              let value = await page.$eval("body > mapml-viewer > layer-",
-                (layer) => layer.opacity);
-              expect(value).toEqual("0.4");
-            });
-          }
+        expect(controlsHidden).toEqual(true);
+        // so far so good
+        await page.$eval("body > mapml-viewer > layer-",
+          (layer) => layer.removeAttribute("hidden"));
+        controlsHidden = await page.$eval(
+          "css=body > mapml-viewer:nth-child(1) >> css=div > div.leaflet-control-container >> .leaflet-control-layers.leaflet-control",
+          (elem) => elem.hasAttribute("hidden")
         );
-      }
-    );
-  }
-})();
+        expect(controlsHidden).toEqual(false);
+      });
+      //        test("[" + browserType + "]" + " Initial map element extent", async () => {
+      //          await page.$eval("body > mapml-viewer > layer-",
+      //            (layer) => layer.setAttribute("checked", ""));
+      //          const layerController = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > details > summary > div > label > input",
+      //            (controller) => controller.checked);
+      //
+      //          expect(layerController).toEqual(true);
+      //        });
+    }
+  );
+
+  describe("Disabled attributes test", () => {
+      test("Setting disabled, attribute reset on update/move", async () => {
+        await page.$eval("body > mapml-viewer > layer-",
+          (layer) => layer.setAttribute("disabled", ""));
+
+        await page.$eval("body > mapml-viewer",
+          (map) => map.zoomTo(47, -92, 0));
+
+        let disabled = await page.$eval("body > mapml-viewer > layer-",
+          (layer) => layer.hasAttribute("disabled", ""));
+        expect(disabled).toEqual(false);
+      });
+    }
+  );
+
+  describe("Opacity setters & getters test", () => {
+      test("Setting opacity", async () => {
+        await page.reload();
+        await page.$eval("body > mapml-viewer > layer-",
+          (layer) => layer.opacity = 0.4);
+        let value = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details > input[type=range]",
+          (input) => input.value);
+        expect(value).toEqual("0.4");
+      });
+
+      test("Getting appropriate opacity", async () => {
+        let value = await page.$eval("body > mapml-viewer > layer-",
+          (layer) => layer.opacity);
+        expect(value).toEqual("0.4");
+      });
+    }
+  );
+});

--- a/test/e2e/core/layerContextMenu.test.js
+++ b/test/e2e/core/layerContextMenu.test.js
@@ -1,119 +1,103 @@
-const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright Layer Context Menu Tests in " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-            slowMo: 50,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "layerContextMenu.html");
-        });
+describe("Playwright Layer Context Menu Tests", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "layerContextMenu.html");
+  });
 
-        afterAll(async function () {
-          await browser.close();
-        });
+  afterAll(async function () {
+    await context.close();
+  });
 
-        test("[" + browserType + "]" + " Layer context menu shows when layer is clicked", async () => {
-          await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
-          await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > div:nth-child(1) > label > span",
-            { button: "right" });
+  test("Layer context menu shows when layer is clicked", async () => {
+    await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
+    await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > div:nth-child(1) > label > span",
+      { button: "right" });
 
-          const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-          const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
-          const resultHandle = await page.evaluateHandle(root => root.querySelector(".mapml-contextmenu.mapml-layer-menu"), nextHandle);
+    const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+    const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
+    const resultHandle = await page.evaluateHandle(root => root.querySelector(".mapml-contextmenu.mapml-layer-menu"), nextHandle);
 
-          const menuDisplay = await (await page.evaluateHandle(elem => elem.style.display, resultHandle)).jsonValue();
+    const menuDisplay = await (await page.evaluateHandle(elem => elem.style.display, resultHandle)).jsonValue();
 
-          expect(menuDisplay).toEqual("block");
-        });
+    expect(menuDisplay).toEqual("block");
+  });
 
-        test("[" + browserType + "]" + " Layer context menu copy layer extent", async () => {
-          await page.keyboard.press("c");
-          await page.click("body > textarea");
-          await page.keyboard.press("Control+v");
-          const copyValue = await page.$eval(
-            "body > textarea",
-            (text) => text.value
-          );
-
-          expect(copyValue).toEqual("<map-meta name=\"extent\" content=\"top-left-easting=-6207743.103886206, top-left-northing=10861943.103886206, bottom-right-easting=3952277.216154434, bottom-right-northing=-3362085.3441706896\"></map-meta>");
-        });
-
-        test("[" + browserType + "]" + " Map zooms in to layer 2", async () => {
-          await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
-          await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(2) > div:nth-child(1) > label > span",
-            { button: "right" });
-          await page.keyboard.press("z");
-          await page.waitForTimeout(1000);
-          const mapLocation = await page.$eval(
-            "body > mapml-viewer",
-            (text) => text._map.getPixelBounds()
-          );
-
-          const mapZoom = await page.$eval(
-            "body > mapml-viewer",
-            (text) => text._map.getZoom()
-          );
-
-          expect(mapZoom).toEqual(11);
-          expect(mapLocation).toEqual({ max: { x: 43130, y: 43130 }, min: { x: 42630, y: 42630 } });
-        });
-
-        test("[" + browserType + "]" + " Map zooms out to layer 3", async () => {
-          for (let i = 0; i < 5; i++)
-            await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-in");
-
-          await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
-          await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(3) > div:nth-child(1) > label > span",
-            { button: "right" });
-          await page.keyboard.press("z");
-          await page.waitForTimeout(1000);
-          const mapLocation = await page.$eval(
-            "body > mapml-viewer",
-            (text) => text._map.getPixelBounds()
-          );
-
-          const mapZoom = await page.$eval(
-            "body > mapml-viewer",
-            (text) => text._map.getZoom()
-          );
-
-          expect(mapZoom).toEqual(11);
-          expect(mapLocation).toEqual({ max: { x: 43130, y: 43557 }, min: { x: 42630, y: 43057 } });
-        });
-
-        test("[" + browserType + "]" + " Map zooms out to layer 4", async () => {
-          for (let i = 0; i < 5; i++)
-            await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-in");
-
-          await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
-          await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(4) > div:nth-child(1) > label > span",
-            { button: "right" });
-          await page.keyboard.press("z");
-          await page.waitForTimeout(1000);
-          const mapLocation = await page.$eval(
-            "body > mapml-viewer",
-            (text) => text._map.getPixelBounds()
-          );
-
-          const mapZoom = await page.$eval(
-            "body > mapml-viewer",
-            (text) => text._map.getZoom()
-          );
-
-          expect(mapZoom).toEqual(5);
-          expect(mapLocation).toEqual({ max: { x: 8084, y: 8084 }, min: { x: 7584, y: 7584 } });
-        });
-      }
+  test("Layer context menu copy layer extent", async () => {
+    await page.keyboard.press("c");
+    await page.click("body > textarea");
+    await page.keyboard.press("Control+v");
+    const copyValue = await page.$eval(
+      "body > textarea",
+      (text) => text.value
     );
-  }
-})();
+
+    expect(copyValue).toEqual("<map-meta name=\"extent\" content=\"top-left-easting=-6207743.103886206, top-left-northing=10861943.103886206, bottom-right-easting=3952277.216154434, bottom-right-northing=-3362085.3441706896\"></map-meta>");
+  });
+
+  test("Map zooms in to layer 2", async () => {
+    await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
+    await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(2) > div:nth-child(1) > label > span",
+      { button: "right" });
+    await page.keyboard.press("z");
+    await page.waitForTimeout(1000);
+    const mapLocation = await page.$eval(
+      "body > mapml-viewer",
+      (text) => text._map.getPixelBounds()
+    );
+
+    const mapZoom = await page.$eval(
+      "body > mapml-viewer",
+      (text) => text._map.getZoom()
+    );
+
+    expect(mapZoom).toEqual(11);
+    expect(mapLocation).toEqual({ max: { x: 43130, y: 43130 }, min: { x: 42630, y: 42630 } });
+  });
+
+  test("Map zooms out to layer 3", async () => {
+    for (let i = 0; i < 5; i++) {
+      await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-in");
+      await page.waitForTimeout(200);
+    }
+    await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
+    await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(3) > div:nth-child(1) > label > span",
+      { button: "right" });
+    await page.keyboard.press("z");
+    await page.waitForTimeout(1000);
+    const mapLocation = await page.$eval(
+      "body > mapml-viewer",
+      (text) => text._map.getPixelBounds()
+    );
+
+    const mapZoom = await page.$eval(
+      "body > mapml-viewer",
+      (text) => text._map.getZoom()
+    );
+
+    expect(mapZoom).toEqual(11);
+    expect(mapLocation).toEqual({ max: { x: 43130, y: 43557 }, min: { x: 42630, y: 43057 } });
+  });
+
+  test("Map zooms out to layer 4", async () => {
+    for (let i = 0; i < 5; i++) {
+      await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-in");
+      await page.waitForTimeout(200);
+    }
+    await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
+    await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(4) > div:nth-child(1) > label > span",
+      { button: "right" });
+    await page.keyboard.press("z");
+    await page.waitForTimeout(1000);
+    const mapLocation = await page.$eval(
+      "body > mapml-viewer",
+      (text) => text._map.getPixelBounds()
+    );
+
+    const mapZoom = await page.$eval(
+      "body > mapml-viewer",
+      (text) => text._map.getZoom()
+    );
+
+    expect(mapZoom).toEqual(5);
+    expect(mapLocation).toEqual({ max: { x: 8084, y: 8084 }, min: { x: 7584, y: 7584 } });
+  });
+});

--- a/test/e2e/core/mapContextMenu.test.js
+++ b/test/e2e/core/mapContextMenu.test.js
@@ -1,247 +1,228 @@
-const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
+//expected topLeft values in the different cs, at the different
+//positions the map goes in
+let expectedPCRS = [
+  { horizontal: -9373489.01871137, vertical: 11303798.154262971 },
+  { horizontal: -5059449.140631609, vertical: 10388337.990009308 }];
+let expectedGCRS = [
+  { horizontal: -128.07848522325827, vertical: -3.3883427348651636 },
+  { horizontal: -131.75138842058425, vertical: 18.07246131233218 }];
+let expectedFirstTileMatrix = [
+  { horizontal: 2.57421875, vertical: 2.8515625 },
+  { horizontal: 3.0134698275862073, vertical: 2.944773706896552 }];
+let expectedFirstTCRS = [
+  { horizontal: 659, vertical: 730 },
+  { horizontal: 771.4482758620691, vertical: 753.8620689655173 }];
 
-  //expected topLeft values in the different cs, at the different
-  //positions the map goes in
-  let expectedPCRS = [
-    { horizontal: -9373489.01871137, vertical: 11303798.154262971 },
-    { horizontal: -5059449.140631609, vertical: 10388337.990009308 }];
-  let expectedGCRS = [
-    { horizontal: -128.07848522325827, vertical: -3.3883427348651636 },
-    { horizontal: -131.75138842058425, vertical: 18.07246131233218 }];
-  let expectedFirstTileMatrix = [
-    { horizontal: 2.57421875, vertical: 2.8515625 },
-    { horizontal: 3.0134698275862073, vertical: 2.944773706896552 }];
-  let expectedFirstTCRS = [
-    { horizontal: 659, vertical: 730 },
-    { horizontal: 771.4482758620691, vertical: 753.8620689655173 }];
+describe("Playwright Map Context Menu Tests", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "mapElement.html");
+  });
 
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright Map Context Menu Tests in " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-            slowMo: 50,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "mapElement.html");
-        });
+  afterAll(async function () {
+    await context.close();
+  });
 
-        afterAll(async function () {
-          await browser.close();
-        });
+  test("Context menu focus on keyboard shortcut", async () => {
+    await page.click("body > map");
+    await page.keyboard.press("Shift+F10");
+    const aHandle = await page.evaluateHandle(() => document.querySelector(".mapml-web-map"));
+    const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
+    const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
+    const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
+    let name = await nameHandle.jsonValue();
+    await nameHandle.dispose();
+    expect(name).toEqual("Back (B)");
+  });
 
-        test("[" + browserType + "]" + " Context menu focus on keyboard shortcut", async () => {
-          await page.click("body > map");
-          await page.keyboard.press("Shift+F10");
-          const aHandle = await page.evaluateHandle(() => document.querySelector(".mapml-web-map"));
-          const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
-          const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
-          const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
-          let name = await nameHandle.jsonValue();
-          await nameHandle.dispose();
-          expect(name).toEqual("Back (B)");
-        });
+  test("Context menu tab goes to next item", async () => {
+    await page.keyboard.press("Tab");
+    const aHandle = await page.evaluateHandle(() => document.querySelector(".mapml-web-map"));
+    const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
+    const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
+    const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
+    let name = await nameHandle.jsonValue();
+    await nameHandle.dispose();
+    expect(name).toEqual("Forward (F)");
+  });
 
-        test("[" + browserType + "]" + " Context menu tab goes to next item", async () => {
-          await page.keyboard.press("Tab");
-          const aHandle = await page.evaluateHandle(() => document.querySelector(".mapml-web-map"));
-          const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
-          const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
-          const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
-          let name = await nameHandle.jsonValue();
-          await nameHandle.dispose();
-          expect(name).toEqual("Forward (F)");
-        });
+  test("Submenu opens on C with focus on first item", async () => {
+    await page.keyboard.press("c");
+    const aHandle = await page.evaluateHandle(() => document.querySelector(".mapml-web-map"));
+    const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
+    const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
+    const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
+    let name = await nameHandle.jsonValue();
+    await nameHandle.dispose();
+    expect(name).toEqual("tile");
+  });
 
-        test("[" + browserType + "]" + " Submenu opens on C with focus on first item", async () => {
-          await page.keyboard.press("c");
-          const aHandle = await page.evaluateHandle(() => document.querySelector(".mapml-web-map"));
-          const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
-          const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
-          const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
-          let name = await nameHandle.jsonValue();
-          await nameHandle.dispose();
-          expect(name).toEqual("tile");
-        });
-
-        test("[" + browserType + "]" + " Context menu displaying on map", async () => {
-          await page.click("body > map", { button: "right" });
-          const contextMenu = await page.$eval(
-            "div > div.mapml-contextmenu",
-            (menu) => menu.style.display
-          );
-          expect(contextMenu).toEqual("block");
-        });
-        test("[" + browserType + "]" + " Context menu, back item", async () => {
-          await page.$eval(
-            "body > map",
-            (map) => map.zoomTo(81, -63, 1)
-          );
-          await page.waitForTimeout(1000);
-          await page.click("body > map", { button: "right" });
-          await page.click("div > div.mapml-contextmenu > button:nth-child(1)");
-          await page.waitForTimeout(1000);
-          const extent = await page.$eval(
-            "body > map",
-            (map) => map.extent
-          );
-
-          expect(extent.projection).toEqual("CBMTILE");
-          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
-          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
-          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
-          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
-          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
-        });
-        test("[" + browserType + "]" + " Context menu, back item at intial location", async () => {
-          await page.click("body > map", { button: "right" });
-          await page.click("div > div.mapml-contextmenu > button:nth-child(1)");
-          await page.waitForTimeout(1000);
-          const extent = await page.$eval(
-            "body > map",
-            (map) => map.extent
-          );
-
-          expect(extent.projection).toEqual("CBMTILE");
-          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
-          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
-          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
-          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
-          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
-        });
-        test("[" + browserType + "]" + " Context menu, forward item", async () => {
-          await page.click("body > map", { button: "right" });
-          await page.click("div > div.mapml-contextmenu > button:nth-child(2)");
-          await page.waitForTimeout(1000);
-          const extent = await page.$eval(
-            "body > map",
-            (map) => map.extent
-          );
-
-          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
-          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
-          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
-          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
-          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
-        });
-        test("[" + browserType + "]" + " Context menu, forward item at most recent location", async () => {
-          await page.click("body > map", { button: "right" });
-          await page.click("div > div.mapml-contextmenu > button:nth-child(2)");
-          await page.waitForTimeout(1000);
-          const extent = await page.$eval(
-            "body > map",
-            (map) => map.extent
-          );
-
-          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
-          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
-          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
-          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
-          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
-        });
-
-        describe("Context Menu, Toggle Controls " + browserType, () => {
-          test("[" + browserType + "]" + " Context menu, toggle controls off", async () => {
-            const controlsOn = await page.$eval(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
-              (controls) => controls.childElementCount
-            );
-
-            await page.click("body > map", { button: "right" });
-            await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
-
-            const controlsOff = await page.$eval(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
-              (controls) => controls.childElementCount
-            );
-
-            expect(controlsOn).toEqual(3);
-            expect(controlsOff).toEqual(0);
-          });
-
-          test("[" + browserType + "]" + " Context menu, toggle controls on", async () => {
-            const controlsOn = await page.$eval(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
-              (controls) => controls.childElementCount
-            );
-
-            await page.click("body > map", { button: "right" });
-            await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
-
-            const controlsOff = await page.$eval(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
-              (controls) => controls.childElementCount
-            );
-
-            expect(controlsOn).toEqual(0);
-            expect(controlsOff).toEqual(3);
-          });
-
-          test("[" + browserType + "]" + " Context menu, toggle controls after changing opacity", async () => {
-            await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
-            await page.click(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div > div > button:nth-child(2)",
-            );
-            await page.$eval(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details",
-              (div) => div.open = true
-            );
-            await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details > input");
-            const valueBefore = await page.$eval(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details > input",
-              (opacity) => opacity.value
-            );
-            expect(valueBefore).toEqual("0.5");
-
-            await page.click("body > map", { button: "right" });
-            await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
-            await page.click("body > map", { button: "right" });
-            await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
-
-            const valueAfter = await page.$eval(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details > input",
-              (opacity) => opacity.value
-            );
-
-            expect(valueAfter).toEqual("0.5");
-          });
-        });
-
-        test("[" + browserType + "]" + " Submenu, copy all coordinate systems using tab + enter to access", async () => {
-          await page.click("body > map");
-          await page.keyboard.press("Shift+F10");
-
-          for (let i = 0; i < 4; i++)
-            await page.keyboard.press("Tab");
-
-          await page.keyboard.press("Enter");
-          await page.click("#mapml-copy-submenu > button:nth-child(10)");
-
-          await page.click("body > textarea");
-          await page.keyboard.press("Control+v");
-          const copyValue = await page.$eval(
-            "body > textarea",
-            (text) => text.value
-          );
-          let expected = "z:1\n";
-          expected += "tile: i:30, j:50\n";
-          expected += "tilematrix: column:6, row:6\n";
-          expected += "map: i:250, j:300\n";
-          expected += "tcrs: x:1566, y:1586\n";
-          expected += "pcrs: easting:562957.94, northing:3641449.50\n";
-          expected += "gcrs: lon :-62.729466, lat:80.881921";
-
-          expect(copyValue).toEqual(expected);
-        });
-      }
+  test("Context menu displaying on map", async () => {
+    await page.click("body > map", { button: "right" });
+    const contextMenu = await page.$eval(
+      "div > div.mapml-contextmenu",
+      (menu) => menu.style.display
     );
-  }
-})();
+    expect(contextMenu).toEqual("block");
+  });
+  test("Context menu, back item", async () => {
+    await page.$eval(
+      "body > map",
+      (map) => map.zoomTo(81, -63, 1)
+    );
+    await page.waitForTimeout(1000);
+    await page.click("body > map", { button: "right" });
+    await page.click("div > div.mapml-contextmenu > button:nth-child(1)");
+    await page.waitForTimeout(1000);
+    const extent = await page.$eval(
+      "body > map",
+      (map) => map.extent
+    );
+
+    expect(extent.projection).toEqual("CBMTILE");
+    expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+    expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
+    expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
+    expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
+    expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
+  });
+  test("Context menu, back item at intial location", async () => {
+    await page.click("body > map", { button: "right" });
+    await page.click("div > div.mapml-contextmenu > button:nth-child(1)");
+    await page.waitForTimeout(1000);
+    const extent = await page.$eval(
+      "body > map",
+      (map) => map.extent
+    );
+
+    expect(extent.projection).toEqual("CBMTILE");
+    expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+    expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
+    expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
+    expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
+    expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
+  });
+  test("Context menu, forward item", async () => {
+    await page.click("body > map", { button: "right" });
+    await page.click("div > div.mapml-contextmenu > button:nth-child(2)");
+    await page.waitForTimeout(1000);
+    const extent = await page.$eval(
+      "body > map",
+      (map) => map.extent
+    );
+
+    expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+    expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
+    expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
+    expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
+    expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
+  });
+  test("Context menu, forward item at most recent location", async () => {
+    await page.click("body > map", { button: "right" });
+    await page.click("div > div.mapml-contextmenu > button:nth-child(2)");
+    await page.waitForTimeout(1000);
+    const extent = await page.$eval(
+      "body > map",
+      (map) => map.extent
+    );
+
+    expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+    expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
+    expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
+    expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
+    expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
+  });
+
+  describe("Context Menu, Toggle Controls ", () => {
+    test("Context menu, toggle controls off", async () => {
+      const controlsOn = await page.$eval(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
+        (controls) => controls.childElementCount
+      );
+
+      await page.click("body > map", { button: "right" });
+      await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
+
+      const controlsOff = await page.$eval(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
+        (controls) => controls.childElementCount
+      );
+
+      expect(controlsOn).toEqual(3);
+      expect(controlsOff).toEqual(0);
+    });
+
+    test("Context menu, toggle controls on", async () => {
+      const controlsOn = await page.$eval(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
+        (controls) => controls.childElementCount
+      );
+
+      await page.click("body > map", { button: "right" });
+      await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
+
+      const controlsOff = await page.$eval(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
+        (controls) => controls.childElementCount
+      );
+
+      expect(controlsOn).toEqual(0);
+      expect(controlsOff).toEqual(3);
+    });
+
+    test("Context menu, toggle controls after changing opacity", async () => {
+      await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
+      await page.click(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div > div > button:nth-child(2)",
+      );
+      await page.$eval(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details",
+        (div) => div.open = true
+      );
+      await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details > input");
+      const valueBefore = await page.$eval(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details > input",
+        (opacity) => opacity.value
+      );
+      expect(valueBefore).toEqual("0.5");
+
+      await page.click("body > map", { button: "right" });
+      await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
+      await page.click("body > map", { button: "right" });
+      await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
+
+      const valueAfter = await page.$eval(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details > input",
+        (opacity) => opacity.value
+      );
+
+      expect(valueAfter).toEqual("0.5");
+    });
+  });
+
+  test("Submenu, copy all coordinate systems using tab + enter to access", async () => {
+    await page.click("body > map");
+    await page.keyboard.press("Shift+F10");
+
+    for (let i = 0; i < 4; i++)
+      await page.keyboard.press("Tab");
+
+    await page.keyboard.press("Enter");
+    await page.click("#mapml-copy-submenu > button:nth-child(10)");
+
+    await page.click("body > textarea");
+    await page.keyboard.press("Control+v");
+    const copyValue = await page.$eval(
+      "body > textarea",
+      (text) => text.value
+    );
+    let expected = "z:1\n";
+    expected += "tile: i:30, j:50\n";
+    expected += "tilematrix: column:6, row:6\n";
+    expected += "map: i:250, j:300\n";
+    expected += "tcrs: x:1566, y:1586\n";
+    expected += "pcrs: easting:562957.94, northing:3641449.50\n";
+    expected += "gcrs: lon :-62.729466, lat:80.881921";
+
+    expect(copyValue).toEqual(expected);
+  });
+});

--- a/test/e2e/core/mapElement.test.js
+++ b/test/e2e/core/mapElement.test.js
@@ -1,106 +1,87 @@
+//expected topLeft values in the different cs, at the different
+//positions the map goes in
 const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
+let expectedPCRS = [
+  { horizontal: -9373489.01871137, vertical: 11303798.154262971 },
+  { horizontal: -5059449.140631609, vertical: 10388337.990009308 }];
+let expectedGCRS = [
+  { horizontal: -128.07848522325827, vertical: -3.3883427348651636 },
+  { horizontal: -131.75138842058425, vertical: 18.07246131233218 }];
+let expectedFirstTileMatrix = [
+  { horizontal: 2.57421875, vertical: 2.8515625 },
+  { horizontal: 3.0134698275862073, vertical: 2.944773706896552 }];
+let expectedFirstTCRS = [
+  { horizontal: 659, vertical: 730 },
+  { horizontal: 771.4482758620691, vertical: 753.8620689655173 }];
 
-  //expected topLeft values in the different cs, at the different
-  //positions the map goes in
-  let expectedPCRS = [
-    { horizontal: -9373489.01871137, vertical: 11303798.154262971 },
-    { horizontal: -5059449.140631609, vertical: 10388337.990009308 }];
-  let expectedGCRS = [
-    { horizontal: -128.07848522325827, vertical: -3.3883427348651636 },
-    { horizontal: -131.75138842058425, vertical: 18.07246131233218 }];
-  let expectedFirstTileMatrix = [
-    { horizontal: 2.57421875, vertical: 2.8515625 },
-    { horizontal: 3.0134698275862073, vertical: 2.944773706896552 }];
-  let expectedFirstTCRS = [
-    { horizontal: 659, vertical: 730 },
-    { horizontal: 771.4482758620691, vertical: 753.8620689655173 }];
+describe("Playwright Map Element Tests", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "mapElement.html");
+  });
 
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright Map Element Tests in " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-            slowMo: 50,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "mapElement.html");
-        });
+  afterAll(async function () {
+    await context.close();
+  });
 
-        afterAll(async function () {
-          await browser.close();
-        });
-
-        test("[" + browserType + "]" + " Initial map element extent", async () => {
-          const extent = await page.$eval(
-            "body > map",
-            (map) => map.extent
-          );
-
-          expect(extent.projection).toEqual("CBMTILE");
-          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
-          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
-          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
-          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
-          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
-        });
-        test("[" + browserType + "]" + " Panned and zoomed initial map's extent", async () => {
-          await page.$eval(
-            "body > map",
-            (map) => map.zoomTo(81, -63, 1)
-          );
-          await page.waitForTimeout(1000);
-          const extent = await page.$eval(
-            "body > map",
-            (map) => map.extent
-          );
-
-          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
-          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
-          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
-          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
-          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
-        });
-
-        test("[" + browserType + "]" + " Reload button takes you back to initial state", async () => {
-          await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.mapml-reload-button.leaflet-bar.leaflet-control > button");
-          await page.waitForTimeout(1000);
-          const extent = await page.$eval(
-            "body > map",
-            (map) => map.extent
-          );
-
-          const history = await page.$eval(
-            "body > map",
-            (map) => map._history
-          );
-
-          expect(history.length).toEqual(1);
-          expect(extent.projection).toEqual("CBMTILE");
-          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
-          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
-          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
-          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
-          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
-        });
-
-        test("[" + browserType + "]" + " Default projection, when no projection attribute, is OSMTILE", async () => {
-          const projection = await page.$eval(
-            "body > map[id=default-projection]",
-            (map) => map.projection
-          );
-  
-          expect(projection).toEqual("OSMTILE");
-          });
-
-    }
+  test("Initial map element extent", async () => {
+    const extent = await page.$eval(
+      "body > map",
+      (map) => map.extent
     );
-  }
-})();
+
+    expect(extent.projection).toEqual("CBMTILE");
+    expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+    expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
+    expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
+    expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
+    expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
+  });
+  test("Panned and zoomed initial map's extent", async () => {
+    await page.$eval(
+      "body > map",
+      (map) => map.zoomTo(81, -63, 1)
+    );
+    await page.waitForTimeout(1000);
+    const extent = await page.$eval(
+      "body > map",
+      (map) => map.extent
+    );
+
+    expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+    expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
+    expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
+    expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
+    expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
+  });
+
+  test("Reload button takes you back to initial state", async () => {
+    await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.mapml-reload-button.leaflet-bar.leaflet-control > button");
+    await page.waitForTimeout(1000);
+    const extent = await page.$eval(
+      "body > map",
+      (map) => map.extent
+    );
+
+    const history = await page.$eval(
+      "body > map",
+      (map) => map._history
+    );
+
+    expect(history.length).toEqual(1);
+    expect(extent.projection).toEqual("CBMTILE");
+    expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+    expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
+    expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
+    expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
+    expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
+  });
+
+  test("Default projection, when no projection attribute, is OSMTILE", async () => {
+    const projection = await page.$eval(
+      "body > map[id=default-projection]",
+      (map) => map.projection
+    );
+
+    expect(projection).toEqual("OSMTILE");
+  });
+});

--- a/test/e2e/core/mapSpan.test.js
+++ b/test/e2e/core/mapSpan.test.js
@@ -1,62 +1,46 @@
 const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
-    for (const browserType of BROWSER) {
-        describe(
-            "<map-span> test " + browserType,
-            ()=> {
-                beforeAll(async () => {
-                    browser = await playwright[browserType].launch({
-                        headless: ISHEADLESS,
-                        slowMo: 100,
-                    });
-                    context = await browser.newContext();
-                    page = await context.newPage();
-                    if (browserType === "firefox") {
-                        await page.waitForNavigation();
-                    }
-                    await page.goto(PATH + "mapSpan.html");
-                });
-                afterAll(async function () {
-                    await browser.close();
-                });
+describe("<map-span> test ", ()=> {
+  beforeAll(async () => {
+    await page.goto(PATH + "mapSpan.html");
+  });
 
-                test("[" + browserType + "]" + " <map-span> hides tile boundaries", async ()=>{
-                    const total = await page.$eval(
-                        'body > mapml-viewer:nth-child(1) div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(1) > svg > g > g:nth-child(1) > path:nth-child(2)',
-                        (path) => path.getAttribute("style")
-                    );
+  afterAll(async function () {
+    await context.close();
+  });
 
-                    const featureOutline = await page.$(
-                        'body > mapml-viewer:nth-child(1) div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(1) > svg > g > g:nth-child(1) > path.fclass._2.mapml-feature-outline'
-                    );
+  test("<map-span> hides tile boundaries", async ()=>{
+    const total = await page.$eval(
+      'body > mapml-viewer:nth-child(1) div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(1) > svg > g > g:nth-child(1) > path:nth-child(2)',
+      (path) => path.getAttribute("style")
+    );
 
-                    const hidden = await page.$eval(
-                        'body > mapml-viewer:nth-child(1) div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(1) > svg > g > g:nth-child(1) > path.noline.fclass._2',
-                        (path) => path.getAttribute("d")
-                    );
-                    expect(featureOutline).not.toBe(null);
+    const featureOutline = await page.$(
+      'body > mapml-viewer:nth-child(1) div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(1) > svg > g > g:nth-child(1) > path.fclass._2.mapml-feature-outline'
+    );
 
-                    const d = await featureOutline.getAttribute("d");
-                    const spliced = await hidden.slice(3, hidden.length);
-                    //Makes sure that the part that should be hidden is not part of the feature outline
-                    let index = d.indexOf(spliced);
+    const hidden = await page.$eval(
+      'body > mapml-viewer:nth-child(1) div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(1) > svg > g > g:nth-child(1) > path.noline.fclass._2',
+      (path) => path.getAttribute("d")
+    );
+    expect(featureOutline).not.toBe(null);
 
-                    expect(total).toEqual("stroke: none;");
-                    expect(index).toEqual(-1);
-                });
+    const d = await featureOutline.getAttribute("d");
+    const spliced = await hidden.slice(3, hidden.length);
+    //Makes sure that the part that should be hidden is not part of the feature outline
+    let index = d.indexOf(spliced);
 
-                //https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/559#issuecomment-959805896
-                test("[" + browserType + "]" + " White space parsing for map-coordinates", async ()=>{
-                    await page.waitForTimeout(1000);
-                    const feature = await page.$eval(
-                        'body > mapml-viewer:nth-child(2) div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(1) > svg > g > g > path.fclass.mapml-feature-outline',
-                        (path) => path.getAttribute("d")
-                    );
+    expect(total).toEqual("stroke: none;");
+    expect(index).toEqual(-1);
+  });
 
-                    expect(feature).toEqual("M0 217L0 217L0 217L2 217L4 218L6 218L6 218L6 216L2 214L0 216L0 216");
-                });
-            }
-        );
-    }
-})();
+  //https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/559#issuecomment-959805896
+  test("White space parsing for map-coordinates", async ()=>{
+    await page.waitForTimeout(1000);
+    const feature = await page.$eval(
+      'body > mapml-viewer:nth-child(2) div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(1) > svg > g > g > path.fclass.mapml-feature-outline',
+      (path) => path.getAttribute("d")
+    );
+
+    expect(feature).toEqual("M0 217L0 217L0 217L2 217L4 218L6 218L6 218L6 216L2 214L0 216L0 216");
+  });
+});

--- a/test/e2e/core/metaDefault.test.js
+++ b/test/e2e/core/metaDefault.test.js
@@ -1,97 +1,81 @@
-jest.setTimeout(50000);
 const playwright = require("playwright");
 
-(async () => {
+let expectedPCRSFirstLayer = {
+  topLeft: {
+    horizontal: -3263369.215138428,
+    vertical: 4046262.80585894,
+  },
+  bottomRight: {
+    horizontal: 3823752.959105924,
+    vertical: -1554448.395563461,
+  },
+}, expectedGCRSFirstLayer = {
+  topLeft: {
+    horizontal: -125.78104358919225,
+    vertical: 56.11474703973131,
+  },
+  bottomRight: {
+    horizontal: -5.116088318047697,
+    vertical: 28.87016583287855,
+  },
+};
 
-  let expectedPCRSFirstLayer = {
-    topLeft: {
-      horizontal: -3263369.215138428,
-      vertical: 4046262.80585894,
-    },
-    bottomRight: {
-      horizontal: 3823752.959105924,
-      vertical: -1554448.395563461,
-    },
-  }, expectedGCRSFirstLayer = {
-    topLeft: {
-      horizontal: -125.78104358919225,
-      vertical: 56.11474703973131,
-    },
-    bottomRight: {
-      horizontal: -5.116088318047697,
-      vertical: 28.87016583287855,
-    },
-  };
+let expectedPCRSSecondLayer = {
+  topLeft: {
+    horizontal: -7786477,
+    vertical: 7928344,
+  },
+  bottomRight: {
+    horizontal: 7148753,
+    vertical: -927808,
+  },
+}, expectedGCRSSecondLayer = {
+  topLeft: {
+    horizontal: -155.3514099767017,
+    vertical: 22.2852694215843,
+  },
+  bottomRight: {
+    horizontal: 32.23057852696884,
+    vertical: 10.170068283825733,
+  },
+};
 
-  let expectedPCRSSecondLayer = {
-    topLeft: {
-      horizontal: -7786477,
-      vertical: 7928344,
-    },
-    bottomRight: {
-      horizontal: 7148753,
-      vertical: -927808,
-    },
-  }, expectedGCRSSecondLayer = {
-    topLeft: {
-      horizontal: -155.3514099767017,
-      vertical: 22.2852694215843,
-    },
-    bottomRight: {
-      horizontal: 32.23057852696884,
-      vertical: 10.170068283825733,
-    },
-  };
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright Missing Min Max Attribute, Meta Default Tests in " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "metaDefault.html");
-        });
+describe("Playwright Missing Min Max Attribute, Meta Default Tests", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "metaDefault.html");
+  });
 
-        afterAll(async function () {
-          await browser.close();
-        });
+  afterAll(async function () {
+    await context.close();
+  });
 
-        test("[" + browserType + "]" + " Inline layer extent test", async () => {
-          const extent = await page.$eval(
-            "body > mapml-viewer > layer-:nth-child(1)",
-            (layer) => layer.extent
-          );
-          expect(extent.hasOwnProperty("zoom")).toBeTruthy();
-          expect(extent.hasOwnProperty("topLeft")).toBeTruthy();
-          expect(extent.hasOwnProperty("bottomRight")).toBeTruthy();
-          expect(extent.hasOwnProperty("projection")).toBeTruthy();
-          expect(extent.topLeft.pcrs).toEqual(expectedPCRSFirstLayer.topLeft);
-          expect(extent.bottomRight.pcrs).toEqual(expectedPCRSFirstLayer.bottomRight);
-          expect(extent.topLeft.gcrs).toEqual(expectedGCRSFirstLayer.topLeft);
-          expect(extent.bottomRight.gcrs).toEqual(expectedGCRSFirstLayer.bottomRight);
-        });
-        test("[" + browserType + "]" + " Fetched layer extent test", async () => {
-          const extent = await page.$eval(
-            "body > mapml-viewer > layer-:nth-child(2)",
-            (layer) => layer.extent
-          );
-
-          expect(extent.hasOwnProperty("zoom")).toBeTruthy();
-          expect(extent.hasOwnProperty("topLeft")).toBeTruthy();
-          expect(extent.hasOwnProperty("bottomRight")).toBeTruthy();
-          expect(extent.hasOwnProperty("projection")).toBeTruthy();
-          expect(extent.topLeft.pcrs).toEqual(expectedPCRSSecondLayer.topLeft);
-          expect(extent.bottomRight.pcrs).toEqual(expectedPCRSSecondLayer.bottomRight);
-          expect(extent.topLeft.gcrs).toEqual(expectedGCRSSecondLayer.topLeft);
-          expect(extent.bottomRight.gcrs).toEqual(expectedGCRSSecondLayer.bottomRight);
-        });
-      }
+  test("Inline layer extent test", async () => {
+    const extent = await page.$eval(
+      "body > mapml-viewer > layer-:nth-child(1)",
+      (layer) => layer.extent
     );
-  }
-})();
+    expect(extent.hasOwnProperty("zoom")).toBeTruthy();
+    expect(extent.hasOwnProperty("topLeft")).toBeTruthy();
+    expect(extent.hasOwnProperty("bottomRight")).toBeTruthy();
+    expect(extent.hasOwnProperty("projection")).toBeTruthy();
+    expect(extent.topLeft.pcrs).toEqual(expectedPCRSFirstLayer.topLeft);
+    expect(extent.bottomRight.pcrs).toEqual(expectedPCRSFirstLayer.bottomRight);
+    expect(extent.topLeft.gcrs).toEqual(expectedGCRSFirstLayer.topLeft);
+    expect(extent.bottomRight.gcrs).toEqual(expectedGCRSFirstLayer.bottomRight);
+  });
+  test("Fetched layer extent test", async () => {
+    const extent = await page.$eval(
+      "body > mapml-viewer > layer-:nth-child(2)",
+      (layer) => layer.extent
+    );
+
+    expect(extent.hasOwnProperty("zoom")).toBeTruthy();
+    expect(extent.hasOwnProperty("topLeft")).toBeTruthy();
+    expect(extent.hasOwnProperty("bottomRight")).toBeTruthy();
+    expect(extent.hasOwnProperty("projection")).toBeTruthy();
+    expect(extent.topLeft.pcrs).toEqual(expectedPCRSSecondLayer.topLeft);
+    expect(extent.bottomRight.pcrs).toEqual(expectedPCRSSecondLayer.bottomRight);
+    expect(extent.topLeft.gcrs).toEqual(expectedGCRSSecondLayer.topLeft);
+    expect(extent.bottomRight.gcrs).toEqual(expectedGCRSSecondLayer.bottomRight);
+  });
+});

--- a/test/e2e/core/mismatchedLayerWithMap.test.js
+++ b/test/e2e/core/mismatchedLayerWithMap.test.js
@@ -1,28 +1,15 @@
 const playwright = require("playwright");
-jest.setTimeout(30000);
+describe("Playwright Mismatched Layers Test", () => {
+  beforeEach(async () => {
+    await page.goto(PATH);
+  });
 
-(async () => {
-  for (const browserType of BROWSER) {
-    let page, browser, context;
-    describe("Playwright Mismatched Layers Test in " + browserType, () => {
-      beforeEach(async () => {
-        browser = await playwright[browserType].launch({
-          headless: ISHEADLESS,
-        });
-        context = await browser.newContext();
-        page = await context.newPage();
-        if (browserType === "firefox") {
-          await page.waitForNavigation();
-        }
-        await page.goto(PATH);
-      });
+  afterAll(async function () {
+    await context.close();
+  });
 
-      afterEach(async function () {
-        await browser.close();
-      });
-
-      test("[" + browserType + "] " + "CBMTILE Map with OSMTILE layer", async () => {
-        await page.setContent(`
+  test("CBMTILE Map with OSMTILE layer", async () => {
+    await page.setContent(`
         <!doctype html>
             <html>
             <head>
@@ -41,19 +28,19 @@ jest.setTimeout(30000);
             </body>
             </html>
         `);
-        await page.waitForLoadState('networkidle');
-        await page.hover('div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > a');
-        const cbmtileLayer = await page.$eval("body > map > layer-:nth-child(1)",
-          (controller) => controller.hasAttribute('disabled'));
-        const osmtileLayer = await page.$eval("#checkMe",
-          (controller) => controller.hasAttribute('disabled'))
+    await page.waitForLoadState('networkidle');
+    await page.hover('div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > a');
+    const cbmtileLayer = await page.$eval("body > map > layer-:nth-child(1)",
+      (controller) => controller.hasAttribute('disabled'));
+    const osmtileLayer = await page.$eval("#checkMe",
+      (controller) => controller.hasAttribute('disabled'))
 
-        expect(cbmtileLayer).toEqual(false);
-        expect(osmtileLayer).toEqual(true);
-      });
+    expect(cbmtileLayer).toEqual(false);
+    expect(osmtileLayer).toEqual(true);
+  });
 
-      test("[" + browserType + "] " + "OSMTILE Map with CBMTILE layer", async () => {
-        await page.setContent(`
+  test("OSMTILE Map with CBMTILE layer", async () => {
+    await page.setContent(`
         <!doctype html>
             <html>
             <head>
@@ -72,28 +59,26 @@ jest.setTimeout(30000);
             </body>
             </html>
         `);
-        await page.waitForLoadState('networkidle');
-        await page.hover('div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > a');
-        const cbmtileLayer = await page.$eval("#checkMe",
-          (controller) => controller.hasAttribute('disabled'));
-        const osmtileLayer = await page.$eval("body > mapml-viewer > layer-:nth-child(2)",
-          (controller) => controller.hasAttribute('disabled'))
+    await page.waitForLoadState('networkidle');
+    await page.hover('div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > a');
+    const cbmtileLayer = await page.$eval("#checkMe",
+      (controller) => controller.hasAttribute('disabled'));
+    const osmtileLayer = await page.$eval("body > mapml-viewer > layer-:nth-child(2)",
+      (controller) => controller.hasAttribute('disabled'))
 
-        await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
-        await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > div:nth-child(1) > label > span",
-          { button: "right" });
+    await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
+    await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > div:nth-child(1) > label > span",
+      { button: "right" });
 
-        const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-        const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
-        const resultHandle = await page.evaluateHandle(root => root.querySelector(".mapml-contextmenu.mapml-layer-menu"), nextHandle);
+    const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+    const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
+    const resultHandle = await page.evaluateHandle(root => root.querySelector(".mapml-contextmenu.mapml-layer-menu"), nextHandle);
 
-        const menuDisplay = await (await page.evaluateHandle(elem => elem.style.display, resultHandle)).jsonValue();
+    const menuDisplay = await (await page.evaluateHandle(elem => elem.style.display, resultHandle)).jsonValue();
 
-        expect(menuDisplay).toEqual("");
+    expect(menuDisplay).toEqual("");
 
-        expect(cbmtileLayer).toEqual(true);
-        expect(osmtileLayer).toEqual(false);
-      });
-    });
-  }
-})();
+    expect(cbmtileLayer).toEqual(true);
+    expect(osmtileLayer).toEqual(false);
+  });
+});

--- a/test/e2e/core/missingMetaParameters.test.js
+++ b/test/e2e/core/missingMetaParameters.test.js
@@ -1,126 +1,111 @@
 const playwright = require("playwright");
-//Could use more tests
-jest.setTimeout(30000);
-(async () => {
-  for (const browserType of BROWSER) {
-    let page, browser, context;
-    describe("Missing Parameters Test in " + browserType, () => {
-      beforeEach(async () => {
-        browser = await playwright[browserType].launch({
-          headless: ISHEADLESS,
-        });
-        context = await browser.newContext();
-        page = await context.newPage();
-        if (browserType === "firefox") {
-          await page.waitForNavigation();
-        }
-        await page.goto(PATH + "missingMetaParameters.html");
-      });
+describe("Missing Parameters Test", () => {
+  beforeEach(async () => {
+    await page.goto(PATH + "missingMetaParameters.html");
+  });
 
-      afterEach(async function () {
-        await browser.close();
-      });
+  afterAll(async function () {
+    await context.close();
+  });
 
-      test("[" + browserType + "]" + " Static features with missing <map-meta name='zoom'></map-meta> & <map-meta name='extent'></map-meta>", async () => {
-        const layerController = await page.$eval("body > map:nth-child(1) > layer-:nth-child(1)",
-          (controller) => controller.extent);
+  test("Static features with missing <map-meta name='zoom'></map-meta> & <map-meta name='extent'></map-meta>", async () => {
+    const layerController = await page.$eval("body > map:nth-child(1) > layer-:nth-child(1)",
+      (controller) => controller.extent);
 
-        expect(layerController.topLeft.pcrs).toEqual({
-          horizontal: -34655800,
-          vertical: 39310000,
-        });
-        expect(layerController.bottomRight.pcrs).toEqual({
-          horizontal: 14450964.88019643,
-          vertical: -39260823.80831429,
-        });
-        expect(layerController.zoom).toEqual({
-          maxNativeZoom: 4,
-          minNativeZoom: 2,
-          minZoom: 0,
-          maxZoom: 25
-        });
-      });
-
-      test("[" + browserType + "]" + " Static tiles with missing <map-meta name='zoom'></map-meta>", async () => {
-        const layerController = await page.$eval("body > map:nth-child(1) > layer-:nth-child(3)",
-          (controller) => controller.extent);
-
-        expect(layerController.topLeft.pcrs).toEqual({
-          horizontal: -4175739.0398780815,
-          vertical: 5443265.599864535,
-        });
-        expect(layerController.bottomRight.pcrs).toEqual({
-          horizontal: 5984281.280162558,
-          vertical: -1330081.280162558,
-        });
-        expect(layerController.zoom).toEqual({
-          maxNativeZoom: 3,
-          minNativeZoom: 2,
-          minZoom: 1,
-          maxZoom: 4,
-          nativeZoom: 2,
-        });
-      });
-
-      test("[" + browserType + "]" + " Templated features with missing <map-meta name='zoom'></map-meta>", async () => {
-        const layerController = await page.$eval("body > map:nth-child(1) > layer-:nth-child(2)",
-          (controller) => controller.extent);
-
-        expect(layerController.topLeft.pcrs).toEqual({
-          horizontal: 1501645.2210838948,
-          vertical: -66110.70639331453,
-        });
-        expect(layerController.bottomRight.pcrs).toEqual({
-          horizontal: 1617642.4028044068,
-          vertical: -222452.18449031282,
-        });
-        expect(layerController.zoom).toEqual({
-          maxNativeZoom: 18,
-          minNativeZoom: 2,
-          minZoom: 0,
-          maxZoom: 25
-        });
-      });
-
-      test("[" + browserType + "]" + " Templated tiles with missing <map-meta name='zoom'></map-meta> & extent", async () => {
-        const layerController = await page.$eval("body > map:nth-child(2) > layer-",
-          (controller) => controller.extent);
-
-        expect(layerController.topLeft.pcrs).toEqual({
-          horizontal: -180,
-          vertical: 90,
-        });
-        expect(layerController.bottomRight.pcrs).toEqual({
-          horizontal: 180,
-          vertical: -90,
-        });
-        expect(layerController.zoom).toEqual({
-          maxNativeZoom: 2,
-          minNativeZoom: 0,
-          minZoom: 0,
-          maxZoom: 21
-        });
-      });
-
-      test("[" + browserType + "]" + " Templated image with missing <map-meta name='zoom'></map-meta>", async () => {
-        const layerController = await page.$eval("body > map:nth-child(1) > layer-:nth-child(4)",
-          (controller) => controller.extent);
-
-        expect(layerController.topLeft.pcrs).toEqual({
-          horizontal: 28448056,
-          vertical: 42672085,
-        });
-        expect(layerController.bottomRight.pcrs).toEqual({
-          horizontal: 38608077,
-          vertical: 28448056,
-        });
-        expect(layerController.zoom).toEqual({
-          maxNativeZoom: 19,
-          minNativeZoom: 0,
-          minZoom: 0,
-          maxZoom: 25
-        });
-      });
+    expect(layerController.topLeft.pcrs).toEqual({
+      horizontal: -34655800,
+      vertical: 39310000,
     });
-  }
-})();
+    expect(layerController.bottomRight.pcrs).toEqual({
+      horizontal: 14450964.88019643,
+      vertical: -39260823.80831429,
+    });
+    expect(layerController.zoom).toEqual({
+      maxNativeZoom: 4,
+      minNativeZoom: 2,
+      minZoom: 0,
+      maxZoom: 25
+    });
+  });
+
+  test("Static tiles with missing <map-meta name='zoom'></map-meta>", async () => {
+    const layerController = await page.$eval("body > map:nth-child(1) > layer-:nth-child(3)",
+      (controller) => controller.extent);
+
+    expect(layerController.topLeft.pcrs).toEqual({
+      horizontal: -4175739.0398780815,
+      vertical: 5443265.599864535,
+    });
+    expect(layerController.bottomRight.pcrs).toEqual({
+      horizontal: 5984281.280162558,
+      vertical: -1330081.280162558,
+    });
+    expect(layerController.zoom).toEqual({
+      maxNativeZoom: 3,
+      minNativeZoom: 2,
+      minZoom: 1,
+      maxZoom: 4,
+      nativeZoom: 2,
+    });
+  });
+
+  test("Templated features with missing <map-meta name='zoom'></map-meta>", async () => {
+    const layerController = await page.$eval("body > map:nth-child(1) > layer-:nth-child(2)",
+      (controller) => controller.extent);
+
+    expect(layerController.topLeft.pcrs).toEqual({
+      horizontal: 1501645.2210838948,
+      vertical: -66110.70639331453,
+    });
+    expect(layerController.bottomRight.pcrs).toEqual({
+      horizontal: 1617642.4028044068,
+      vertical: -222452.18449031282,
+    });
+    expect(layerController.zoom).toEqual({
+      maxNativeZoom: 18,
+      minNativeZoom: 2,
+      minZoom: 0,
+      maxZoom: 25
+    });
+  });
+
+  test("Templated tiles with missing <map-meta name='zoom'></map-meta> & extent", async () => {
+    const layerController = await page.$eval("body > map:nth-child(2) > layer-",
+      (controller) => controller.extent);
+
+    expect(layerController.topLeft.pcrs).toEqual({
+      horizontal: -180,
+      vertical: 90,
+    });
+    expect(layerController.bottomRight.pcrs).toEqual({
+      horizontal: 180,
+      vertical: -90,
+    });
+    expect(layerController.zoom).toEqual({
+      maxNativeZoom: 2,
+      minNativeZoom: 0,
+      minZoom: 0,
+      maxZoom: 21
+    });
+  });
+
+  test("Templated image with missing <map-meta name='zoom'></map-meta>", async () => {
+    const layerController = await page.$eval("body > map:nth-child(1) > layer-:nth-child(4)",
+      (controller) => controller.extent);
+
+    expect(layerController.topLeft.pcrs).toEqual({
+      horizontal: 28448056,
+      vertical: 42672085,
+    });
+    expect(layerController.bottomRight.pcrs).toEqual({
+      horizontal: 38608077,
+      vertical: 28448056,
+    });
+    expect(layerController.zoom).toEqual({
+      maxNativeZoom: 19,
+      minNativeZoom: 0,
+      minZoom: 0,
+      maxZoom: 25
+    });
+  });
+});

--- a/test/e2e/core/projectionChange.test.js
+++ b/test/e2e/core/projectionChange.test.js
@@ -1,120 +1,104 @@
 const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright Projection Change Tests " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-            slowMo: 100,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "projectionChange.html");
-        });
+describe("Playwright Projection Change Tests", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "projectionChange.html");
+  });
 
-        afterAll(async function () {
-          await browser.close();
-        });
-        describe("Linked Feature Projection Change Tests in " + browserType, () => {
-          test("[" + browserType + "]" + " _self Linked Feature Change To OSMTILE", async () => {
-            for(let i = 0; i < 2; i++)
-              await page.keyboard.press("Tab");
-            await page.keyboard.press("Enter");
-            await page.waitForTimeout(2000);
-            const isChecked = await page.$eval(
-              "body > map:nth-child(1) > layer-",
-              (layer) => layer.checked
-            );
-            const isDisabled = await page.$eval(
-              "body > map:nth-child(1) > layer-",
-              (layer) => layer.disabled
-            );
-            expect(isChecked).toBeTruthy();
-            expect(isDisabled).toEqual(false);
-          });
+  afterAll(async function () {
+    await context.close();
+  });
 
-          test("[" + browserType + "]" + " _parent Linked Feature Change To OSMTILE", async () => {
-            for(let i = 0; i < 10; i++)
-              await page.keyboard.press("Tab");
-            await page.keyboard.press("Enter");
-            await page.waitForTimeout(2000);
-            const isChecked = await page.$eval(
-              "body > map:nth-child(1) > layer-",
-              (layer) => layer.checked
-            );
-            const isDisabled = await page.$eval(
-              "body > map:nth-child(1) > layer-",
-              (layer) => layer.disabled
-            );
-            expect(isChecked).toBeTruthy();
-            expect(isDisabled).toEqual(false);
-          });
+  describe("Linked Feature Projection Change Tests", () => {
+    test("_self Linked Feature Change To OSMTILE", async () => {
+      for(let i = 0; i < 2; i++)
+        await page.keyboard.press("Tab");
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(2000);
+      const isChecked = await page.$eval(
+        "body > map:nth-child(1) > layer-",
+        (layer) => layer.checked
+      );
+      const isDisabled = await page.$eval(
+        "body > map:nth-child(1) > layer-",
+        (layer) => layer.disabled
+      );
+      expect(isChecked).toBeTruthy();
+      expect(isDisabled).toEqual(false);
+    });
 
-          test("[" + browserType + "]" + " Debug components update with projection changes", async () => {
-            await page.reload();
-            await page.$eval(
-              "body > map:nth-child(1)",
-              (map) => map.toggleDebug()
-            );
+    test("_parent Linked Feature Change To OSMTILE", async () => {
+      for(let i = 0; i < 10; i++)
+        await page.keyboard.press("Tab");
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(2000);
+      const isChecked = await page.$eval(
+        "body > map:nth-child(1) > layer-",
+        (layer) => layer.checked
+      );
+      const isDisabled = await page.$eval(
+        "body > map:nth-child(1) > layer-",
+        (layer) => layer.disabled
+      );
+      expect(isChecked).toBeTruthy();
+      expect(isDisabled).toEqual(false);
+    });
 
-            const colBefore = await page.$eval(
-              "xpath=//html/body/map[1] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid > div > div:nth-child(1)",
-              (tile) => tile.getAttribute("col")
-            );
-            const rowBefore = await page.$eval(
-              "xpath=//html/body/map[1] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid > div > div:nth-child(1)",
-              (tile) => tile.getAttribute("row")
-            );
-            const zoomBefore = await page.$eval(
-              "xpath=//html/body/map[1] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid > div > div:nth-child(1)",
-              (tile) => tile.getAttribute("zoom")
-            );
+    test("Debug components update with projection changes", async () => {
+      await page.reload();
+      await page.$eval(
+        "body > map:nth-child(1)",
+        (map) => map.toggleDebug()
+      );
 
-            const centerBefore = await page.$eval(
-              "xpath=//html/body/map[1] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(1)",
-              (path) => path.getAttribute("d")
-            )
+      const colBefore = await page.$eval(
+        "xpath=//html/body/map[1] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid > div > div:nth-child(1)",
+        (tile) => tile.getAttribute("col")
+      );
+      const rowBefore = await page.$eval(
+        "xpath=//html/body/map[1] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid > div > div:nth-child(1)",
+        (tile) => tile.getAttribute("row")
+      );
+      const zoomBefore = await page.$eval(
+        "xpath=//html/body/map[1] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid > div > div:nth-child(1)",
+        (tile) => tile.getAttribute("zoom")
+      );
 
-            for(let i = 0; i < 2; i++)
-              await page.keyboard.press("Tab");
-            await page.keyboard.press("Enter");
-            await page.waitForTimeout(2000);
+      const centerBefore = await page.$eval(
+        "xpath=//html/body/map[1] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(1)",
+        (path) => path.getAttribute("d")
+      )
 
-            const colAfter = await page.$eval(
-              "xpath=//html/body/map[1] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid > div > div:nth-child(1)",
-              (tile) => tile.getAttribute("col")
-            );
-            const rowAfter = await page.$eval(
-              "xpath=//html/body/map[1] >> css=div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid > div > div:nth-child(1)",
-              (tile) => tile.getAttribute("row")
-            );
-            const zoomAfter = await page.$eval(
-              "xpath=//html/body/map[1] >> css=div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid > div > div:nth-child(1)",
-              (tile) => tile.getAttribute("zoom")
-            );
+      for(let i = 0; i < 2; i++)
+        await page.keyboard.press("Tab");
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(2000);
 
-            const centerAfter = await page.$eval(
-              "xpath=//html/body/map[1] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(1)",
-              (path) => path.getAttribute("d")
-            )
+      const colAfter = await page.$eval(
+        "xpath=//html/body/map[1] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid > div > div:nth-child(1)",
+        (tile) => tile.getAttribute("col")
+      );
+      const rowAfter = await page.$eval(
+        "xpath=//html/body/map[1] >> css=div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid > div > div:nth-child(1)",
+        (tile) => tile.getAttribute("row")
+      );
+      const zoomAfter = await page.$eval(
+        "xpath=//html/body/map[1] >> css=div.leaflet-pane.leaflet-map-pane > div.leaflet-layer.mapml-debug-grid > div > div:nth-child(1)",
+        (tile) => tile.getAttribute("zoom")
+      );
 
-            expect(colBefore).toEqual("10");
-            expect(rowBefore).toEqual("11");
-            expect(zoomBefore).toEqual("2");
-            expect(colAfter).toEqual("0");
-            expect(rowAfter).toEqual("0");
-            expect(zoomAfter).toEqual("0");
-            expect(centerBefore).toEqual("M132.64578432000008,238.45862407874074a1,1 0 1,0 2,0 a1,1 0 1,0 -2,0 ");
-            expect(centerAfter).toEqual("M249,250a1,1 0 1,0 2,0 a1,1 0 1,0 -2,0 ");
-          });
-        });
-      }
-    );
-  }
-})();
+      const centerAfter = await page.$eval(
+        "xpath=//html/body/map[1] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > svg > g > path:nth-child(1)",
+        (path) => path.getAttribute("d")
+      )
+
+      expect(colBefore).toEqual("10");
+      expect(rowBefore).toEqual("11");
+      expect(zoomBefore).toEqual("2");
+      expect(colAfter).toEqual("0");
+      expect(rowAfter).toEqual("0");
+      expect(zoomAfter).toEqual("0");
+      expect(centerBefore).toEqual("M132.64578432000008,238.45862407874074a1,1 0 1,0 2,0 a1,1 0 1,0 -2,0 ");
+      expect(centerAfter).toEqual("M249,250a1,1 0 1,0 2,0 a1,1 0 1,0 -2,0 ");
+    });
+  });
+});

--- a/test/e2e/core/projectionChange.test.js
+++ b/test/e2e/core/projectionChange.test.js
@@ -10,8 +10,10 @@ describe("Playwright Projection Change Tests", () => {
 
   describe("Linked Feature Projection Change Tests", () => {
     test("_self Linked Feature Change To OSMTILE", async () => {
-      for(let i = 0; i < 2; i++)
+      for(let i = 0; i < 2; i++) {
         await page.keyboard.press("Tab");
+        await page.waitForTimeout(200);
+      }
       await page.keyboard.press("Enter");
       await page.waitForTimeout(2000);
       const isChecked = await page.$eval(
@@ -27,8 +29,10 @@ describe("Playwright Projection Change Tests", () => {
     });
 
     test("_parent Linked Feature Change To OSMTILE", async () => {
-      for(let i = 0; i < 10; i++)
+      for(let i = 0; i < 10; i++) {
         await page.keyboard.press("Tab");
+        await page.waitForTimeout(200);
+      }
       await page.keyboard.press("Enter");
       await page.waitForTimeout(2000);
       const isChecked = await page.$eval(
@@ -68,8 +72,10 @@ describe("Playwright Projection Change Tests", () => {
         (path) => path.getAttribute("d")
       )
 
-      for(let i = 0; i < 2; i++)
+      for(let i = 0; i < 2; i++) {
         await page.keyboard.press("Tab");
+        await page.waitForTimeout(200);
+      }
       await page.keyboard.press("Enter");
       await page.waitForTimeout(2000);
 

--- a/test/e2e/core/styleParsing.test.js
+++ b/test/e2e/core/styleParsing.test.js
@@ -1,106 +1,88 @@
-const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
-  for (const browserType of BROWSER) {
-    let page, browser, context;
-    describe(
-      "Style Parsed and Implemented Test in " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "styleParsing.html");
-        });
+describe("Style Parsed and Implemented Test", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "styleParsing.html");
+  });
 
-        afterAll(async function () {
-          await browser.close();
-        });
+  afterAll(async function () {
+    await context.close();
+  });
 
-        //tests using the 1st map in the page
-        test("[" + browserType + "]" + " CSS within html page added to inorder to overlay-pane container", async () => {
-          const styleContent = await page.$eval(
-            "css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div",
-            (styleE) => styleE.innerHTML
-          );
-          expect(styleContent.indexOf("first")).toBeLessThan(
-            styleContent.indexOf(".second")
-          );
-          expect(styleContent.indexOf(".second")).toBeLessThan(
-            styleContent.indexOf(".third")
-          );
-          expect(styleContent.indexOf(".third")).toBeLessThan(
-            styleContent.indexOf("forth")
-          );
-        });
-
-        test("[" + browserType + "]" + " CSS from a retrieved MapML file added inorder inside templated-layer container", async () => {
-          const firstStyle = await page.$eval(
-            "css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > link",
-            (styleE) => styleE.outerHTML
-          );
-          const secondStyle = await page.$eval(
-            "css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > link:nth-child(2)",
-            (styleL) => styleL.outerHTML
-          );
-          expect(firstStyle).toMatch("canvec_cantopo");
-          expect(secondStyle).toMatch("canvec_feature");
-        });
-
-        test("[" + browserType + "]" + " CSS within html page added to overlay-pane container", async () => {
-          const foundStyleLink = await page.$("#first");
-          const foundStyleTag = await page.$(
-            "css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > style:nth-child(2)"
-          );
-          expect(foundStyleTag).toBeTruthy();
-          expect(foundStyleLink).toBeTruthy();
-        });
-
-        test("[" + browserType + "]" + " CSS from a retrieved MapML File added to templated-layer container", async () => {
-          const foundStyleLinkOne = await page.$(
-            "css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > link"
-          );
-          const foundStyleLinkTwo = await page.$(
-            "css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > link:nth-child(2)"
-          );
-          expect(foundStyleLinkOne).toBeTruthy();
-          expect(foundStyleLinkTwo).toBeTruthy();
-        });
-
-        //testing done on 2nd map in the page
-        test("[" + browserType + "]" + " CSS from a retrieved MapML file added inorder inside svg within templated-tile-container", async () => {
-          const firstStyle = await page.$eval(
-            "xpath=//html/body/map[2]/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div > style:nth-child(1)",
-            (styleE) => styleE.innerHTML
-          );
-          const secondStyle = await page.$eval(
-            "xpath=//html/body/map[2]/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div > style:nth-child(2)",
-            (styleE) => styleE.innerHTML
-          );
-          const foundStyleLink = await page.$(
-            "xpath=//html/body/map[2]/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div > link"
-          );
-          expect(firstStyle).toMatch("refStyleOne");
-          expect(secondStyle).toMatch("refStyleTwo");
-          expect(foundStyleLink).toBeTruthy();
-        });
-
-        test("[" + browserType + "]" + " CSS within html page added inorder to overlay-pane container", async () => {
-          const foundStyleLink = await page.$(
-            "xpath=//html/body/map[2]/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > link"
-          );
-          const foundStyleTag = await page.$(
-            "xpath=//html/body/map[2]/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > style"
-          );
-          expect(foundStyleTag).toBeTruthy();
-          expect(foundStyleLink).toBeTruthy();
-        });
-      }
+  //tests using the 1st map in the page
+  test("CSS within html page added to inorder to overlay-pane container", async () => {
+    const styleContent = await page.$eval(
+      "css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div",
+      (styleE) => styleE.innerHTML
     );
-  }
-})();
+    expect(styleContent.indexOf("first")).toBeLessThan(
+      styleContent.indexOf(".second")
+    );
+    expect(styleContent.indexOf(".second")).toBeLessThan(
+      styleContent.indexOf(".third")
+    );
+    expect(styleContent.indexOf(".third")).toBeLessThan(
+      styleContent.indexOf("forth")
+    );
+  });
+
+  test("CSS from a retrieved MapML file added inorder inside templated-layer container", async () => {
+    const firstStyle = await page.$eval(
+      "css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > link",
+      (styleE) => styleE.outerHTML
+    );
+    const secondStyle = await page.$eval(
+      "css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > link:nth-child(2)",
+      (styleL) => styleL.outerHTML
+    );
+    expect(firstStyle).toMatch("canvec_cantopo");
+    expect(secondStyle).toMatch("canvec_feature");
+  });
+
+  test("CSS within html page added to overlay-pane container", async () => {
+    const foundStyleLink = await page.$("#first");
+    const foundStyleTag = await page.$(
+      "css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > style:nth-child(2)"
+    );
+    expect(foundStyleTag).toBeTruthy();
+    expect(foundStyleLink).toBeTruthy();
+  });
+
+  test("CSS from a retrieved MapML File added to templated-layer container", async () => {
+    const foundStyleLinkOne = await page.$(
+      "css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > link"
+    );
+    const foundStyleLinkTwo = await page.$(
+      "css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > link:nth-child(2)"
+    );
+    expect(foundStyleLinkOne).toBeTruthy();
+    expect(foundStyleLinkTwo).toBeTruthy();
+  });
+
+  //testing done on 2nd map in the page
+  test("CSS from a retrieved MapML file added inorder inside svg within templated-tile-container", async () => {
+    const firstStyle = await page.$eval(
+      "xpath=//html/body/map[2]/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div > style:nth-child(1)",
+      (styleE) => styleE.innerHTML
+    );
+    const secondStyle = await page.$eval(
+      "xpath=//html/body/map[2]/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div > style:nth-child(2)",
+      (styleE) => styleE.innerHTML
+    );
+    const foundStyleLink = await page.$(
+      "xpath=//html/body/map[2]/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div > link"
+    );
+    expect(firstStyle).toMatch("refStyleOne");
+    expect(secondStyle).toMatch("refStyleTwo");
+    expect(foundStyleLink).toBeTruthy();
+  });
+
+  test("CSS within html page added inorder to overlay-pane container", async () => {
+    const foundStyleLink = await page.$(
+      "xpath=//html/body/map[2]/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > link"
+    );
+    const foundStyleTag = await page.$(
+      "xpath=//html/body/map[2]/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > style"
+    );
+    expect(foundStyleTag).toBeTruthy();
+    expect(foundStyleLink).toBeTruthy();
+  });
+});

--- a/test/e2e/core/tms.test.js
+++ b/test/e2e/core/tms.test.js
@@ -1,38 +1,20 @@
-const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright Map Element Tests in " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-            slowMo: 50,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "tms.html");
-        });
+describe("Playwright Map Element Tests", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "tms.html");
+  });
 
-        afterAll(async function () {
-          await browser.close();
-        });
+  afterAll(async function () {
+    await browser.close();
+  });
 
-        test("[" + browserType + "]" + " Painting tiles are in proper order", async () => {
-          let tileOrder = ["1/0/1", "1/0/0", "1/1/1", "1/1/0"]
-          for (let i = 0; i < 4; i++) {
-            const feature = await page.$eval(
-              `xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(${i + 1}) > img`,
-              (tile) => tile.getAttribute("src")
-            );
-            expect(feature).toEqual(`https://maps4html.org/TiledArt-Rousseau/TheBanksOfTheBièvreNearBicêtre/${tileOrder[i]}.png`);
-          }
-        });
-      }
-    );
-  }
-})();
+  test("Painting tiles are in proper order", async () => {
+    let tileOrder = ["1/0/1", "1/0/0", "1/1/1", "1/1/0"]
+    for (let i = 0; i < 4; i++) {
+      const feature = await page.$eval(
+        `xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(${i + 1}) > img`,
+        (tile) => tile.getAttribute("src")
+      );
+      expect(feature).toEqual(`https://maps4html.org/TiledArt-Rousseau/TheBanksOfTheBièvreNearBicêtre/${tileOrder[i]}.png`);
+    }
+  });
+});

--- a/test/e2e/core/zoomChangeProjection.test.js
+++ b/test/e2e/core/zoomChangeProjection.test.js
@@ -1,57 +1,39 @@
-const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright zoomin zoomout Projection Change Tests in " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-            slowMo: 50,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "zoomChangeProjection.html");
-        });
+describe("Playwright zoomin zoomout Projection Change Tests", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "zoomChangeProjection.html");
+  });
 
-        afterAll(async function () {
-          await browser.close();
-        });
+  afterAll(async function () {
+    await context.close();
+  });
 
-        test("[" + browserType + "]" + " zoomin link changes projections", async () => {
-          await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-in");
-          await page.waitForTimeout(1000);
-          const newProjection = await page.$eval(
-            'body > map',
-            (map) => map.projection
-          );
-          const layerValid = await page.$eval(
-            'body > map > layer-',
-            (layer) => !layer.hasAttribute('disabled')
-          )
-          expect(newProjection).toEqual("OSMTILE");
-          expect(layerValid).toEqual(true);
-        });
-
-        test("[" + browserType + "]" + " zoomout link changes projections", async () => {
-          await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-out");
-          await page.waitForTimeout(1000);
-          const newProjection = await page.$eval(
-            'body > map',
-            (map) => map.projection
-          );
-          const layerValid = await page.$eval(
-            'body > map > layer-',
-            (layer) => !layer.hasAttribute('disabled')
-          )
-          expect(newProjection).toEqual("CBMTILE");
-          expect(layerValid).toEqual(true);
-        });
-      }
+  test("zoomin link changes projections", async () => {
+    await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-in");
+    await page.waitForTimeout(1000);
+    const newProjection = await page.$eval(
+      'body > map',
+      (map) => map.projection
     );
-  }
-})();
+    const layerValid = await page.$eval(
+      'body > map > layer-',
+      (layer) => !layer.hasAttribute('disabled')
+    )
+    expect(newProjection).toEqual("OSMTILE");
+    expect(layerValid).toEqual(true);
+  });
+
+  test("zoomout link changes projections", async () => {
+    await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-out");
+    await page.waitForTimeout(1000);
+    const newProjection = await page.$eval(
+      'body > map',
+      (map) => map.projection
+    );
+    const layerValid = await page.$eval(
+      'body > map > layer-',
+      (layer) => !layer.hasAttribute('disabled')
+    )
+    expect(newProjection).toEqual("CBMTILE");
+    expect(layerValid).toEqual(true);
+  });
+});

--- a/test/e2e/layers/clientTemplatedTileLayer.test.js
+++ b/test/e2e/layers/clientTemplatedTileLayer.test.js
@@ -1,74 +1,54 @@
-const playwright = require("playwright");
+describe("Playwright Client Tile Tests", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "clientTemplatedTileLayer.html");
+  });
 
-jest.setTimeout(50000);
-(async () => {
+  afterAll(async function () {
+    await browser.close();
+  });
 
-  for (const browserType of BROWSER) {
-    let page, browser, context;
-    describe(
-      "Playwright Client Tile Tests in " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-            slowMo: 50,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "clientTemplatedTileLayer.html");
-        });
+  test("Custom Tiles Loaded In, Accurate Coordinates", async () => {
+    const one = await page.$eval(
+      "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(1) > p",
+      (tile) => tile.textContent
+    );
+    const two = await page.$eval(
+      "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(2) > p",
+      (tile) => tile.textContent
+    );
+    const three = await page.$eval(
+      "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(3) > p",
+      (tile) => tile.textContent
+    );
+    const four = await page.$eval(
+      "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(4) > p",
+      (tile) => tile.textContent
+    );
+    const five = await page.$eval(
+      "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(5) > p",
+      (tile) => tile.textContent
+    );
+    const six = await page.$eval(
+      "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(6) > p",
+      (tile) => tile.textContent
+    );
+    const seven = await page.$eval(
+      "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(7) > p",
+      (tile) => tile.textContent
+    );
+    const eight = await page.$eval(
+      "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(8) > p",
+      (tile) => tile.textContent
+    );
 
-        afterAll(async function () {
-          await browser.close();
-        });
+    expect(one).toEqual("101");
+    expect(two).toEqual("001");
+    expect(three).toEqual("201");
+    expect(four).toEqual("111");
+    expect(five).toEqual("011");
+    expect(six).toEqual("211");
+    expect(seven).toEqual("301");
+    expect(eight).toEqual("311");
 
-        test("[" + browserType + "]" + " Custom Tiles Loaded In, Accurate Coordinates", async () => {
-          const one = await page.$eval(
-            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(1) > p",
-            (tile) => tile.textContent
-          );
-          const two = await page.$eval(
-            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(2) > p",
-            (tile) => tile.textContent
-          );
-          const three = await page.$eval(
-            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(3) > p",
-            (tile) => tile.textContent
-          );
-          const four = await page.$eval(
-            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(4) > p",
-            (tile) => tile.textContent
-          );
-          const five = await page.$eval(
-            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(5) > p",
-            (tile) => tile.textContent
-          );
-          const six = await page.$eval(
-            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(6) > p",
-            (tile) => tile.textContent
-          );
-          const seven = await page.$eval(
-            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(7) > p",
-            (tile) => tile.textContent
-          );
-          const eight = await page.$eval(
-            "xpath=//html/body/mapml-viewer >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-templatedlayer-container > div > div > div:nth-child(8) > p",
-            (tile) => tile.textContent
-          );
-
-          expect(one).toEqual("101");
-          expect(two).toEqual("001");
-          expect(three).toEqual("201");
-          expect(four).toEqual("111");
-          expect(five).toEqual("011");
-          expect(six).toEqual("211");
-          expect(seven).toEqual("301");
-          expect(eight).toEqual("311");
-
-        });
-      });
-  }
-})();
+  });
+});

--- a/test/e2e/layers/general/extentProperty.js
+++ b/test/e2e/layers/general/extentProperty.js
@@ -1,51 +1,32 @@
-const playwright = require("playwright");
+exports.test = (path, expectedPCRS, expectedGCRS) => {
+  describe(`<Layer>.extent Property Tests for ${path.split(".")[0]}`, () => {
+    beforeAll(async () => {
+      await page.goto(PATH + path);
+    });
 
-exports.test = (path, expectedPCRS, expectedGCRS, browserType) => {
-  let page, browser, context;
-  describe(
-    `<Layer>.extent Property Tests for ${path.split(".")[0]} in ` + browserType,
-    () => {
-      beforeAll(async () => {
-        browser = await playwright[browserType].launch({
-          headless: ISHEADLESS,
-        });
-        context = await browser.newContext();
-        page = await context.newPage();
-        if (browserType === "firefox") {
-          await page.waitForNavigation();
-        }
-        await page.goto(PATH + path);
-      });
-
-      afterAll(async function () {
-        await browser.close();
-      });
-
-      test("[" + browserType + "]" + " <layer->.extent test", async () => {
-        const extent = await page.$eval(
-          "body > map > layer-:nth-child(1)",
-          (layer) => layer.extent
-        );
-        expect(extent.hasOwnProperty("zoom")).toBeTruthy();
-        expect(extent.hasOwnProperty("topLeft")).toBeTruthy();
-        expect(extent.hasOwnProperty("bottomRight")).toBeTruthy();
-        expect(extent.hasOwnProperty("projection")).toBeTruthy();
-        expect(extent.topLeft.pcrs).toEqual(expectedPCRS.topLeft);
-        expect(extent.bottomRight.pcrs).toEqual(expectedPCRS.bottomRight);
-        expect(extent.topLeft.gcrs).toEqual(expectedGCRS.topLeft);
-        expect(extent.bottomRight.gcrs).toEqual(expectedGCRS.bottomRight);
-      });
-      test("[" + browserType + "]" + " 2nd <layer->.extent test", async () => {
-        const extent = await page.$eval(
-          "body > map > layer-:nth-child(2)",
-          (layer) => layer.extent
-        );
-        expect(extent.hasOwnProperty("zoom")).toBeTruthy();
-        expect(extent.hasOwnProperty("topLeft")).toBeTruthy();
-        expect(extent.hasOwnProperty("bottomRight")).toBeTruthy();
-        expect(extent.hasOwnProperty("projection")).toBeTruthy();
-      });
-    }
-  );
-
+    test("<layer->.extent test", async () => {
+      const extent = await page.$eval(
+        "body > map > layer-:nth-child(1)",
+        (layer) => layer.extent
+      );
+      expect(extent.hasOwnProperty("zoom")).toBeTruthy();
+      expect(extent.hasOwnProperty("topLeft")).toBeTruthy();
+      expect(extent.hasOwnProperty("bottomRight")).toBeTruthy();
+      expect(extent.hasOwnProperty("projection")).toBeTruthy();
+      expect(extent.topLeft.pcrs).toEqual(expectedPCRS.topLeft);
+      expect(extent.bottomRight.pcrs).toEqual(expectedPCRS.bottomRight);
+      expect(extent.topLeft.gcrs).toEqual(expectedGCRS.topLeft);
+      expect(extent.bottomRight.gcrs).toEqual(expectedGCRS.bottomRight);
+    });
+    test("2nd <layer->.extent test", async () => {
+      const extent = await page.$eval(
+        "body > map > layer-:nth-child(2)",
+        (layer) => layer.extent
+      );
+      expect(extent.hasOwnProperty("zoom")).toBeTruthy();
+      expect(extent.hasOwnProperty("topLeft")).toBeTruthy();
+      expect(extent.hasOwnProperty("bottomRight")).toBeTruthy();
+      expect(extent.hasOwnProperty("projection")).toBeTruthy();
+    });
+  });
 };

--- a/test/e2e/layers/general/isVisible.js
+++ b/test/e2e/layers/general/isVisible.js
@@ -1,48 +1,30 @@
-const playwright = require("playwright");
+exports.test = (path, zoomIn, zoomOut) => {
+  describe(`isVisible Property Tests for ${path.split(".")[0]}`, () => {
+    beforeAll(async () => {
+      await page.goto(PATH + path);
+    });
 
-exports.test = (path, zoomIn, zoomOut, browserType) => {
-  let page, browser, context;
-  describe(
-    `isVisible Property Tests for ${path.split(".")[0]} in ` + browserType,
-    () => {
-      beforeAll(async () => {
-        browser = await playwright[browserType].launch({
-          headless: ISHEADLESS,
-          slowMo: 70,
-        });
-        context = await browser.newContext();
-        page = await context.newPage();
-        if (browserType === "firefox") {
-          await page.waitForNavigation();
-        }
-        await page.goto(PATH + path);
-      });
+    test("isVisible property false when zoomed out of bounds (zooming in)", async () => {
+      for (let i = 0; i < zoomIn; i++) {
+        await page.click('div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-in');
+        await page.waitForTimeout(300);
+      }
+      await page.hover('div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > a');
+      const layerController = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1)",
+        (controller) => controller.hasAttribute('disabled'))
 
-      afterAll(async function () {
-        await browser.close();
-      });
+      expect(layerController).toEqual(true);
+    });
+    test("isVisible property false when zoomed out of bounds (zooming out)", async () => {
 
-      test("[" + browserType + "]" + " isVisible property false when zoomed out of bounds (zooming in)", async () => {
-        for (let i = 0; i < zoomIn; i++)
-          await page.click('div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-in');
+      for (let i = 0; i < zoomOut + zoomIn; i++) {
+        await page.click('div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-out');
+        await page.waitForTimeout(300);
+      }
+      const layerController = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1)",
+        (controller) => controller.hasAttribute('disabled'))
 
-        await page.hover('div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > a');
-        const layerController = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1)",
-          (controller) => controller.hasAttribute('disabled'))
-
-        expect(layerController).toEqual(true);
-      });
-      test("[" + browserType + "]" + " isVisible property false when zoomed out of bounds (zooming out)", async () => {
-
-        for (let i = 0; i < zoomOut + zoomIn; i++)
-          await page.click('div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-out');
-
-        const layerController = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1)",
-          (controller) => controller.hasAttribute('disabled'))
-
-        expect(layerController).toEqual(true);
-      });
-    }
-  );
-
+      expect(layerController).toEqual(true);
+    });
+  });
 };

--- a/test/e2e/layers/general/zoomLimit.js
+++ b/test/e2e/layers/general/zoomLimit.js
@@ -1,67 +1,49 @@
-const playwright = require("playwright");
-
-exports.test = (path, zoomIn, zoomOut, browserType) => {
-  let page, browser, context;
-  describe(
-    `Map Zoom Limit Tests for ${path.split(".")[0]} in ` + browserType,
-    () => {
+exports.test = (path, zoomIn, zoomOut) => {
+  describe(`Map Zoom Limit Tests for ${path.split(".")[0]}`, () => {
       beforeAll(async () => {
-        browser = await playwright[browserType].launch({
-          headless: ISHEADLESS,
-          slowMo: 70,
-        });
-        context = await browser.newContext();
-        page = await context.newPage();
-        if (browserType === "firefox") {
-          await page.waitForNavigation();
-        }
         await page.goto(PATH + path);
         await page.$eval("xpath=/html/body/map",
           (controller) => controller.removeChild(controller.children[1]));
       });
 
-      afterAll(async function () {
-        await browser.close();
-      });
-
-      test("[" + browserType + "]" + " Limit map zooming (zooming in)", async () => {
-        for (let i = 0; i < zoomIn; i++)
+      test("Limit map zooming (zooming in)", async () => {
+        for (let i = 0; i < zoomIn; i++) {
           await page.click('div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-in');
-
+          await page.waitForTimeout(500);
+        }
         const zoomButton = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-in",
           (controller) => controller.className);
 
         expect(zoomButton).toMatch("disabled");
       });
 
-      test("[" + browserType + "]" + " Allow zooming before reaching limit (zooming in)", async () => {
+      test("Allow zooming before reaching limit (zooming in)", async () => {
         await page.click('div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-out');
-
+        await page.waitForTimeout(300);
         const zoomButton = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-in",
           (controller) => controller.className);
 
         expect(zoomButton).not.toMatch("disabled");
       });
 
-      test("[" + browserType + "]" + " Limit map zooming (zooming out)", async () => {
-        for (let i = 0; i < zoomOut + zoomIn - 1; i++)
+      test("Limit map zooming (zooming out)", async () => {
+        for (let i = 0; i < zoomOut + zoomIn - 1; i++) {
           await page.click('div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-out');
-
+          await page.waitForTimeout(500);
+        }
         const zoomButton = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-out",
           (controller) => controller.className);
 
         expect(zoomButton).toMatch("disabled");
       });
 
-      test("[" + browserType + "]" + " Allow zooming before reaching limit (zooming out)", async () => {
+      test("Allow zooming before reaching limit (zooming out)", async () => {
         await page.click('div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-in');
-
+        await page.waitForTimeout(300);
         const zoomButton = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.leaflet-control-zoom.leaflet-bar.leaflet-control > a.leaflet-control-zoom-out",
           (controller) => controller.className);
 
         expect(zoomButton).not.toMatch("disabled");
       });
-    }
-  );
-
+    });
 };

--- a/test/e2e/layers/mapMLFeatures.test.js
+++ b/test/e2e/layers/mapMLFeatures.test.js
@@ -3,128 +3,101 @@ const isVisible = require("./general/isVisible");
 const zoomLimit = require("./general/zoomLimit");
 const extentProperty = require("./general/extentProperty");
 jest.setTimeout(50000);
-(async () => {
-  let expectedPCRS = {
-    topLeft: {
-      horizontal: -34655800,
-      vertical: 39310000,
-    },
-    bottomRight: {
-      horizontal: 14450964.88019643,
-      vertical: -9796764.88019643,
-    },
-  }, expectedGCRS = {
-    topLeft: {
-      horizontal: -169.78391348558873,
-      vertical: -60.79113663130127,
-    },
-    bottomRight: {
-      horizontal: 79.6961805581841,
-      vertical: -60.79110984572508,
-    },
-  };
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright mapMLFeatures (Static Features) Layer Tests in " + browserType,
-      () => {
-        isVisible.test("mapMLFeatures.html", 5, 2, browserType);
-        zoomLimit.test("mapMLFeatures.html", 3, 1, browserType);
-        extentProperty.test("mapMLFeatures.html", expectedPCRS, expectedGCRS, browserType);
-        describe("Retreived Static Features Tests", () => {
-          beforeAll(async () => {
-            browser = await playwright[browserType].launch({
-              headless: ISHEADLESS,
-              slowMo: 50,
-            });
-            context = await browser.newContext();
-            page = await context.newPage();
-            if (browserType === "firefox") {
-              await page.waitForNavigation();
-            }
-            await page.goto(PATH + "mapMLFeatures.html");
-          });
 
-          afterAll(async function () {
-            await browser.close();
-          });
+let expectedPCRS = {
+  topLeft: {
+    horizontal: -34655800,
+    vertical: 39310000,
+  },
+  bottomRight: {
+    horizontal: 14450964.88019643,
+    vertical: -9796764.88019643,
+  },
+}, expectedGCRS = {
+  topLeft: {
+    horizontal: -169.78391348558873,
+    vertical: -60.79113663130127,
+  },
+  bottomRight: {
+    horizontal: 79.6961805581841,
+    vertical: -60.79110984572508,
+  },
+};
 
-          test("[" + browserType + "]" + " Loading in retreived features", async () => {
-            const features = await page.$eval(
-              "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(3) > div.leaflet-layer.leaflet-pane.mapml-vector-container > svg > g",
-              (featureGroups) => featureGroups.childNodes.length
-            );
-            expect(features).toEqual(52);
-          });
+describe("Playwright mapMLFeatures (Static Features) Layer Tests", () => {
+  isVisible.test("mapMLFeatures.html", 5, 2);
+  zoomLimit.test("mapMLFeatures.html", 3, 1);
+  extentProperty.test("mapMLFeatures.html", expectedPCRS, expectedGCRS);
+  describe("Retrieved Static Features Tests", () => {
+    beforeAll(async () => {
+      await page.goto(PATH + "mapMLFeatures.html");
+    });
 
-          test("[" + browserType + "]" + " Loading in tilematrix feature", async () => {
-            const feature = await page.$eval(
-              "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div.leaflet-layer.leaflet-pane.mapml-vector-container > svg > g > g:nth-child(1) > path.leaflet-interactive",
-              (tile) => tile.getAttribute("d")
-            );
-            expect(feature).toEqual("M330 83L586 83L586 339L330 339L330 83z");
-          });
+    test("Loading in retrieved features", async () => {
+      const features = await page.$eval(
+        "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(3) > div.leaflet-layer.leaflet-pane.mapml-vector-container > svg > g",
+        (featureGroups) => featureGroups.childNodes.length
+      );
+      expect(features).toEqual(52);
+    });
 
-          test("[" + browserType + "]" + " Loading in pcrs feature", async () => {
-            const feature = await page.$eval(
-              "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div.leaflet-layer.leaflet-pane.mapml-vector-container > svg > g > g:nth-child(2) > path.leaflet-interactive",
-              (tile) => tile.getAttribute("d")
-            );
-            expect(feature).toEqual("M153 508L113 146L-161 220L-107 436z");
-          });
+    test("Loading in tilematrix feature", async () => {
+      const feature = await page.$eval(
+        "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div.leaflet-layer.leaflet-pane.mapml-vector-container > svg > g > g:nth-child(1) > path.leaflet-interactive",
+        (tile) => tile.getAttribute("d")
+      );
+      expect(feature).toEqual("M330 83L586 83L586 339L330 339L330 83z");
+    });
 
-          test("[" + browserType + "]" + " Loading in tcrs feature", async () => {
-            const feature = await page.$eval(
-              "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div.leaflet-layer.leaflet-pane.mapml-vector-container > svg > g > g:nth-child(3) > path.leaflet-interactive",
-              (tile) => tile.getAttribute("d")
-            );
-            expect(feature).toEqual("M285 373L460 380L468 477L329 459z");
-          });
+    test("Loading in pcrs feature", async () => {
+      const feature = await page.$eval(
+        "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div.leaflet-layer.leaflet-pane.mapml-vector-container > svg > g > g:nth-child(2) > path.leaflet-interactive",
+        (tile) => tile.getAttribute("d")
+      );
+      expect(feature).toEqual("M153 508L113 146L-161 220L-107 436z");
+    });
 
-          test("[" + browserType + "]" + " valid <layer>.extent", async () => {
-            const layerExtent = await page.$eval(
-              "body > map > layer-:nth-child(3)",
-              (layer) => layer.extent
-            );
-            expect(layerExtent.topLeft.pcrs).toEqual({ horizontal: -34655800, vertical: 39310000 });
-            expect(layerExtent.topLeft.gcrs).toEqual({ horizontal: -169.78391348558873, vertical: -60.79113663130127 });
-            expect(layerExtent.bottomRight.pcrs).toEqual({ horizontal: 14450964.88019643, vertical: -9796764.88019643 });
-            expect(layerExtent.bottomRight.gcrs).toEqual({ horizontal: 79.6961805581841, vertical: -60.79110984572508 });
-            expect(layerExtent.zoom).toEqual({ maxNativeZoom: 0, minNativeZoom: 0, maxZoom: 2, minZoom: 2 });
-            expect(layerExtent.projection).toEqual("CBMTILE");
-          });
-        });
-        describe("Inline Static Features Tests", () => {
-          beforeAll(async () => {
-            browser = await playwright[browserType].launch({
-              headless: ISHEADLESS,
-              slowMo: 50,
-            });
-            context = await browser.newContext();
-            page = await context.newPage();
-            if (browserType === "firefox") {
-              await page.waitForNavigation();
-            }
-            await page.goto(PATH + "mapMLFeatures.html");
-          });
+    test("Loading in tcrs feature", async () => {
+      const feature = await page.$eval(
+        "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div.leaflet-layer.leaflet-pane.mapml-vector-container > svg > g > g:nth-child(3) > path.leaflet-interactive",
+        (tile) => tile.getAttribute("d")
+      );
+      expect(feature).toEqual("M285 373L460 380L468 477L329 459z");
+    });
 
-          afterAll(async function () {
-            await browser.close();
-          });
+    test("valid <layer>.extent", async () => {
+      const layerExtent = await page.$eval(
+        "body > map > layer-:nth-child(3)",
+        (layer) => layer.extent
+      );
+      expect(layerExtent.topLeft.pcrs).toEqual({ horizontal: -34655800, vertical: 39310000 });
+      expect(layerExtent.topLeft.gcrs).toEqual({ horizontal: -169.78391348558873, vertical: -60.79113663130127 });
+      expect(layerExtent.bottomRight.pcrs).toEqual({ horizontal: 14450964.88019643, vertical: -9796764.88019643 });
+      expect(layerExtent.bottomRight.gcrs).toEqual({ horizontal: 79.6961805581841, vertical: -60.79110984572508 });
+      expect(layerExtent.zoom).toEqual({ maxNativeZoom: 0, minNativeZoom: 0, maxZoom: 2, minZoom: 2 });
+      expect(layerExtent.projection).toEqual("CBMTILE");
+    });
+  });
+  describe("Inline Static Features Tests", () => {
+    beforeAll(async () => {
+      await page.goto(PATH + "mapMLFeatures.html");
+    });
 
-          test("[" + browserType + "]" + " Feature without properties renders & is not interactable", async () => {
-            const feature = await page.$eval(
-              "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(4) > div.leaflet-layer.leaflet-pane.mapml-vector-container > svg > g > g > path",
-              (path) => path.getAttribute("d")
-            );
-            const classList = await page.$eval(
-              "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(4) > div.leaflet-layer.leaflet-pane.mapml-vector-container > svg > g > g",
-              (g) => g.getAttribute("class")
-            );
-            expect(feature).toEqual("M74 -173L330 -173L330 83L74 83L74 -173z");
-            expect(classList).toBeFalsy();
-          });
-        });
-      }
-    );
-  }
-})();
+    afterAll(async function () {
+      await context.close();
+    });
+
+    test("Feature without properties renders & is not interactable", async () => {
+      const feature = await page.$eval(
+        "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(4) > div.leaflet-layer.leaflet-pane.mapml-vector-container > svg > g > g > path",
+        (path) => path.getAttribute("d")
+      );
+      const classList = await page.$eval(
+        "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(4) > div.leaflet-layer.leaflet-pane.mapml-vector-container > svg > g > g",
+        (g) => g.getAttribute("class")
+      );
+      expect(feature).toEqual("M74 -173L330 -173L330 83L74 83L74 -173z");
+      expect(classList).toBeFalsy();
+    });
+  });
+});

--- a/test/e2e/layers/mapMLLayerControl.test.js
+++ b/test/e2e/layers/mapMLLayerControl.test.js
@@ -1,46 +1,27 @@
-const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
+describe("Playwright mapMLLayerControl Tests", () => {
+  describe("Control Layer Panel Tests", () => {
+    beforeAll(async () => {
+      await page.goto(PATH + "mapMLLayerControl.html");
+    });
 
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright mapMLLayerControl Tests in " + browserType,
-      () => {
-        describe("Control Layer Panel Tests", () => {
-          beforeAll(async () => {
-            browser = await playwright[browserType].launch({
-              headless: ISHEADLESS,
-              slowMo: 50,
-            });
-            context = await browser.newContext();
-            page = await context.newPage();
-            if (browserType === "firefox") {
-              await page.waitForNavigation();
-            }
-            await page.goto(PATH + "mapMLLayerControl.html");
-          });
+    afterAll(async function () {
+      await context.close();
+    });
 
-          afterAll(async function () {
-            await browser.close();
-          });
+    test("Control panel hidden when no layers/all layers hidden", async () => {
+      const controlsHidden = await page.$eval(
+        "css=body > mapml-viewer:nth-child(1) >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div",
+        (elem) => elem.hasAttribute("hidden")
+      );
+      expect(controlsHidden).toEqual(true);
+    });
 
-          test("[" + browserType + "]" + " Control panel hidden when no layers/all layers hidden", async () => {
-            const controlsHidden = await page.$eval(
-              "css=body > mapml-viewer:nth-child(1) >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div",
-              (elem) => elem.hasAttribute("hidden")
-            );
-            expect(controlsHidden).toEqual(true);
-          });
-
-          test("[" + browserType + "]" + " Control panel shown when layers are on map", async () => {
-            const controlsHidden = await page.$eval(
-              "css=body > mapml-viewer:nth-child(2) >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div",
-              (elem) => elem.hasAttribute("hidden")
-            );
-            expect(controlsHidden).toEqual(false);
-          });
-        });
-      }
-    );
-  }
-})();
+    test("Control panel shown when layers are on map", async () => {
+      const controlsHidden = await page.$eval(
+        "css=body > mapml-viewer:nth-child(2) >> css=div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div",
+        (elem) => elem.hasAttribute("hidden")
+      );
+      expect(controlsHidden).toEqual(false);
+    });
+  });
+});

--- a/test/e2e/layers/mapMLStaticTileLayer.test.js
+++ b/test/e2e/layers/mapMLStaticTileLayer.test.js
@@ -1,63 +1,46 @@
-const playwright = require("playwright");
 const isVisible = require("./general/isVisible");
 const zoomLimit = require("./general/zoomLimit");
 const extentProperty = require("./general/extentProperty");
-jest.setTimeout(50000);
-(async () => {
-  let expectedPCRS = {
-    topLeft: {
-      horizontal: -4175739.0398780815,
-      vertical: 5443265.599864535,
-    },
-    bottomRight: {
-      horizontal: 5984281.280162558,
-      vertical: -1330081.280162558,
-    },
-  }, expectedGCRS = {
-    topLeft: {
-      horizontal: -133.75137103791573,
-      vertical: 36.915777752306546,
-    },
-    bottomRight: {
-      horizontal: 13.251318374931316,
-      vertical: 26.63127363018255,
-    },
-  };
-  for (const browserType of BROWSER) {
-    let page, browser, context;
-    describe(
-      "Playwright mapMLStaticTile Layer Tests in " + browserType,
-      () => {
-        isVisible.test("mapMLStaticTileLayer.html", 3, 3, browserType);
-        zoomLimit.test("mapMLStaticTileLayer.html", 2, 2, browserType);
-        extentProperty.test("mapMLStaticTileLayer.html", expectedPCRS, expectedGCRS, browserType);
-        describe("General Tests ", () => {
-          beforeAll(async () => {
-            browser = await playwright[browserType].launch({
-              headless: ISHEADLESS,
-              slowMo: 50,
-            });
-            context = await browser.newContext();
-            page = await context.newPage();
-            if (browserType === "firefox") {
-              await page.waitForNavigation();
-            }
-            await page.goto(PATH + "mapMLStaticTileLayer.html");
-          });
 
-          afterAll(async function () {
-            await browser.close();
-          });
+let expectedPCRS = {
+  topLeft: {
+    horizontal: -4175739.0398780815,
+    vertical: 5443265.599864535,
+  },
+  bottomRight: {
+    horizontal: 5984281.280162558,
+    vertical: -1330081.280162558,
+  },
+}, expectedGCRS = {
+  topLeft: {
+    horizontal: -133.75137103791573,
+    vertical: 36.915777752306546,
+  },
+  bottomRight: {
+    horizontal: 13.251318374931316,
+    vertical: 26.63127363018255,
+  },
+};
 
-          test("[" + browserType + "]" + " Tiles load in on default map zoom level", async () => {
-            const tiles = await page.$eval(
-              "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-static-tile-layer > div",
-              (tileGroup) => tileGroup.getElementsByTagName("map-tile").length
-            );
-            expect(tiles).toEqual(1);
-          });
-        });
-      }
-    );
-  }
-})();
+describe("Playwright mapMLStaticTile Layer Tests", () => {
+  isVisible.test("mapMLStaticTileLayer.html", 3, 3);
+  zoomLimit.test("mapMLStaticTileLayer.html", 2, 2);
+  extentProperty.test("mapMLStaticTileLayer.html", expectedPCRS, expectedGCRS);
+  describe("General Tests ", () => {
+    beforeAll(async () => {
+      await page.goto(PATH + "mapMLStaticTileLayer.html");
+    });
+
+    afterAll(async function () {
+      await context.close();
+    });
+
+    test("Tiles load in on default map zoom level", async () => {
+      const tiles = await page.$eval(
+        "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div > div.leaflet-layer.mapml-static-tile-layer > div",
+        (tileGroup) => tileGroup.getElementsByTagName("map-tile").length
+      );
+      expect(tiles).toEqual(1);
+    });
+  });
+});

--- a/test/e2e/layers/mapMLTemplatedFeatures.test.js
+++ b/test/e2e/layers/mapMLTemplatedFeatures.test.js
@@ -1,80 +1,64 @@
-const playwright = require("playwright");
 const isVisible = require("./general/isVisible");
 const zoomLimit = require("./general/zoomLimit");
 const extentProperty = require("./general/extentProperty");
-jest.setTimeout(50000);
-(async () => {
-  let expectedPCRS = {
-    topLeft: {
-      horizontal: 1501645.2210838948,
-      vertical: -66110.70639331453,
-    },
-    bottomRight: {
-      horizontal: 1617642.4028044068,
-      vertical: -222452.18449031282,
-    },
-  }, expectedGCRS = {
-    topLeft: {
-      horizontal: -76,
-      vertical: 45.999999999999936,
-    },
-    bottomRight: {
-      horizontal: -74,
-      vertical: 44.99999999999991,
-    },
-  };
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright mapMLTemplatedFeatures Layer Tests in " + browserType,
-      () => {
-        isVisible.test("mapMLTemplatedFeatures.html", 3, 2, browserType);
-        zoomLimit.test("mapMLTemplatedFeatures.html", 2, 1, browserType);
-        extentProperty.test("mapMLTemplatedFeatures.html", expectedPCRS, expectedGCRS, browserType);
 
-        describe("Retreived Features Loading Tests", () => {
-          beforeAll(async () => {
-            browser = await playwright[browserType].launch({
-              headless: ISHEADLESS,
-              slowMo: 50,
-            });
-            context = await browser.newContext();
-            page = await context.newPage();
-            if (browserType === "firefox") {
-              await page.waitForNavigation();
-            }
-            await page.goto(PATH + "mapMLTemplatedFeatures.html");
-          });
+let expectedPCRS = {
+  topLeft: {
+    horizontal: 1501645.2210838948,
+    vertical: -66110.70639331453,
+  },
+  bottomRight: {
+    horizontal: 1617642.4028044068,
+    vertical: -222452.18449031282,
+  },
+}, expectedGCRS = {
+  topLeft: {
+    horizontal: -76,
+    vertical: 45.999999999999936,
+  },
+  bottomRight: {
+    horizontal: -74,
+    vertical: 44.99999999999991,
+  },
+};
 
-          afterAll(async function () {
-            await browser.close();
-          });
+describe("Playwright mapMLTemplatedFeatures Layer Tests", () => {
+  isVisible.test("mapMLTemplatedFeatures.html", 3, 2);
+  zoomLimit.test("mapMLTemplatedFeatures.html", 2, 1);
+  extentProperty.test("mapMLTemplatedFeatures.html", expectedPCRS, expectedGCRS);
 
+  describe("Retreived Features Loading Tests", () => {
+    beforeAll(async () => {
+      await page.goto(PATH + "mapMLTemplatedFeatures.html");
+    });
 
-          test("[" + browserType + "]" + " Loading in tilematrix feature", async () => {
-            const feature = await page.$eval(
-              "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div.leaflet-layer.mapml-templatedlayer-container > div > div > svg > g > g:nth-child(3) > path.leaflet-interactive",
-              (tile) => tile.getAttribute("d")
-            );
-            expect(feature).toEqual("M382 -28L809 -28L809 399L382 399z");
-          });
+    afterAll(async function () {
+      await context.close();
+    });
 
-          test("[" + browserType + "]" + " Loading in pcrs feature", async () => {
-            const feature = await page.$eval(
-              "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div.leaflet-layer.mapml-templatedlayer-container > div > div > svg > g > g:nth-child(1) > path.leaflet-interactive",
-              (tile) => tile.getAttribute("d")
-            );
-            expect(feature).toEqual("M88 681L21 78L-436 201L-346 561z");
-          });
+    test("Loading in tilematrix feature", async () => {
+      await page.waitForTimeout(200);
+      const feature = await page.$eval(
+        "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div.leaflet-layer.mapml-templatedlayer-container > div > div > svg > g > g:nth-child(3) > path.leaflet-interactive",
+        (tile) => tile.getAttribute("d")
+      );
+      expect(feature).toEqual("M382 -28L809 -28L809 399L382 399z");
+    });
 
-          test("[" + browserType + "]" + " Loading in tcrs feature", async () => {
-            const feature = await page.$eval(
-              "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div.leaflet-layer.mapml-templatedlayer-container > div > div > svg > g > g:nth-child(2) > path.leaflet-interactive",
-              (tile) => tile.getAttribute("d")
-            );
-            expect(feature).toEqual("M307 456L599 467L612 629L381 599z");
-          });
-        });
-      }
-    );
-  }
-})();
+    test("Loading in pcrs feature", async () => {
+      const feature = await page.$eval(
+        "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div.leaflet-layer.mapml-templatedlayer-container > div > div > svg > g > g:nth-child(1) > path.leaflet-interactive",
+        (tile) => tile.getAttribute("d")
+      );
+      expect(feature).toEqual("M88 681L21 78L-436 201L-346 561z");
+    });
+
+    test("Loading in tcrs feature", async () => {
+      const feature = await page.$eval(
+        "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div.leaflet-layer.mapml-templatedlayer-container > div > div > svg > g > g:nth-child(2) > path.leaflet-interactive",
+        (tile) => tile.getAttribute("d")
+      );
+      expect(feature).toEqual("M307 456L599 467L612 629L381 599z");
+    });
+  });
+});

--- a/test/e2e/layers/mapMLTemplatedImageLayer.test.js
+++ b/test/e2e/layers/mapMLTemplatedImageLayer.test.js
@@ -1,35 +1,29 @@
 const isVisible = require('./general/isVisible');
 const zoomLimit = require("./general/zoomLimit");
 const extentProperty = require("./general/extentProperty");
-jest.setTimeout(50000);
-(async () => {
-  let expectedPCRS = {
-    topLeft: {
-      horizontal: -6207743.103886206,
-      vertical: 3952277.216154434,
-    },
-    bottomRight: {
-      horizontal: 3952277.216154434,
-      vertical: -3362085.3441706896,
-    },
-  }, expectedGCRS = {
-    topLeft: {
-      horizontal: -136.9120743861578,
-      vertical: 54.8100849543377,
-    },
-    bottomRight: {
-      horizontal: -6.267177352336376,
-      vertical: 6.5831982143623975,
-    },
-  };
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright mapMLTemplatedImage Layer Tests in " + browserType,
-      () => {
-        isVisible.test("mapMLTemplatedImageLayer.html", 2, 1, browserType);
-        zoomLimit.test("mapMLTemplatedImageLayer.html", 1, 0, browserType);
-        extentProperty.test("mapMLTemplatedImageLayer.html", expectedPCRS, expectedGCRS, browserType);
-      }
-    );
-  }
-})();
+
+let expectedPCRS = {
+  topLeft: {
+    horizontal: -6207743.103886206,
+    vertical: 3952277.216154434,
+  },
+  bottomRight: {
+    horizontal: 3952277.216154434,
+    vertical: -3362085.3441706896,
+  },
+}, expectedGCRS = {
+  topLeft: {
+    horizontal: -136.9120743861578,
+    vertical: 54.8100849543377,
+  },
+  bottomRight: {
+    horizontal: -6.267177352336376,
+    vertical: 6.5831982143623975,
+  },
+};
+
+describe("Playwright mapMLTemplatedImage Layer Tests", () => {
+  isVisible.test("mapMLTemplatedImageLayer.html", 2, 1);
+  zoomLimit.test("mapMLTemplatedImageLayer.html", 1, 0);
+  extentProperty.test("mapMLTemplatedImageLayer.html", expectedPCRS, expectedGCRS);
+});

--- a/test/e2e/layers/mapMLTemplatedTileLayer.test.js
+++ b/test/e2e/layers/mapMLTemplatedTileLayer.test.js
@@ -1,65 +1,47 @@
-const playwright = require("playwright");
 const isVisible = require('./general/isVisible');
 const zoomLimit = require("./general/zoomLimit");
 const extentProperty = require("./general/extentProperty");
-jest.setTimeout(50000);
-(async () => {
-  let expectedPCRS = {
-    topLeft: {
-      horizontal: -180,
-      vertical: 90,
-    },
-    bottomRight: {
-      horizontal: 180,
-      vertical: -270,
-    },
-  }, expectedGCRS = {
-    topLeft: {
-      horizontal: -180,
-      vertical: 90,
-    },
-    bottomRight: {
-      horizontal: 180,
-      vertical: -270,
-    },
-  };
-  for (const browserType of BROWSER) {
-    let page, browser, context;
-    describe(
-      "Playwright mapMLTemplatedTile Layer Tests in " + browserType,
-      () => {
-        isVisible.test("mapMLTemplatedTileLayer.html", 2, 2, browserType);
-        zoomLimit.test("mapMLTemplatedTileLayer.html", 1, 0, browserType);
-        extentProperty.test("mapMLTemplatedTileLayer.html", expectedPCRS, expectedGCRS, browserType);
-        describe(
-          "General Tests " + browserType,
-          () => {
-            beforeAll(async () => {
-              browser = await playwright[browserType].launch({
-                headless: ISHEADLESS,
-                slowMo: 50,
-              });
-              context = await browser.newContext();
-              page = await context.newPage();
-              if (browserType === "firefox") {
-                await page.waitForNavigation();
-              }
-              await page.goto(PATH + "mapMLTemplatedTileLayer.html");
-            });
 
-            afterAll(async function () {
-              await browser.close();
-            });
+let expectedPCRS = {
+  topLeft: {
+    horizontal: -180,
+    vertical: 90,
+  },
+  bottomRight: {
+    horizontal: 180,
+    vertical: -270,
+  },
+}, expectedGCRS = {
+  topLeft: {
+    horizontal: -180,
+    vertical: 90,
+  },
+  bottomRight: {
+    horizontal: 180,
+    vertical: -270,
+  },
+};
 
-            test("[" + browserType + "]" + " SVG tiles load in on default map zoom level", async () => {
-              const tiles = await page.$eval(
-                "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div.leaflet-layer.mapml-templatedlayer-container > div > div",
-                (tileGroup) => tileGroup.getElementsByTagName("svg").length
-              );
-              expect(tiles).toEqual(2);
-            });
-          });
+describe("Playwright mapMLTemplatedTile Layer Tests", () => {
+  isVisible.test("mapMLTemplatedTileLayer.html", 2, 2);
+  zoomLimit.test("mapMLTemplatedTileLayer.html", 1, 0);
+  extentProperty.test("mapMLTemplatedTileLayer.html", expectedPCRS, expectedGCRS);
+  describe("General Tests ", () => {
+    beforeAll(async () => {
+      await page.goto(PATH + "mapMLTemplatedTileLayer.html");
+    });
 
-      });
-  }
-})();
+    afterAll(async function () {
+      await context.close();
+    });
+
+    test("SVG tiles load in on default map zoom level", async () => {
+      const tiles = await page.$eval(
+        "xpath=//html/body/map/div >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div.leaflet-layer.mapml-templatedlayer-container > div > div",
+        (tileGroup) => tileGroup.getElementsByTagName("svg").length
+      );
+      expect(tiles).toEqual(2);
+    });
+  });
+
+});

--- a/test/e2e/layers/queryLink.test.js
+++ b/test/e2e/layers/queryLink.test.js
@@ -1,187 +1,168 @@
-const playwright = require("playwright");
+describe("Playwright Query Link Tests", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "queryLink.html");
+  });
 
-jest.setTimeout(50000);
-(async () => {
+  afterAll(async function () {
+    await context.close();
+  });
 
-  for (const browserType of BROWSER) {
-    let page, browser, context;
-    describe(
-      "Playwright Query Link Tests in " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-            slowMo: 50,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "queryLink.html");
-        });
+  describe("Query Popup Tests", () => {
 
-        afterAll(async function () {
-          await browser.close();
-        });
+    test("Query link shows when within bounds", async () => {
+      await page.click("div");
+      await page.waitForSelector("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div");
+      const popupNum = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane", (div) => div.childElementCount);
+      expect(popupNum).toEqual(1);
+    });
 
-        describe("Query Popup Tests in " + browserType, () => {
+    test("Query link closes previous popup when new query made within bounds", async () => {
+      await page.evaluateHandle(() => document.querySelector("mapml-viewer").zoomTo(9, -27, 0));
+      await page.waitForTimeout(1000);
+      await page.click("div");
+      await page.waitForTimeout(500);
+      await page.waitForSelector("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div");
+      const popupNum = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane", (div) => div.childElementCount);
+      expect(popupNum).toEqual(1);
+    });
 
-          test("[" + browserType + "]" + " Query link shows when within bounds", async () => {
-            await page.click("div");
-            await page.waitForSelector("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div");
-            const popupNum = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane", (div) => div.childElementCount);
-            expect(popupNum).toEqual(1);
-          });
+    test("Query link does not show when out of bounds", async () => {
+      await page.evaluateHandle(() => document.querySelector("mapml-viewer").zoomTo(-37.078210, -9.010487, 0));
+      await page.waitForTimeout(1000);
+      await page.click("div");
+      await page.waitForSelector("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div", { state: "hidden" });
+      const popupNumRight = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane", (div) => div.childElementCount);
 
-          test("[" + browserType + "]" + " Query link closes previous popup when new query made within bounds", async () => {
-            await page.evaluateHandle(() => document.querySelector("mapml-viewer").zoomTo(9, -27, 0));
-            await page.waitForTimeout(1000);
-            await page.click("div");
-            await page.waitForSelector("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div");
-            const popupNum = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane", (div) => div.childElementCount);
-            expect(popupNum).toEqual(1);
-          });
+      await page.evaluateHandle(() => document.querySelector("mapml-viewer").zoomTo(-45.679787, -93.041053, 0));
+      await page.waitForTimeout(1000);
+      await page.click("div");
+      await page.waitForTimeout(1000);
+      const popupNumBottom = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane", (div) => div.childElementCount);
 
-          test("[" + browserType + "]" + " Query link does not show when out of bounds", async () => {
-            await page.evaluateHandle(() => document.querySelector("mapml-viewer").zoomTo(-37.078210, -9.010487, 0));
-            await page.waitForTimeout(1000);
-            await page.click("div");
-            await page.waitForSelector("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div", { state: "hidden" });
-            const popupNumRight = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane", (div) => div.childElementCount);
+      await page.evaluateHandle(() => document.querySelector("mapml-viewer").zoomTo(-37.399782, 177.152220, 0));
+      await page.waitForTimeout(1000);
+      await page.click("div");
+      await page.waitForTimeout(1000);
+      const popupNumLeft = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane", (div) => div.childElementCount);
 
-            await page.evaluateHandle(() => document.querySelector("mapml-viewer").zoomTo(-45.679787, -93.041053, 0));
-            await page.waitForTimeout(1000);
-            await page.click("div");
-            await page.waitForTimeout(1000);
-            const popupNumBottom = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane", (div) => div.childElementCount);
+      await page.evaluateHandle(() => document.querySelector("mapml-viewer").zoomTo(-32.240953, 94.969783, 0));
+      await page.waitForTimeout(1000);
+      await page.click("div");
+      await page.waitForTimeout(1000);
+      const popupNumTop = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane", (div) => div.childElementCount);
 
-            await page.evaluateHandle(() => document.querySelector("mapml-viewer").zoomTo(-37.399782, 177.152220, 0));
-            await page.waitForTimeout(1000);
-            await page.click("div");
-            await page.waitForTimeout(1000);
-            const popupNumLeft = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane", (div) => div.childElementCount);
+      expect(popupNumRight).toEqual(0);
+      expect(popupNumBottom).toEqual(0);
+      expect(popupNumLeft).toEqual(0);
+      expect(popupNumTop).toEqual(0);
+    });
+  });
+  describe("Queried Feature Tests", () => {
+    test("First feature added + popup content updated ", async () => {
+      await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.mapml-reload-button.leaflet-bar.leaflet-control > button");
+      await page.click("div");
+      await page.waitForSelector("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div");
+      const feature = await page.$eval(
+        "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div:nth-child(5) > svg > g > g > path",
+        (tile) => tile.getAttribute("d")
+      );
+      const popup = await page.$eval(
+        "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > iframe",
+        (iframe) => iframe.contentWindow.document.querySelector("h1").innerText
+      );
 
-            await page.evaluateHandle(() => document.querySelector("mapml-viewer").zoomTo(-32.240953, 94.969783, 0));
-            await page.waitForTimeout(1000);
-            await page.click("div");
-            await page.waitForTimeout(1000);
-            const popupNumTop = await page.$eval("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane", (div) => div.childElementCount);
+      expect(feature).toEqual("M259 279L263 279L264 281L265 285L266 286L266 287L266 287L267 287L266 288L266 288L266 288L266 289L266 290L267 291L266 291L260 292L260 293L260 293L260 294L261 294L260 294L260 294L259 294L259 293L259 293L259 294L259 294L258 294L257 289L257 283L257 280L257 280L259 279z");
+      expect(popup).toEqual("Alabama");
+    });
 
-            expect(popupNumRight).toEqual(0);
-            expect(popupNumBottom).toEqual(0);
-            expect(popupNumLeft).toEqual(0);
-            expect(popupNumTop).toEqual(0);
-          });
-        });
-        describe("Queried Feature Tests in " + browserType, () => {
-          test("[" + browserType + "]" + " First feature added + popup content updated ", async () => {
-            await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-left > div.mapml-reload-button.leaflet-bar.leaflet-control > button");
-            await page.click("div");
-            await page.waitForSelector("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div");
-            const feature = await page.$eval(
-              "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div:nth-child(5) > svg > g > g > path",
-              (tile) => tile.getAttribute("d")
-            );
-            const popup = await page.$eval(
-              "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > iframe",
-              (iframe) => iframe.contentWindow.document.querySelector("h1").innerText
-            );
+    test("Next feature added + popup content updated ", async () => {
+      await page.click("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > nav > button:nth-child(4)");
+      const feature = await page.$eval(
+        "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div:nth-child(5) > svg > g > g > path",
+        (tile) => tile.getAttribute("d")
+      );
+      const popup = await page.$eval(
+        "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > iframe",
+        (iframe) => iframe.contentWindow.document.querySelector("h1").innerText
+      );
 
-            expect(feature).toEqual("M259 279L263 279L264 281L265 285L266 286L266 287L266 287L267 287L266 288L266 288L266 288L266 289L266 290L267 291L266 291L260 292L260 293L260 293L260 294L261 294L260 294L260 294L259 294L259 293L259 293L259 294L259 294L258 294L257 289L257 283L257 280L257 280L259 279z");
-            expect(popup).toEqual("Alabama");
-          });
+      expect(feature).toEqual("M205 271L201 288L196 287L193 285L187 280L187 280L188 280L188 279L188 279L188 279L188 278L189 277L189 277L189 276L189 276L190 276L190 275L190 275L190 274L190 273L190 273L190 273L190 272L190 271L191 270L191 270L192 270L192 270L192 270L193 267L201 270L205 271z");
+      expect(popup).toEqual("Arizona");
+    });
 
-          test("[" + browserType + "]" + " Next feature added + popup content updated ", async () => {
-            await page.click("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > nav > button:nth-child(4)");
-            const feature = await page.$eval(
-              "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div:nth-child(5) > svg > g > g > path",
-              (tile) => tile.getAttribute("d")
-            );
-            const popup = await page.$eval(
-              "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > iframe",
-              (iframe) => iframe.contentWindow.document.querySelector("h1").innerText
-            );
+    test("Previous feature added + popup content updated ", async () => {
+      await page.click("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > nav > button:nth-child(2)");
+      const feature = await page.$eval(
+        "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div:nth-child(5) > svg > g > g > path",
+        (tile) => tile.getAttribute("d")
+      );
+      const popup = await page.$eval(
+        "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > iframe",
+        (iframe) => iframe.contentWindow.document.querySelector("h1").innerText
+      );
 
-            expect(feature).toEqual("M205 271L201 288L196 287L193 285L187 280L187 280L188 280L188 279L188 279L188 279L188 278L189 277L189 277L189 276L189 276L190 276L190 275L190 275L190 274L190 273L190 273L190 273L190 272L190 271L191 270L191 270L192 270L192 270L192 270L193 267L201 270L205 271z");
-            expect(popup).toEqual("Arizona");
-          });
+      expect(feature).toEqual("M259 279L263 279L264 281L265 285L266 286L266 287L266 287L267 287L266 288L266 288L266 288L266 289L266 290L267 291L266 291L260 292L260 293L260 293L260 294L261 294L260 294L260 294L259 294L259 293L259 293L259 294L259 294L258 294L257 289L257 283L257 280L257 280L259 279z");
+      expect(popup).toEqual("Alabama");
+    });
 
-          test("[" + browserType + "]" + " Previous feature added + popup content updated ", async () => {
-            await page.click("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > nav > button:nth-child(2)");
-            const feature = await page.$eval(
-              "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div:nth-child(5) > svg > g > g > path",
-              (tile) => tile.getAttribute("d")
-            );
-            const popup = await page.$eval(
-              "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > iframe",
-              (iframe) => iframe.contentWindow.document.querySelector("h1").innerText
-            );
+    test("PCRS feature added + popup content updated ", async () => {
+      for (let i = 0; i < 2; i++)
+        await page.click("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > nav > button:nth-child(4)");
+      const feature = await page.$eval(
+        "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div:nth-child(5) > svg > g > g > path",
+        (tile) => tile.getAttribute("d")
+      );
+      const popup = await page.$eval(
+        "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > iframe",
+        (iframe) => iframe.contentWindow.document.querySelector("h1").innerText
+      );
 
-            expect(feature).toEqual("M259 279L263 279L264 281L265 285L266 286L266 287L266 287L267 287L266 288L266 288L266 288L266 289L266 290L267 291L266 291L260 292L260 293L260 293L260 294L261 294L260 294L260 294L259 294L259 293L259 293L259 294L259 294L258 294L257 289L257 283L257 280L257 280L259 279z");
-            expect(popup).toEqual("Alabama");
-          });
+      expect(feature).toEqual("M246 332L232 207L138 232L156 307z");
+      expect(popup).toEqual("PCRS Test");
+    });
 
-          test("[" + browserType + "]" + " PCRS feature added + popup content updated ", async () => {
-            for (let i = 0; i < 2; i++)
-              await page.click("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > nav > button:nth-child(4)");
-            const feature = await page.$eval(
-              "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div:nth-child(5) > svg > g > g > path",
-              (tile) => tile.getAttribute("d")
-            );
-            const popup = await page.$eval(
-              "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > iframe",
-              (iframe) => iframe.contentWindow.document.querySelector("h1").innerText
-            );
+    test("TCRS feature added + popup content updated ", async () => {
+      await page.click("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > nav > button:nth-child(4)");
+      const feature = await page.$eval(
+        "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div:nth-child(5) > svg > g > g > path",
+        (tile) => tile.getAttribute("d")
+      );
+      const popup = await page.$eval(
+        "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > iframe",
+        (iframe) => iframe.contentWindow.document.querySelector("h1").innerText
+      );
 
-            expect(feature).toEqual("M246 332L232 207L138 232L156 307z");
-            expect(popup).toEqual("PCRS Test");
-          });
+      expect(feature).toEqual("M292 285L352 287L355 321L307 315z");
+      expect(popup).toEqual("TCRS Test");
+    });
 
-          test("[" + browserType + "]" + " TCRS feature added + popup content updated ", async () => {
-            await page.click("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > nav > button:nth-child(4)");
-            const feature = await page.$eval(
-              "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div:nth-child(5) > svg > g > g > path",
-              (tile) => tile.getAttribute("d")
-            );
-            const popup = await page.$eval(
-              "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > iframe",
-              (iframe) => iframe.contentWindow.document.querySelector("h1").innerText
-            );
+    test("Tilematrix feature added + popup content updated ", async () => {
+      await page.click("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > nav > button:nth-child(4)");
+      const feature = await page.$eval(
+        "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div:nth-child(5) > svg > g > g > path",
+        (tile) => tile.getAttribute("d")
+      );
+      const popup = await page.$eval(
+        "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > iframe",
+        (iframe) => iframe.contentWindow.document.querySelector("h1").innerText
+      );
 
-            expect(feature).toEqual("M292 285L352 287L355 321L307 315z");
-            expect(popup).toEqual("TCRS Test");
-          });
+      expect(feature).toEqual("M307 185L395 185L395 273L307 273z");
+      expect(popup).toEqual("TILEMATRIX Test");
+    });
+    test("Synthesized point, valid location ", async () => {
+      await page.click("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > nav > button:nth-child(4)");
+      const feature = await page.$eval(
+        "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div:nth-child(5) > svg > g > g > path",
+        (tile) => tile.getAttribute("d")
+      );
+      const popup = await page.$eval(
+        "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > iframe",
+        (iframe) => iframe.contentWindow.document.querySelector("h1").innerText
+      );
 
-          test("[" + browserType + "]" + " Tilematrix feature added + popup content updated ", async () => {
-            await page.click("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > nav > button:nth-child(4)");
-            const feature = await page.$eval(
-              "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div:nth-child(5) > svg > g > g > path",
-              (tile) => tile.getAttribute("d")
-            );
-            const popup = await page.$eval(
-              "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > iframe",
-              (iframe) => iframe.contentWindow.document.querySelector("h1").innerText
-            );
-
-            expect(feature).toEqual("M307 185L395 185L395 273L307 273z");
-            expect(popup).toEqual("TILEMATRIX Test");
-          });
-          test("[" + browserType + "]" + " Synthesized point, valid location ", async () => {
-            await page.click("div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > nav > button:nth-child(4)");
-            const feature = await page.$eval(
-              "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(1) > div:nth-child(5) > svg > g > g > path",
-              (tile) => tile.getAttribute("d")
-            );
-            const popup = await page.$eval(
-              "div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-popup-pane > div > div.leaflet-popup-content-wrapper > div > div > iframe",
-              (iframe) => iframe.contentWindow.document.querySelector("h1").innerText
-            );
-
-            expect(feature).toEqual("M250 250 L237.5 220 C237.5 200, 262.5 200, 262.5 220 L250 250z");
-            expect(popup).toEqual("No Geometry");
-          });
-        });
-      });
-  };
-})();
+      expect(feature).toEqual("M250 250 L237.5 220 C237.5 200, 262.5 200, 262.5 220 L250 250z");
+      expect(popup).toEqual("No Geometry");
+    });
+  });
+});

--- a/test/e2e/mapml-viewer/customTCRS.test.js
+++ b/test/e2e/mapml-viewer/customTCRS.test.js
@@ -1,90 +1,71 @@
-const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
+describe("Playwright Custom TCRS Tests", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "customTCRS.html");
+  });
 
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright Custom TCRS Tests in " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-            slowMo: 50,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "customTCRS.html");
-        });
+  afterAll(async function () {
+    await context.close();
+  });
 
-        afterAll(async function () {
-          await browser.close();
-        });
+  test("Simple Custom TCRS, tiles load, mismatched layer disabled", async () => {
+    const misMatchedLayerDisabled = await page.$eval(
+      "body > mapml-viewer:nth-child(1) > layer-:nth-child(1)",
+      (layer) => layer.hasAttribute('disabled'));
 
-        test("[" + browserType + "]" + " Simple Custom TCRS, tiles load, mismatched layer disabled", async () => {
-          const misMatchedLayerDisabled = await page.$eval(
-            "body > mapml-viewer:nth-child(1) > layer-:nth-child(1)",
-            (layer) => layer.hasAttribute('disabled'));
-
-          const tilesLoaded = await page.$eval(
-            "xpath=//html/body/mapml-viewer[1] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-static-tile-layer > div",
-            (tileGroup) => tileGroup.getElementsByTagName("map-tile").length
-          );
-
-          expect(tilesLoaded).toEqual(2);
-          expect(misMatchedLayerDisabled).toEqual(true);
-        });
-        test("[" + browserType + "]" + " A projection name containing a colon is invalid", async () => {
-          const message = await page.$eval(
-            "body > p",
-            (message) => message.innerHTML
-          ); 
-          expect(message).toEqual("passing");
-        });
-        test("[" + browserType + "]" + " Complex Custom TCRS, static features loaded, templated features loaded", async () => {
-          const staticFeatures = await page.$eval(
-            "body > mapml-viewer:nth-child(3) > layer-:nth-child(1)",
-            (layer) => layer.hasAttribute('disabled'));
-
-          const templatedFeatures = await page.$eval(
-            "body > mapml-viewer:nth-child(3) > layer-:nth-child(2)",
-            (layer) => layer.hasAttribute('disabled'));
-
-
-          const featureOne = await page.$eval(
-            "xpath=//html/body/mapml-viewer[2] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > svg > g > g:nth-child(1) > path.leaflet-interactive",
-            (tile) => tile.getAttribute("d")
-          );
-          const featureTwo = await page.$eval(
-            "xpath=//html/body/mapml-viewer[2] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > svg > g > g:nth-child(2) > path.leaflet-interactive",
-            (tile) => tile.getAttribute("d")
-          );
-
-          const featureThree = await page.$eval(
-            "xpath=//html/body/mapml-viewer[2] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > svg > g > g:nth-child(3) > path.leaflet-interactive",
-            (tile) => tile.getAttribute("d")
-          );
-          const featureFour = await page.$eval(
-            "xpath=//html/body/mapml-viewer[2] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > svg > g > g:nth-child(4) > path.leaflet-interactive",
-            (tile) => tile.getAttribute("d")
-          );
-
-
-          expect(featureOne).toEqual("M88 681L21 78L-436 201L-346 561z");
-          expect(featureTwo).toEqual("M307 456L599 467L612 629L381 599z");
-
-          expect(featureThree).toEqual("M382 -28L809 -28L809 399L382 399z");
-          expect(featureFour).toEqual("M150 429L171 426L175 438L181 457L183 461L185 463L185 465L187 465L185 468L185 470L184 472L186 477L186 4" +
-            "81L188 485L182 486L154 490L154 492L157 494L157 497L158 498L156 501L154 501L151 499L150 495L149 495L148 498L148 501L14" +
-            "4 501L141 477L141 448L141 431L139 430L150 429z");
-
-          expect(staticFeatures).toEqual(false);
-          expect(templatedFeatures).toEqual(false);
-
-        });
-      }
+    const tilesLoaded = await page.$eval(
+      "xpath=//html/body/mapml-viewer[1] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-static-tile-layer > div",
+      (tileGroup) => tileGroup.getElementsByTagName("map-tile").length
     );
-  }
-})();
+
+    expect(tilesLoaded).toEqual(2);
+    expect(misMatchedLayerDisabled).toEqual(true);
+  });
+  test("A projection name containing a colon is invalid", async () => {
+    const message = await page.$eval(
+      "body > p",
+      (message) => message.innerHTML
+    );
+    expect(message).toEqual("passing");
+  });
+  test("Complex Custom TCRS, static features loaded, templated features loaded", async () => {
+    const staticFeatures = await page.$eval(
+      "body > mapml-viewer:nth-child(3) > layer-:nth-child(1)",
+      (layer) => layer.hasAttribute('disabled'));
+
+    const templatedFeatures = await page.$eval(
+      "body > mapml-viewer:nth-child(3) > layer-:nth-child(2)",
+      (layer) => layer.hasAttribute('disabled'));
+
+
+    const featureOne = await page.$eval(
+      "xpath=//html/body/mapml-viewer[2] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > svg > g > g:nth-child(1) > path.leaflet-interactive",
+      (tile) => tile.getAttribute("d")
+    );
+    const featureTwo = await page.$eval(
+      "xpath=//html/body/mapml-viewer[2] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > svg > g > g:nth-child(2) > path.leaflet-interactive",
+      (tile) => tile.getAttribute("d")
+    );
+
+    const featureThree = await page.$eval(
+      "xpath=//html/body/mapml-viewer[2] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > svg > g > g:nth-child(3) > path.leaflet-interactive",
+      (tile) => tile.getAttribute("d")
+    );
+    const featureFour = await page.$eval(
+      "xpath=//html/body/mapml-viewer[2] >> css=div > div.leaflet-pane.leaflet-map-pane > div.leaflet-pane.leaflet-overlay-pane > div:nth-child(2) > div.leaflet-layer.mapml-templatedlayer-container > div > div > svg > g > g:nth-child(4) > path.leaflet-interactive",
+      (tile) => tile.getAttribute("d")
+    );
+
+
+    expect(featureOne).toEqual("M88 681L21 78L-436 201L-346 561z");
+    expect(featureTwo).toEqual("M307 456L599 467L612 629L381 599z");
+
+    expect(featureThree).toEqual("M382 -28L809 -28L809 399L382 399z");
+    expect(featureFour).toEqual("M150 429L171 426L175 438L181 457L183 461L185 463L185 465L187 465L185 468L185 470L184 472L186 477L186 4" +
+      "81L188 485L182 486L154 490L154 492L157 494L157 497L158 498L156 501L154 501L151 499L150 495L149 495L148 498L148 501L14" +
+      "4 501L141 477L141 448L141 431L139 430L150 429z");
+
+    expect(staticFeatures).toEqual(false);
+    expect(templatedFeatures).toEqual(false);
+
+  });
+});

--- a/test/e2e/mapml-viewer/mapml-viewer.test.js
+++ b/test/e2e/mapml-viewer/mapml-viewer.test.js
@@ -1,129 +1,110 @@
-const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
+//expected topLeft values in the different cs, at the different
+//positions the map goes in
+let expectedPCRS = [
+  { horizontal: -9373489.01871137, vertical: 11303798.154262971 },
+  { horizontal: -5059449.140631609, vertical: 10388337.990009308 }];
+let expectedGCRS = [
+  { horizontal: -128.07848522325827, vertical: -3.3883427348651636 },
+  { horizontal: -131.75138842058425, vertical: 18.07246131233218 }];
+let expectedFirstTileMatrix = [
+  { horizontal: 2.57421875, vertical: 2.8515625 },
+  { horizontal: 3.0134698275862073, vertical: 2.944773706896552 }];
+let expectedFirstTCRS = [
+  { horizontal: 659, vertical: 730 },
+  { horizontal: 771.4482758620691, vertical: 753.8620689655173 }];
 
-  //expected topLeft values in the different cs, at the different
-  //positions the map goes in
-  let expectedPCRS = [
-    { horizontal: -9373489.01871137, vertical: 11303798.154262971 },
-    { horizontal: -5059449.140631609, vertical: 10388337.990009308 }];
-  let expectedGCRS = [
-    { horizontal: -128.07848522325827, vertical: -3.3883427348651636 },
-    { horizontal: -131.75138842058425, vertical: 18.07246131233218 }];
-  let expectedFirstTileMatrix = [
-    { horizontal: 2.57421875, vertical: 2.8515625 },
-    { horizontal: 3.0134698275862073, vertical: 2.944773706896552 }];
-  let expectedFirstTCRS = [
-    { horizontal: 659, vertical: 730 },
-    { horizontal: 771.4482758620691, vertical: 753.8620689655173 }];
+let controls = ["leaflet-control-zoom leaflet-bar leaflet-control",
+  "mapml-reload-button leaflet-bar leaflet-control",
+  "leaflet-control-fullscreen leaflet-bar leaflet-control"];
+let options = ["nozoom", "noreload", "nofullscreen"];
 
-  let controls = ["leaflet-control-zoom leaflet-bar leaflet-control",
-    "mapml-reload-button leaflet-bar leaflet-control",
-    "leaflet-control-fullscreen leaflet-bar leaflet-control"];
-  let options = ["nozoom", "noreload", "nofullscreen"];
+describe("Playwright mapml-viewer Element Tests", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "mapml-viewer.html");
+  });
 
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright mapml-viewer Element Tests in " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-            slowMo: 50,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "mapml-viewer.html");
-        });
+  afterAll(async function () {
+    await context.close();
+  });
 
-        afterAll(async function () {
-          await browser.close();
-        });
-
-        test("[" + browserType + "]" + " Initial map element extent", async () => {
-          const extent = await page.$eval(
-            "body > mapml-viewer",
-            (map) => map.extent
-          );
-
-          expect(extent.projection).toEqual("CBMTILE");
-          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
-          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
-          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
-          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
-          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
-        });
-        test("[" + browserType + "]" + " Panned and zoomed initial map's extent", async () => {
-          await page.$eval(
-            "body > mapml-viewer",
-            (map) => map.zoomTo(81, -63, 1)
-          );
-          await page.waitForTimeout(1000);
-          const extent = await page.$eval(
-            "body > mapml-viewer",
-            (map) => map.extent
-          );
-
-          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
-          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
-          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
-          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
-          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
-        });
-
-        describe("Attributes Tests in" + browserType, () => {
-          for (let i in controls) {
-            describe("Controls List " + options[i] + " Attribute Tests", () => {
-              test("[" + browserType + "] " + options[i] + " removes controls", async () => {
-                await page.$eval("body > mapml-viewer",
-                  (layer, context) => layer.setAttribute("controlslist", context.options[context.i]), { options: options, i: i });
-
-                let children = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-left", (div) => div.children),
-                  found = false;
-                for (let [key, value] of Object.entries(children)) {
-                  if (value.className === controls[i]) found = true;
-                }
-                expect(found).toEqual(false);
-              });
-              test("[" + browserType + "]" + " toggle controls, controls aren't re-enabled", async () => {
-                await page.click("body > mapml-viewer", { button: "right" });
-                await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
-                await page.click("body > mapml-viewer", { button: "right" });
-                await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
-
-                let children = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-left", (div) => div.children),
-                  found = false;
-                for (let [key, value] of Object.entries(children)) {
-                  if (value.className === controls[i]) found = true;
-                }
-                expect(found).toEqual(false);
-              });
-
-            });
-          }
-          describe("Controls List nolayer Attribute Tests", () => {
-            test("[" + browserType + "] nolayer removes controls", async () => {
-              await page.$eval("body > mapml-viewer",
-                (layer) => layer.setAttribute("controlslist", "nolayer"));
-
-              let children = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right", (div) => div.childElementCount);
-              expect(children).toEqual(0);
-            });
-            test("[" + browserType + "]" + " toggle controls, controls aren't re-enabled", async () => {
-              await page.click("body > mapml-viewer", { button: "right" });
-              await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
-              await page.click("body > mapml-viewer", { button: "right" });
-              await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
-
-              let children = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right", (div) => div.childElementCount);
-              expect(children).toEqual(0);
-            });
-          });
-        });
-      }
+  test("Initial map element extent", async () => {
+    const extent = await page.$eval(
+      "body > mapml-viewer",
+      (map) => map.extent
     );
-  }
-})();
+
+    expect(extent.projection).toEqual("CBMTILE");
+    expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+    expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
+    expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
+    expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
+    expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
+  });
+  test("Panned and zoomed initial map's extent", async () => {
+    await page.$eval(
+      "body > mapml-viewer",
+      (map) => map.zoomTo(81, -63, 1)
+    );
+    await page.waitForTimeout(1000);
+    const extent = await page.$eval(
+      "body > mapml-viewer",
+      (map) => map.extent
+    );
+
+    expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+    expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
+    expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
+    expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
+    expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
+  });
+
+  describe("Attributes Tests", () => {
+    for (let i in controls) {
+      describe("Controls List " + options[i] + " Attribute Tests", () => {
+        test(options[i] + " removes controls", async () => {
+          await page.$eval("body > mapml-viewer",
+            (layer, context) => layer.setAttribute("controlslist", context.options[context.i]), { options: options, i: i });
+
+          let children = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-left", (div) => div.children),
+            found = false;
+          for (let [key, value] of Object.entries(children)) {
+            if (value.className === controls[i]) found = true;
+          }
+          expect(found).toEqual(false);
+        });
+        test("Toggle controls, controls aren't re-enabled", async () => {
+          await page.click("body > mapml-viewer", { button: "right" });
+          await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
+          await page.click("body > mapml-viewer", { button: "right" });
+          await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
+
+          let children = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-left", (div) => div.children),
+            found = false;
+          for (let [key, value] of Object.entries(children)) {
+            if (value.className === controls[i]) found = true;
+          }
+          expect(found).toEqual(false);
+        });
+
+      });
+    }
+    describe("Controls List nolayer Attribute Tests", () => {
+      test("Nolayer removes controls", async () => {
+        await page.$eval("body > mapml-viewer",
+          (layer) => layer.setAttribute("controlslist", "nolayer"));
+
+        let children = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right", (div) => div.childElementCount);
+        expect(children).toEqual(0);
+      });
+      test("Toggle controls, controls aren't re-enabled", async () => {
+        await page.click("body > mapml-viewer", { button: "right" });
+        await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
+        await page.click("body > mapml-viewer", { button: "right" });
+        await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
+
+        let children = await page.$eval("div > div.leaflet-control-container > div.leaflet-top.leaflet-right", (div) => div.childElementCount);
+        expect(children).toEqual(0);
+      });
+    });
+  });
+});

--- a/test/e2e/mapml-viewer/viewerContextMenu.test.js
+++ b/test/e2e/mapml-viewer/viewerContextMenu.test.js
@@ -1,286 +1,267 @@
-const playwright = require("playwright");
-jest.setTimeout(50000);
-(async () => {
+//expected topLeft values in the different cs, at the different
+//positions the map goes in
+let expectedPCRS = [
+  { horizontal: -9373489.01871137, vertical: 11303798.154262971 },
+  { horizontal: -5059449.140631609, vertical: 10388337.990009308 }];
+let expectedGCRS = [
+  { horizontal: -128.07848522325827, vertical: -3.3883427348651636 },
+  { horizontal: -131.75138842058425, vertical: 18.07246131233218 }];
+let expectedFirstTileMatrix = [
+  { horizontal: 2.57421875, vertical: 2.8515625 },
+  { horizontal: 3.0134698275862073, vertical: 2.944773706896552 }];
+let expectedFirstTCRS = [
+  { horizontal: 659, vertical: 730 },
+  { horizontal: 771.4482758620691, vertical: 753.8620689655173 }];
 
-  //expected topLeft values in the different cs, at the different
-  //positions the map goes in
-  let expectedPCRS = [
-    { horizontal: -9373489.01871137, vertical: 11303798.154262971 },
-    { horizontal: -5059449.140631609, vertical: 10388337.990009308 }];
-  let expectedGCRS = [
-    { horizontal: -128.07848522325827, vertical: -3.3883427348651636 },
-    { horizontal: -131.75138842058425, vertical: 18.07246131233218 }];
-  let expectedFirstTileMatrix = [
-    { horizontal: 2.57421875, vertical: 2.8515625 },
-    { horizontal: 3.0134698275862073, vertical: 2.944773706896552 }];
-  let expectedFirstTCRS = [
-    { horizontal: 659, vertical: 730 },
-    { horizontal: 771.4482758620691, vertical: 753.8620689655173 }];
+describe("Playwright mapml-viewer Context Menu (and api) Tests", () => {
+  beforeAll(async () => {
+    await page.goto(PATH + "mapml-viewer.html");
+  });
 
-  for (const browserType of BROWSER) {
-    describe(
-      "Playwright mapml-viewer Context Menu (and api) Tests in " + browserType,
-      () => {
-        beforeAll(async () => {
-          browser = await playwright[browserType].launch({
-            headless: ISHEADLESS,
-            slowMo: 50,
-          });
-          context = await browser.newContext();
-          page = await context.newPage();
-          if (browserType === "firefox") {
-            await page.waitForNavigation();
-          }
-          await page.goto(PATH + "mapml-viewer.html");
-        });
+  afterAll(async function () {
+    await context.close();
+  });
 
-        afterAll(async function () {
-          await browser.close();
-        });
+  test("Context menu focus on keyboard shortcut", async () => {
+    await page.click("body > mapml-viewer");
+    await page.keyboard.press("Shift+F10");
+    const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+    const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
+    const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
+    const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
+    let name = await nameHandle.jsonValue();
+    await nameHandle.dispose();
+    expect(name).toEqual("Back (B)");
+  });
 
-        test("[" + browserType + "]" + " Context menu focus on keyboard shortcut", async () => {
-          await page.click("body > mapml-viewer");
-          await page.keyboard.press("Shift+F10");
-          const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-          const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
-          const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
-          const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
-          let name = await nameHandle.jsonValue();
-          await nameHandle.dispose();
-          expect(name).toEqual("Back (B)");
-        });
-
-        test("[" + browserType + "]" + " Context menu tab goes to next item", async () => {
-          await page.keyboard.press("Tab");
-          const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-          const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
-          const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
-          const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
-          let name = await nameHandle.jsonValue();
-          await nameHandle.dispose();
-          expect(name).toEqual("Forward (F)");
-        });
+  test("Context menu tab goes to next item", async () => {
+    await page.keyboard.press("Tab");
+    const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+    const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
+    const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
+    const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
+    let name = await nameHandle.jsonValue();
+    await nameHandle.dispose();
+    expect(name).toEqual("Forward (F)");
+  });
 
 
-        test("[" + browserType + "]" + " Context menu shift + tab goes to previous item", async () => {
-          await page.keyboard.press("Shift+Tab");
-          const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-          const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
-          const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
-          const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
-          let name = await nameHandle.jsonValue();
-          await nameHandle.dispose();
-          expect(name).toEqual("Back (B)");
-        });
+  test("Context menu shift + tab goes to previous item", async () => {
+    await page.keyboard.press("Shift+Tab");
+    const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+    const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
+    const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
+    const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
+    let name = await nameHandle.jsonValue();
+    await nameHandle.dispose();
+    expect(name).toEqual("Back (B)");
+  });
 
-        test("[" + browserType + "]" + " Submenu opens on C with focus on first item", async () => {
-          await page.keyboard.press("c");
-          const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
-          const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
-          const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
-          const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
-          let name = await nameHandle.jsonValue();
-          await nameHandle.dispose();
-          expect(name).toEqual("tile");
-        });
+  test("Submenu opens on C with focus on first item", async () => {
+    await page.keyboard.press("c");
+    const aHandle = await page.evaluateHandle(() => document.querySelector("mapml-viewer"));
+    const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
+    const resultHandle = await page.evaluateHandle(root => root.activeElement, nextHandle);
+    const nameHandle = await page.evaluateHandle(name => name.outerText, resultHandle);
+    let name = await nameHandle.jsonValue();
+    await nameHandle.dispose();
+    expect(name).toEqual("tile");
+  });
 
-        test("[" + browserType + "]" + " Context menu displaying on map", async () => {
-          await page.click("body > mapml-viewer", { button: "right" });
-          const contextMenu = await page.$eval(
-            "div > div.mapml-contextmenu",
-            (menu) => menu.style.display
-          );
-          expect(contextMenu).toEqual("block");
-        });
-        test("[" + browserType + "]" + " Context menu, back item", async () => {
-          await page.$eval(
-            "body > mapml-viewer",
-            (map) => map.zoomTo(81, -63, 1)
-          );
-          await page.waitForTimeout(1000);
-          await page.click("body > mapml-viewer", { button: "right" });
-          await page.click("div > div.mapml-contextmenu > button:nth-child(1)");
-          await page.waitForTimeout(1000);
-          const extent = await page.$eval(
-            "body > mapml-viewer",
-            (map) => map.extent
-          );
-
-          expect(extent.projection).toEqual("CBMTILE");
-          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
-          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
-          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
-          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
-          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
-        });
-        test("[" + browserType + "]" + " Context menu, back item at intial location", async () => {
-          await page.click("body > mapml-viewer", { button: "right" });
-          await page.click("div > div.mapml-contextmenu > button:nth-child(1)");
-          await page.waitForTimeout(1000);
-          const extent = await page.$eval(
-            "body > mapml-viewer",
-            (map) => map.extent
-          );
-
-          expect(extent.projection).toEqual("CBMTILE");
-          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
-          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
-          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
-          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
-          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
-        });
-        test("[" + browserType + "]" + " Context menu, forward item", async () => {
-          await page.click("body > mapml-viewer", { button: "right" });
-          await page.click("div > div.mapml-contextmenu > button:nth-child(2)");
-          await page.waitForTimeout(1000);
-          const extent = await page.$eval(
-            "body > mapml-viewer",
-            (map) => map.extent
-          );
-
-          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
-          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
-          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
-          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
-          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
-        });
-        test("[" + browserType + "]" + " Context menu, forward item at most recent location", async () => {
-          await page.click("body > mapml-viewer", { button: "right" });
-          await page.click("div > div.mapml-contextmenu > button:nth-child(2)");
-          await page.waitForTimeout(1000);
-          const extent = await page.$eval(
-            "body > mapml-viewer",
-            (map) => map.extent
-          );
-
-          expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
-          expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
-          expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
-          expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
-          expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
-        });
-
-        describe("Context Menu, Toggle Controls " + browserType, () => {
-          test("[" + browserType + "]" + " Context menu, toggle controls off", async () => {
-            const controlsOn = await page.$eval(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
-              (controls) => controls.childElementCount
-            );
-
-            await page.click("body > mapml-viewer", { button: "right" });
-            await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
-
-            const controlsOff = await page.$eval(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
-              (controls) => controls.childElementCount
-            );
-
-            expect(controlsOn).toEqual(3);
-            expect(controlsOff).toEqual(0);
-          });
-
-          test("[" + browserType + "]" + " Context menu, toggle controls on", async () => {
-            const controlsOn = await page.$eval(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
-              (controls) => controls.childElementCount
-            );
-
-            await page.click("body > mapml-viewer", { button: "right" });
-            await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
-
-            const controlsOff = await page.$eval(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
-              (controls) => controls.childElementCount
-            );
-
-            expect(controlsOn).toEqual(0);
-            expect(controlsOff).toEqual(3);
-          });
-
-          test("[" + browserType + "]" + " Context menu, toggle controls after changing opacity", async () => {
-            await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
-            await page.click(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div > div > button:nth-child(2)",
-              (div) => div.open = true
-            );
-            await page.$eval(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details",
-              (div) => div.open = true
-            );
-            await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details > input");
-            const valueBefore = await page.$eval(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details > input",
-              (opacity) => opacity.value
-            );
-            expect(valueBefore).toEqual("0.5");
-
-            await page.click("body > mapml-viewer", { button: "right" });
-            await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
-            await page.click("body > mapml-viewer", { button: "right" });
-            await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
-
-            const valueAfter = await page.$eval(
-              "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details > input",
-              (opacity) => opacity.value
-            );
-
-            expect(valueAfter).toEqual("0.5");
-          });
-        });
-
-        test("[" + browserType + "]" + " Submenu, copy all coordinate systems using tab + enter to access", async () => {
-          await page.click("body > mapml-viewer");
-          await page.keyboard.press("Shift+F10");
-          for (let i = 0; i < 4; i++)
-            await page.keyboard.press("Tab");
-
-          await page.keyboard.press("Enter");
-
-          await page.click("#mapml-copy-submenu > button:nth-child(10)");
-
-          await page.click("body > textarea");
-          await page.keyboard.press("Control+v");
-          const copyValue = await page.$eval(
-            "body > textarea",
-            (text) => text.value
-          );
-          let expected = "z:1\n";
-          expected += "tile: i:30, j:50\n";
-          expected += "tilematrix: column:6, row:6\n";
-          expected += "map: i:250, j:300\n";
-          expected += "tcrs: x:1566, y:1586\n";
-          expected += "pcrs: easting:562957.94, northing:3641449.50\n";
-          expected += "gcrs: lon :-62.729466, lat:80.881921";
-
-          expect(copyValue).toEqual(expected);
-        });
-
-        test("[" + browserType + "]" + " Submenu, copy all coordinate systems", async () => {
-          await page.click("body > mapml-viewer");
-          await page.keyboard.press("Shift+F10");
-          await page.keyboard.press("c");
-
-          await page.click("#mapml-copy-submenu > button:nth-child(10)");
-
-          await page.click("body > textarea");
-          await page.keyboard.press("Control+a");
-          await page.keyboard.press("Backspace");
-          await page.keyboard.press("Control+v");
-          const copyValue = await page.$eval(
-            "body > textarea",
-            (text) => text.value
-          );
-          let expected = "z:1\n";
-          expected += "tile: i:30, j:50\n";
-          expected += "tilematrix: column:6, row:6\n";
-          expected += "map: i:250, j:300\n";
-          expected += "tcrs: x:1566, y:1586\n";
-          expected += "pcrs: easting:562957.94, northing:3641449.50\n";
-          expected += "gcrs: lon :-62.729466, lat:80.881921";
-
-          expect(copyValue).toEqual(expected);
-        });
-      }
+  test("Context menu displaying on map", async () => {
+    await page.click("body > mapml-viewer", { button: "right" });
+    const contextMenu = await page.$eval(
+      "div > div.mapml-contextmenu",
+      (menu) => menu.style.display
     );
-  }
-})();
+    expect(contextMenu).toEqual("block");
+  });
+  test("Context menu, back item", async () => {
+    await page.$eval(
+      "body > mapml-viewer",
+      (map) => map.zoomTo(81, -63, 1)
+    );
+    await page.waitForTimeout(1000);
+    await page.click("body > mapml-viewer", { button: "right" });
+    await page.click("div > div.mapml-contextmenu > button:nth-child(1)");
+    await page.waitForTimeout(1000);
+    const extent = await page.$eval(
+      "body > mapml-viewer",
+      (map) => map.extent
+    );
+
+    expect(extent.projection).toEqual("CBMTILE");
+    expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+    expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
+    expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
+    expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
+    expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
+  });
+  test("Context menu, back item at intial location", async () => {
+    await page.click("body > mapml-viewer", { button: "right" });
+    await page.click("div > div.mapml-contextmenu > button:nth-child(1)");
+    await page.waitForTimeout(1000);
+    const extent = await page.$eval(
+      "body > mapml-viewer",
+      (map) => map.extent
+    );
+
+    expect(extent.projection).toEqual("CBMTILE");
+    expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+    expect(extent.topLeft.pcrs).toEqual(expectedPCRS[0]);
+    expect(extent.topLeft.gcrs).toEqual(expectedGCRS[0]);
+    expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[0]);
+    expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[0]);
+  });
+  test("Context menu, forward item", async () => {
+    await page.click("body > mapml-viewer", { button: "right" });
+    await page.click("div > div.mapml-contextmenu > button:nth-child(2)");
+    await page.waitForTimeout(1000);
+    const extent = await page.$eval(
+      "body > mapml-viewer",
+      (map) => map.extent
+    );
+
+    expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+    expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
+    expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
+    expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
+    expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
+  });
+  test("Context menu, forward item at most recent location", async () => {
+    await page.click("body > mapml-viewer", { button: "right" });
+    await page.click("div > div.mapml-contextmenu > button:nth-child(2)");
+    await page.waitForTimeout(1000);
+    const extent = await page.$eval(
+      "body > mapml-viewer",
+      (map) => map.extent
+    );
+
+    expect(extent.zoom).toEqual({ minZoom: 0, maxZoom: 25 });
+    expect(extent.topLeft.pcrs).toEqual(expectedPCRS[1]);
+    expect(extent.topLeft.gcrs).toEqual(expectedGCRS[1]);
+    expect(extent.topLeft.tilematrix[0]).toEqual(expectedFirstTileMatrix[1]);
+    expect(extent.topLeft.tcrs[0]).toEqual(expectedFirstTCRS[1]);
+  });
+
+  describe("Context Menu, Toggle Controls ", () => {
+    test("Context menu, toggle controls off", async () => {
+      const controlsOn = await page.$eval(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
+        (controls) => controls.childElementCount
+      );
+
+      await page.click("body > mapml-viewer", { button: "right" });
+      await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
+
+      const controlsOff = await page.$eval(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
+        (controls) => controls.childElementCount
+      );
+
+      expect(controlsOn).toEqual(3);
+      expect(controlsOff).toEqual(0);
+    });
+
+    test("Context menu, toggle controls on", async () => {
+      const controlsOn = await page.$eval(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
+        (controls) => controls.childElementCount
+      );
+
+      await page.click("body > mapml-viewer", { button: "right" });
+      await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
+
+      const controlsOff = await page.$eval(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-left",
+        (controls) => controls.childElementCount
+      );
+
+      expect(controlsOn).toEqual(0);
+      expect(controlsOff).toEqual(3);
+    });
+
+    test("Context menu, toggle controls after changing opacity", async () => {
+      await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
+      await page.click(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div > div > button:nth-child(2)",
+        (div) => div.open = true
+      );
+      await page.$eval(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details",
+        (div) => div.open = true
+      );
+      await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details > input");
+      const valueBefore = await page.$eval(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details > input",
+        (opacity) => opacity.value
+      );
+      expect(valueBefore).toEqual("0.5");
+
+      await page.click("body > mapml-viewer", { button: "right" });
+      await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
+      await page.click("body > mapml-viewer", { button: "right" });
+      await page.click("div > div.mapml-contextmenu > button:nth-child(5)");
+
+      const valueAfter = await page.$eval(
+        "div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset > div:nth-child(2) > details > input",
+        (opacity) => opacity.value
+      );
+
+      expect(valueAfter).toEqual("0.5");
+    });
+  });
+
+  test("Submenu, copy all coordinate systems using tab + enter to access", async () => {
+    await page.click("body > mapml-viewer");
+    await page.keyboard.press("Shift+F10");
+    for (let i = 0; i < 4; i++)
+      await page.keyboard.press("Tab");
+
+    await page.keyboard.press("Enter");
+
+    await page.click("#mapml-copy-submenu > button:nth-child(10)");
+
+    await page.click("body > textarea");
+    await page.keyboard.press("Control+v");
+    const copyValue = await page.$eval(
+      "body > textarea",
+      (text) => text.value
+    );
+    let expected = "z:1\n";
+    expected += "tile: i:30, j:50\n";
+    expected += "tilematrix: column:6, row:6\n";
+    expected += "map: i:250, j:300\n";
+    expected += "tcrs: x:1566, y:1586\n";
+    expected += "pcrs: easting:562957.94, northing:3641449.50\n";
+    expected += "gcrs: lon :-62.729466, lat:80.881921";
+
+    expect(copyValue).toEqual(expected);
+  });
+
+  test("Submenu, copy all coordinate systems", async () => {
+    await page.click("body > mapml-viewer");
+    await page.keyboard.press("Shift+F10");
+    await page.keyboard.press("c");
+
+    await page.click("#mapml-copy-submenu > button:nth-child(10)");
+
+    await page.click("body > textarea");
+    await page.keyboard.press("Control+a");
+    await page.keyboard.press("Backspace");
+    await page.keyboard.press("Control+v");
+    const copyValue = await page.$eval(
+      "body > textarea",
+      (text) => text.value
+    );
+    let expected = "z:1\n";
+    expected += "tile: i:30, j:50\n";
+    expected += "tilematrix: column:6, row:6\n";
+    expected += "map: i:250, j:300\n";
+    expected += "tcrs: x:1566, y:1586\n";
+    expected += "pcrs: easting:562957.94, northing:3641449.50\n";
+    expected += "gcrs: lon :-62.729466, lat:80.881921";
+
+    expect(copyValue).toEqual(expected);
+  });
+});


### PR DESCRIPTION
![time](https://user-images.githubusercontent.com/55214462/141663858-37fe027c-eafe-4671-82fd-bddfcba70559.PNG)

Refactor and parallelism resulted in tests running in under 2 minutes (or less).
This requires the use of `await page.waitForTimeout(200);` when doing many keyboard interactions in a row to prevent missed keys.

- [x] Certain tests are currently unstable, need fix

Closes #518 (indirect, as instead of launching a single browser, it's launching multiple browsers depending on the device)