### PR TITLE
Support the `hidden` attribute on the map elements

### DIFF
--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -124,6 +124,9 @@ export class MapViewer extends HTMLElement {
     `:host([frameborder="0"]) {` +
     `border-width: 0;` +
     `}` +
+    `:host([hidden]) {` +
+    `display: none!important;` +
+    `}` +
     `:host .mapml-contextmenu,` +
     `:host .leaflet-control-container {` +
     `visibility: hidden!important;` + // Visibility hack to improve percieved performance (mitigate FOUC) – visibility is unset in mapml.css! (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/154).

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -133,6 +133,9 @@ export class WebMap extends HTMLMapElement {
     `[is="web-map"][frameborder="0"] {` +
   	`border-width: 0;` +
   	`}` +
+    `[is="web-map"][hidden] {` +
+    `display: none!important;` +
+    `}` +
     `[is="web-map"] .mapml-web-map {` +
     `display: contents;` + // This div doesn't have to participate in layout by generating its own box.
     `}`;


### PR DESCRIPTION
Quite an oversight. To support the global [`hidden`](https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute) attribute we have to handle the `display` ourselves, otherwise it is overridden by the [`display: inline-block` declaration](https://github.com/Maps4HTML/Web-Map-Custom-Element/blob/7a0b4dc99e31c65f978816a8b60ff80b9c0869fe/src/mapml-viewer.js#L118) that is set for the default display.

I chose to use an `!important` declaration because if the authors changes the default from `display: inline-block` (which is used in a `:host` selector that has lower specificity than element selectors) to `mapml-viewer { display: block }` then uses `hidden` it'll still be `display: block`. And because: https://github.com/jensimmons/cssremedy/issues/71#issuecomment-771180150.
