### PR TITLE
Ctrl arrow decreases pan offset

### DIFF
--- a/src/mapml/keyboard.js
+++ b/src/mapml/keyboard.js
@@ -28,7 +28,7 @@ L.Map.Keyboard.include({
                     offset = L.point(offset).multiplyBy(3);
                 }
                 if (e.ctrlKey) {
-                    offset = L.point(offset).divideBy(3);
+                    offset = L.point(offset).divideBy(5);
                 }
 
                 map.panBy(offset);

--- a/src/mapml/keyboard.js
+++ b/src/mapml/keyboard.js
@@ -1,7 +1,7 @@
 L.Map.Keyboard.include({
     _onKeyDown: function (e) {
 
-        if (e.altKey || e.ctrlKey || e.metaKey) { return; }
+        if (e.altKey || e.metaKey) { return; }
 
         let zoomIn = {
             187: 187,
@@ -26,6 +26,9 @@ L.Map.Keyboard.include({
                 offset = this._panKeys[key];
                 if (e.shiftKey) {
                     offset = L.point(offset).multiplyBy(3);
+                }
+                if (e.ctrlKey) {
+                    offset = L.point(offset).divideBy(3);
                 }
 
                 map.panBy(offset);


### PR DESCRIPTION
Closes https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/388
Leaflet does not want modifier + arrow keys being pressed -> https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/388#issuecomment-980096154 so leaving this as a draft for further discussion.