### PR TITLE
Focus on Layer Menu Item or Link if Remove Button is clicked

### DIFF
--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -386,9 +386,6 @@ export var MapMLLayer = L.Layer.extend({
     getAttribution: function () {
         return this.options.attribution;
     },
-    getShadowRoot: function(root){
-
-    },
     getLayerUserControlsHTML: function () {
       var fieldset = L.DomUtil.create('fieldset', 'mapml-layer-item'),
         input = L.DomUtil.create('input'),

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -386,6 +386,9 @@ export var MapMLLayer = L.Layer.extend({
     getAttribution: function () {
         return this.options.attribution;
     },
+    getShadowRoot: function(root){
+
+    },
     getLayerUserControlsHTML: function () {
       var fieldset = L.DomUtil.create('fieldset', 'mapml-layer-item'),
         input = L.DomUtil.create('input'),
@@ -425,7 +428,8 @@ export var MapMLLayer = L.Layer.extend({
         //L.DomEvent.disableClickPropagation(removeControlButton);
         L.DomEvent.on(removeControlButton, 'click', L.DomEvent.stop);
         L.DomEvent.on(removeControlButton, 'click', (e)=>{
-          let fieldset = 0, elem;
+          let fieldset = 0, elem, root;
+          root = mapEl.tagName === "MAPML-VIEWER" ? mapEl.shadowRoot : mapEl.querySelector(".mapml-web-map").shadowRoot;
           if(e.target.closest("fieldset").nextElementSibling){
             elem = e.target.closest("fieldset").previousElementSibling;
             while(elem){
@@ -434,11 +438,11 @@ export var MapMLLayer = L.Layer.extend({
             }
           } else {
             // focus on the link
-            elem = document.getElementsByTagName('mapml-viewer')[0].shadowRoot.querySelector(".leaflet-control-attribution").firstElementChild;
+            elem = root.querySelector(".leaflet-control-attribution").firstElementChild;
           }
           mapEl.removeChild(e.target.closest("fieldset").querySelector("span").layer._layerEl);
           if(elem === null){
-            elem = document.body.getElementsByTagName('mapml-viewer')[0].shadowRoot.querySelectorAll('input')[fieldset];
+            elem = root.querySelectorAll('input')[fieldset];
           }
           if(elem) setTimeout(() => elem.focus(), 800); // a timeout is set so "pressed remove layer" is announced first
         }, this);

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -425,7 +425,22 @@ export var MapMLLayer = L.Layer.extend({
         //L.DomEvent.disableClickPropagation(removeControlButton);
         L.DomEvent.on(removeControlButton, 'click', L.DomEvent.stop);
         L.DomEvent.on(removeControlButton, 'click', (e)=>{
+          let fieldset = 0, elem;
+          if(e.target.closest("fieldset").nextElementSibling){
+            elem = e.target.closest("fieldset").previousElementSibling;
+            while(elem){
+              fieldset += 2; // find the next layer menu item
+              elem = elem.previousElementSibling;
+            }
+          } else {
+            // focus on the link
+            elem = document.getElementsByTagName('mapml-viewer')[0].shadowRoot.querySelector(".leaflet-control-attribution").firstElementChild;
+          }
           mapEl.removeChild(e.target.closest("fieldset").querySelector("span").layer._layerEl);
+          if(elem === null){
+            elem = document.body.getElementsByTagName('mapml-viewer')[0].shadowRoot.querySelectorAll('input')[fieldset];
+          }
+          if(elem) setTimeout(() => elem.focus(), 800); // a timeout is set so "pressed remove layer" is announced first
         }, this);
 
         let itemSettingControlButton = L.DomUtil.create('button', 'mapml-layer-item-settings-control', layerItemControls);

--- a/src/mapml/layers/MapLayer.js
+++ b/src/mapml/layers/MapLayer.js
@@ -427,7 +427,7 @@ export var MapMLLayer = L.Layer.extend({
         L.DomEvent.on(removeControlButton, 'click', (e)=>{
           let fieldset = 0, elem, root;
           root = mapEl.tagName === "MAPML-VIEWER" ? mapEl.shadowRoot : mapEl.querySelector(".mapml-web-map").shadowRoot;
-          if(e.target.closest("fieldset").nextElementSibling){
+          if(e.target.closest("fieldset").nextElementSibling && !e.target.closest("fieldset").nextElementSibling.disbaled){
             elem = e.target.closest("fieldset").previousElementSibling;
             while(elem){
               fieldset += 2; // find the next layer menu item
@@ -435,13 +435,11 @@ export var MapMLLayer = L.Layer.extend({
             }
           } else {
             // focus on the link
-            elem = root.querySelector(".leaflet-control-attribution").firstElementChild;
+            elem = "link";
           }
           mapEl.removeChild(e.target.closest("fieldset").querySelector("span").layer._layerEl);
-          if(elem === null){
-            elem = root.querySelectorAll('input')[fieldset];
-          }
-          if(elem) setTimeout(() => elem.focus(), 800); // a timeout is set so "pressed remove layer" is announced first
+          elem = elem ? root.querySelector(".leaflet-control-attribution").firstElementChild: elem = root.querySelectorAll('input')[fieldset];
+          setTimeout(() => elem.focus(), 800); // a timeout is set so "pressed remove layer" is announced first
         }, this);
 
         let itemSettingControlButton = L.DomUtil.create('button', 'mapml-layer-item-settings-control', layerItemControls);

--- a/test/e2e/core/featureLinks.test.js
+++ b/test/e2e/core/featureLinks.test.js
@@ -25,6 +25,7 @@ describe("Playwright Feature Links Tests", () => {
       test("Sub-point inplace link adds new layer, parent feature has separate link", async () => {
         await page.hover(".leaflet-top.leaflet-right");
         await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(2) > div:nth-child(1) > div > button:nth-child(1)");
+        await page.waitForTimeout(850);
         await page.click("body > map");
         for(let i = 0; i < 6; i++) {
           await page.keyboard.press("Tab");
@@ -59,6 +60,7 @@ describe("Playwright Feature Links Tests", () => {
       test("Main part adds new layer", async () => {
         await page.hover(".leaflet-top.leaflet-right");
         await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(2) > div:nth-child(1) > div > button:nth-child(1)");
+        await page.waitForTimeout(850);
         await page.click("body > map");
         for(let i = 0; i < 5; i++) {
           await page.keyboard.press("Tab");


### PR DESCRIPTION
Once a layer is removed using the layer control, the focus shifts to the next layer menu item, if it exists, or the attribution link

Closes #589