### PR TITLE
Layer control Accessibility Bug Fixes

### DIFF
--- a/src/mapml/handlers/ContextMenu.js
+++ b/src/mapml/handlers/ContextMenu.js
@@ -426,6 +426,8 @@ export var ContextMenu = L.Handler.extend({
     if(e.originalEvent.button === 0 || e.originalEvent.button === -1){
       this._keyboardEvent = true;
       if(this._layerClicked){
+        let activeEl = document.activeElement;
+        this._elementInFocus = activeEl.shadowRoot.activeElement;
         this._layerMenuTabs = 1;
         this._layerMenu.firstChild.focus();
       } else {
@@ -526,7 +528,12 @@ export var ContextMenu = L.Handler.extend({
     this._mapMenuVisible = false;
     delete this._layerMenuTabs;
     this._layerMenu.style.display = 'none';
-    this._layerClicked.parentElement.firstChild.focus();
+    if(this._elementInFocus){
+      this._elementInFocus.focus();
+    } else {
+      this._layerClicked.parentElement.firstChild.focus();
+    }
+    delete this._elementInFocus;
   },
 
   _onKeyDown: function (e) {
@@ -537,8 +544,10 @@ export var ContextMenu = L.Handler.extend({
 
     if(key === 13)
       e.preventDefault();
-    if(key !== 16 && key!== 9 && !(!this._layerClicked && key === 67) && path[0].innerText !== (M.options.locale.cmCopyCoords + " (C)"))
-      this._hide();
+    if(key !== 16 && key!== 9 && !(!this._layerClicked && key === 67) && path[0].innerText !== (M.options.locale.cmCopyCoords + " (C)")){
+      L.DomEvent.stop(e);
+      this._focusOnLayerControl();
+    }
     // keep track of where the focus is on the layer menu and when the layer menu is tabbed out of, focus on layer control
     if(key === 9){
       if(e.shiftKey){
@@ -586,9 +595,6 @@ export var ContextMenu = L.Handler.extend({
         break;
       case 86: //V KEY
         this._viewSource(e);
-        break;
-      case 27: //H KEY
-        this._hide();
         break;
       case 90: //Z KEY
         if(this._layerClicked)

--- a/src/mapml/handlers/ContextMenu.js
+++ b/src/mapml/handlers/ContextMenu.js
@@ -425,7 +425,13 @@ export var ContextMenu = L.Handler.extend({
     }
     if(e.originalEvent.button === 0 || e.originalEvent.button === -1){
       this._keyboardEvent = true;
-      this._container.firstChild.focus();
+      if(this._layerClicked){
+        this._layerMenuTabs = 1;
+        this._layerMenu.firstChild.focus();
+      } else {
+        this._container.firstChild.focus();
+      }
+
     }
   },
 
@@ -515,6 +521,14 @@ export var ContextMenu = L.Handler.extend({
       return size;
   },
 
+   // once tab is clicked on the layer menu, change the focus back to the layer control
+   _focusOnLayerControl: function(){
+    this._mapMenuVisible = false;
+    delete this._layerMenuTabs;
+    this._layerMenu.style.display = 'none';
+    this._layerClicked.parentElement.firstChild.focus();
+  },
+
   _onKeyDown: function (e) {
     if(!this._mapMenuVisible) return;
 
@@ -525,6 +539,18 @@ export var ContextMenu = L.Handler.extend({
       e.preventDefault();
     if(key !== 16 && key!== 9 && !(!this._layerClicked && key === 67) && path[0].innerText !== (M.options.locale.cmCopyCoords + " (C)"))
       this._hide();
+    // keep track of where the focus is on the layer menu and when the layer menu is tabbed out of, focus on layer control
+    if(key === 9){
+      if(e.shiftKey){
+        this._layerMenuTabs -= 1;
+      } else {
+        this._layerMenuTabs += 1;
+      }
+      if(this._layerMenuTabs === 0 || this._layerMenuTabs === 3){
+        L.DomEvent.stop(e);
+        this._focusOnLayerControl();
+      } 
+    }
     switch(key){
       case 13:  //ENTER KEY
       case 32:  //SPACE KEY

--- a/src/mapml/layers/ControlLayer.js
+++ b/src/mapml/layers/ControlLayer.js
@@ -25,6 +25,7 @@ export var MapMLLayerControl = L.Control.Layers.extend({
         this._initLayout();
         this._map.on('validate', this._validateInput, this);
         L.DomEvent.on(this.options.mapEl, "layerchange", this._validateInput, this);
+        L.DomEvent.on(this._container, 'keydown', this._focusFirstLayer, this._container);
         this._update();
         //this._validateExtents();
         if(this._layers.length < 1 && !this._map._showControls){
@@ -36,6 +37,7 @@ export var MapMLLayerControl = L.Control.Layers.extend({
     },
     onRemove: function (map) {
         map.off('validate', this._validateInput, this);
+        L.DomEvent.off(this._container, 'keydown', this._focusFirstLayer, this._container);
         // remove layer-registerd event handlers so that if the control is not
         // on the map it does not generate layer events
         for (var i = 0; i < this._layers.length; i++) {
@@ -84,6 +86,15 @@ export var MapMLLayerControl = L.Control.Layers.extend({
       }
 
     },
+
+    // focus the first layer in the layer control when enter is pressed
+    _focusFirstLayer: function(e){
+      if(e.key === 'Enter' && this.className != 'leaflet-control-layers leaflet-control leaflet-control-layers-expanded'){
+        var elem = this.children[1].children[2].children[0].children[0].children[0].children[0];
+        if(elem) setTimeout(() => elem.focus(), 0);
+        }
+    },
+    
     _withinZoomBounds: function(zoom, range) {
         return range.min <= zoom && zoom <= range.max;
     },


### PR DESCRIPTION
Fixed the following issues:

- shift the focus to first layer entry upon pressing enter to open the layer control
- shift focus to layer context menu when it's opened and shift focus back to the layer entry when it's closed

Closes #578