### PR TITLE
Use host selector for debug mode's fullscreen styles

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -385,6 +385,11 @@
   display: inline;
 }
 
+:host(.mapml-fullscreen-on) .mapml-debug-grid {
+  color: #fff;
+  text-shadow: 1px 1px 1px #000, 1px 1px 1px #000;
+}
+
 /*
  * User interaction.
  */
@@ -610,11 +615,6 @@ summary {
 svg.leaflet-image-layer.leaflet-interactive g {
   pointer-events: visiblePainted; /* IE 9-10 doesn't have auto */
   pointer-events: auto;
-}
-
-:fullscreen .mapml-debug-grid {
-  color: #fff;
-  text-shadow: 1px 1px 1px #000, 1px 1px 1px #000;
 }
 
 .mapml-link-preview {


### PR DESCRIPTION
I forgot these styles existed when reviewing https://github.com/Maps4HTML/Web-Map-Custom-Element/pull/581.