### PR TITLE
Fix keyboard panning scrolling document issue

### DIFF
--- a/src/mapml/keyboard.js
+++ b/src/mapml/keyboard.js
@@ -45,6 +45,6 @@ L.Map.Keyboard.include({
             return;
         }
 
-        stop(e);
+        L.DomEvent.stop(e);
     }
 });


### PR DESCRIPTION
I did not properly call stop() when overriding the onKeyDown function (https://github.com/Maps4HTML/Web-Map-Custom-Element/pull/567)
Closes https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/592
