### PR TITLE
Replace `style` attributes with presentation attributes in the context menu and crosshair

### DIFF
--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -127,7 +127,6 @@ export class MapViewer extends HTMLElement {
     `:host([hidden]) {` +
     `display: none!important;` +
     `}` +
-    `:host .mapml-contextmenu,` +
     `:host .leaflet-control-container {` +
     `visibility: hidden!important;` + // Visibility hack to improve percieved performance (mitigate FOUC) – visibility is unset in mapml.css! (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/154).
     `}`;

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -259,7 +259,6 @@
  */
 
 .mapml-contextmenu {
-  display: none;
   border-radius: 4px;
   padding: 4px 0;
   background-color: #fff;
@@ -270,7 +269,6 @@
 }
 
 .mapml-contextmenu button.mapml-contextmenu-item {
-  display: block;
   color: #222;
   font-size: 12px;
   line-height: 20px;

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -462,7 +462,7 @@
   outline: 0;
 }
 .leaflet-container:not(:focus-within) .mapml-crosshair {
-  visibility: hidden;
+  display: none;
 }
 
 /* Restore the default UA tap highlight color by overriding the opinionated tap
@@ -494,6 +494,10 @@ summary {
   cursor: crosshair;
 }
 
+[hidden] {
+  display: none!important;
+}
+
 /*
  * Visibility hack – mitigates FOUC.
  * (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/154)
@@ -511,8 +515,6 @@ summary {
   height: 72px;
   left: 50%;
   top: 50%;
-  content: '';
-  display: block;
   position: absolute;
   z-index: 10000;
 }

--- a/src/mapml/handlers/ContextMenu.js
+++ b/src/mapml/handlers/ContextMenu.js
@@ -106,6 +106,7 @@ export var ContextMenu = L.Handler.extend({
     this._keyboardEvent = false;
 
     this._container = L.DomUtil.create("div", "mapml-contextmenu", map._container);
+    this._container.setAttribute('hidden', '');
     
     for (let i = 0; i < 6; i++) {
       this._items[i].el = this._createItem(this._container, this._items[i]);
@@ -113,6 +114,7 @@ export var ContextMenu = L.Handler.extend({
 
     this._coordMenu = L.DomUtil.create("div", "mapml-contextmenu mapml-submenu", this._container);
     this._coordMenu.id = "mapml-copy-submenu";
+    this._coordMenu.setAttribute('hidden', '');
 
     this._clickEvent = null;
 
@@ -125,6 +127,7 @@ export var ContextMenu = L.Handler.extend({
     this._items[8].el = this._createItem(this._container, this._items[8]);
 
     this._layerMenu = L.DomUtil.create("div", "mapml-contextmenu mapml-layer-menu", map._container);
+    this._layerMenu.setAttribute('hidden', '');
     for (let i = 0; i < this._layerItems.length; i++) {
       this._createItem(this._layerMenu, this._layerItems[i]);
     }
@@ -452,7 +455,7 @@ export var ContextMenu = L.Handler.extend({
           this._setPosition(pt,container);
 
           if (!this._mapMenuVisible) {
-            container.style.display = 'block';
+            container.removeAttribute('hidden');
               this._mapMenuVisible = true;
           }
 
@@ -463,9 +466,9 @@ export var ContextMenu = L.Handler.extend({
   _hide: function () {
       if (this._mapMenuVisible) {
           this._mapMenuVisible = false;
-          this._container.style.display = 'none';
-          this._coordMenu.style.display = 'none';
-          this._layerMenu.style.display = 'none';
+          this._container.setAttribute('hidden', '');
+          this._coordMenu.setAttribute('hidden', '');
+          this._layerMenu.setAttribute('hidden', '');
           this._map.fire('contextmenu.hide', {contextmenu: this});
           setTimeout(() => this._map._container.focus(), 0);
       }
@@ -501,21 +504,18 @@ export var ContextMenu = L.Handler.extend({
   },
 
   _getElementSize: function (el) {
-      let size = this._size,
-          initialDisplay = el.style.display;
+      let size = this._size;
 
       if (!size || this._sizeChanged) {
           size = {};
 
           el.style.left = '-999999px';
           el.style.right = 'auto';
-          el.style.display = 'block';
 
           size.x = el.offsetWidth;
           size.y = el.offsetHeight;
 
           el.style.left = 'auto';
-          el.style.display = initialDisplay;
 
           this._sizeChanged = false;
       }
@@ -527,7 +527,7 @@ export var ContextMenu = L.Handler.extend({
    _focusOnLayerControl: function(){
     this._mapMenuVisible = false;
     delete this._layerMenuTabs;
-    this._layerMenu.style.display = 'none';
+    this._layerMenu.setAttribute('hidden', '');
     if(this._elementInFocus){
       this._elementInFocus.focus();
     } else {
@@ -608,7 +608,7 @@ export var ContextMenu = L.Handler.extend({
         copyEl = this._items[5].el.el;
 
     copyEl.setAttribute("aria-expanded","true");
-    menu.style.display = "block";
+    menu.removeAttribute('hidden');
 
     if (click.containerPoint.x + 160 + 80 > mapSize.x) {
       menu.style.left = 'auto';
@@ -633,7 +633,7 @@ export var ContextMenu = L.Handler.extend({
         e.srcElement.innerText === (M.options.locale.cmCopyCoords + " (C)"))return;
     let menu = this._coordMenu, copyEl = this._items[5].el.el;
     copyEl.setAttribute("aria-expanded","false");
-    menu.style.display = "none";
+    menu.setAttribute('hidden', '');
   },
 
   _onItemMouseOver: function (e) {

--- a/src/mapml/layers/Crosshair.js
+++ b/src/mapml/layers/Crosshair.js
@@ -1,32 +1,9 @@
 export var Crosshair = L.Layer.extend({
   onAdd: function (map) {
 
-    //SVG crosshair design from https://github.com/xguaita/Leaflet.MapCenterCoord/blob/master/src/icons/MapCenterCoordIcon1.svg?short_path=81a5c76
-    let svgInnerHTML = `<svg
-    xmlns:dc="http://purl.org/dc/elements/1.1/"
-    xmlns:cc="http://creativecommons.org/ns#"
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:svg="http://www.w3.org/2000/svg"
-    xmlns="http://www.w3.org/2000/svg"
-    version="1.1"
-    x="0px"
-    y="0px"
-    viewBox="0 0 99.999998 99.999998"
-    xml:space="preserve">
-    <g><circle
-        r="3.9234731"
-        cy="50.21946"
-        cx="50.027821"
-        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
-        d="m 4.9734042,54.423642 31.7671398,0 c 2.322349,0 4.204185,-1.881836 4.204185,-4.204185 0,-2.322349 -1.881836,-4.204184 -4.204185,-4.204184 l -31.7671398,0 c -2.3223489,-2.82e-4 -4.20418433,1.881554 -4.20418433,4.204184 0,2.322631 1.88183543,4.204185 4.20418433,4.204185 z"
-        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
-        d="m 54.232003,5.1650429 c 0,-2.3223489 -1.881836,-4.20418433 -4.204184,-4.20418433 -2.322349,0 -4.204185,1.88183543 -4.204185,4.20418433 l 0,31.7671401 c 0,2.322349 1.881836,4.204184 4.204185,4.204184 2.322348,0 4.204184,-1.881835 4.204184,-4.204184 l 0,-31.7671401 z"
-        style="fill:#000000;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1" /><path
-        d="m 99.287826,50.219457 c 0,-2.322349 -1.881835,-4.204184 -4.204184,-4.204184 l -31.76714,0 c -2.322349,0 -4.204184,1.881835 -4.204184,4.204184 0,2.322349 1.881835,4.204185 4.204184,4.204185 l 31.76714,0 c 2.320658,0 4.204184,-1.881836 4.204184,-4.204185 z"
-        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
-        d="m 45.823352,95.27359 c 0,2.322349 1.881836,4.204184 4.204185,4.204184 2.322349,0 4.204184,-1.881835 4.204184,-4.204184 l 0,-31.76714 c 0,-2.322349 -1.881835,-4.204185 -4.204184,-4.204185 -2.322349,0 -4.204185,1.881836 -4.204185,4.204185 l 0,31.76714 z"
-        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /></g></svg>
- `;
+    // SVG crosshair design from https://github.com/xguaita/Leaflet.MapCenterCoord/blob/master/src/icons/MapCenterCoordIcon1.svg?short_path=81a5c76
+    // Optimized with SVGOMG: https://jakearchibald.github.io/svgomg/
+    let svgInnerHTML = `<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 100 100"><g stroke="#fff" stroke-linecap="round" stroke-linejoin="round"><circle cx="50.028" cy="50.219" r="3.923" stroke-width="2" color="currentColor" overflow="visible"/><path stroke-width="3" d="M4.973 54.424h31.768a4.204 4.204 0 1 0 0-8.409H4.973A4.203 4.203 0 0 0 .77 50.22a4.203 4.203 0 0 0 4.204 4.205z" color="currentColor" overflow="visible"/><path stroke-width="3" d="M54.232 5.165a4.204 4.204 0 1 0-8.408 0v31.767a4.204 4.204 0 1 0 8.408 0V5.165z"/><path stroke-width="3" d="M99.288 50.22a4.204 4.204 0 0 0-4.204-4.205H63.317a4.204 4.204 0 1 0 0 8.409h31.767a4.205 4.205 0 0 0 4.204-4.205zM45.823 95.274a4.204 4.204 0 1 0 8.409 0V63.506a4.204 4.204 0 1 0-8.409 0v31.768z" color="currentColor" overflow="visible"/></g></svg>`;
 
     this._container = L.DomUtil.create("div", "mapml-crosshair", map._container);
     this._container.innerHTML = svgInnerHTML;
@@ -57,9 +34,9 @@ export var Crosshair = L.Layer.extend({
 
   _addOrRemoveCrosshair: function (e) {
     if (this._hasQueryableLayer()) {
-      this._container.style.visibility = null;
+      this._container.removeAttribute("hidden");
     } else {
-      this._container.style.visibility = "hidden";
+      this._container.setAttribute("hidden", "");
     }
   },
 

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -142,7 +142,6 @@ export class WebMap extends HTMLMapElement {
     
     let shadowRootCSS = document.createElement('style');
     shadowRootCSS.innerHTML =
-    `:host .mapml-contextmenu,` +
     `:host .leaflet-control-container {` +
     `visibility: hidden!important;` + // Visibility hack to improve percieved performance (mitigate FOUC) – visibility is unset in mapml.css! (https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/154).
     `}`;

--- a/test/e2e/core/layerContextMenu.test.js
+++ b/test/e2e/core/layerContextMenu.test.js
@@ -16,7 +16,7 @@ describe("Playwright Layer Context Menu Tests", () => {
     const nextHandle = await page.evaluateHandle(doc => doc.shadowRoot, aHandle);
     const resultHandle = await page.evaluateHandle(root => root.querySelector(".mapml-contextmenu.mapml-layer-menu"), nextHandle);
 
-    const menuDisplay = await (await page.evaluateHandle(elem => elem.style.display, resultHandle)).jsonValue();
+    const menuDisplay = await (await page.evaluateHandle(elem => window.getComputedStyle(elem).getPropertyValue("display"), resultHandle)).jsonValue();
 
     await expect(menuDisplay).toEqual("block");
   });

--- a/test/e2e/core/mapContextMenu.test.js
+++ b/test/e2e/core/mapContextMenu.test.js
@@ -60,7 +60,7 @@ describe("Playwright Map Context Menu Tests", () => {
     await page.click("body > map", { button: "right" });
     const contextMenu = await page.$eval(
       "div > div.mapml-contextmenu",
-      (menu) => menu.style.display
+      (menu) => window.getComputedStyle(menu).getPropertyValue("display")
     );
     await expect(contextMenu).toEqual("block");
   });

--- a/test/e2e/core/reticle.test.js
+++ b/test/e2e/core/reticle.test.js
@@ -9,11 +9,11 @@ describe("Playwright Keyboard Navigation + Query Layer Tests" , () => {
 
   describe("Crosshair Reticle Tests", () => {
     test("Crosshair hidden onload, shows on focus", async () => {
-      const beforeTabHidden = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
+      const beforeTabHidden = await page.$eval("div > div.mapml-crosshair", (div) => window.getComputedStyle(div).getPropertyValue("display"));
       await page.keyboard.press("Tab");
-      const afterTab = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
-      await expect(beforeTabHidden).toEqual("hidden");
-      await expect(afterTab).toEqual("");
+      const afterTab = await page.$eval("div > div.mapml-crosshair", (div) => window.getComputedStyle(div).getPropertyValue("display"));
+      await expect(beforeTabHidden).toEqual("none");
+      await expect(afterTab).toEqual("block");
     });
 
     test("Crosshair remains on map move with arrow keys", async () => {
@@ -25,22 +25,22 @@ describe("Playwright Keyboard Navigation + Query Layer Tests" , () => {
       await page.waitForTimeout(1000);
       await page.keyboard.press("ArrowRight");
       await page.waitForTimeout(1000);
-      const afterMove = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
-      await expect(afterMove).toEqual("");
+      const afterMove = await page.$eval("div > div.mapml-crosshair", (div) => window.getComputedStyle(div).getPropertyValue("display"));
+      await expect(afterMove).toEqual("block");
     });
 
     test("Crosshair shows on esc but hidden on tab out", async () => {
       await page.keyboard.press("Escape");
-      const afterEsc = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
+      const afterEsc = await page.$eval("div > div.mapml-crosshair", (div) => window.getComputedStyle(div).getPropertyValue("display"));
       await page.click("body");
       await page.keyboard.press("Tab");
       await page.keyboard.press("ArrowUp");
 
       await page.keyboard.press("Tab");
-      const afterTab = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
+      const afterTab = await page.$eval("div > div.mapml-crosshair", (div) => window.getComputedStyle(div).getPropertyValue("display"));
 
-      await expect(afterEsc).toEqual("");
-      await expect(afterTab).toEqual("hidden");
+      await expect(afterEsc).toEqual("block");
+      await expect(afterTab).toEqual("none");
     });
 
     test("Crosshair hidden when queryable layer is unselected, shows on reselect", async () => {
@@ -48,13 +48,13 @@ describe("Playwright Keyboard Navigation + Query Layer Tests" , () => {
       await page.keyboard.press("Tab");
       await page.keyboard.press("ArrowUp");
       await page.evaluateHandle(() => document.querySelector("layer-").removeAttribute("checked"));
-      const afterUncheck = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
+      const afterUncheck = await page.$eval("div > div.mapml-crosshair", (div) => window.getComputedStyle(div).getPropertyValue("display"));
 
       await page.evaluateHandle(() => document.querySelector("layer-").setAttribute("checked", ""));
-      const afterCheck = await page.$eval("div > div.mapml-crosshair", (div) => div.style.visibility);
+      const afterCheck = await page.$eval("div > div.mapml-crosshair", (div) => window.getComputedStyle(div).getPropertyValue("display"));
 
-      await expect(afterUncheck).toEqual("hidden");
-      await expect(afterCheck).toEqual("");
+      await expect(afterUncheck).toEqual("none");
+      await expect(afterCheck).toEqual("block");
     });
   });
 });

--- a/test/e2e/mapml-viewer/viewerContextMenu.test.js
+++ b/test/e2e/mapml-viewer/viewerContextMenu.test.js
@@ -72,7 +72,7 @@ describe("Playwright mapml-viewer Context Menu (and api) Tests", () => {
     await page.click("body > mapml-viewer", { button: "right" });
     const contextMenu = await page.$eval(
       "div > div.mapml-contextmenu",
-      (menu) => menu.style.display
+      (menu) => window.getComputedStyle(menu).getPropertyValue("display")
     );
     await expect(contextMenu).toEqual("block");
   });


### PR DESCRIPTION
Unlike `style=""`, the `hidden` attribute is not governed by CSP `style-src`. This change:
- removes the need for 3 `style-src` hashes in the currently ["required" CSP](https://maps4html.org/experiments/security/csp/)
- optimizes the byte size of the crosshair SVG (part of the process of moving from `style` attributes to SVG presentation attributes)
- removes the need to apply the "`visibility` hack" to the context menu
- removes some redundant CSS