### PR TITLE
Move feature interaction styles to `mapml.css`

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -735,3 +735,37 @@ label.mapml-layer-item-toggle {
   white-space: nowrap;
   width: 1px;
 }
+
+/*
+ * Feature styles.
+ */
+ 
+.mapml-vector-container svg :is(
+  [role="link"]:focus,
+  [role="link"]:hover,
+  [role="link"]:focus path,
+  [role="link"]:hover path,
+  [role="link"] path:focus,
+  [role="link"] path:hover,
+  [role="button"]:focus,
+  [role="button"]:hover,
+  [role="button"]:focus path,
+  [role="button"]:hover path,
+  [role="button"] path:focus,
+  [role="button"] path:hover,
+  path[tabindex="0"]:focus
+  ) {
+  stroke: #0000EE;
+  stroke: LinkText;
+}
+.mapml-vector-container svg :is(
+  [role="link"]:focus:not(:focus-visible),
+  [role="link"]:focus:not(:focus-visible) path,
+  [role="link"] path:focus:not(:focus-visible),
+  [role="button"]:focus:not(:focus-visible),
+  [role="button"]:focus:not(:focus-visible) path,
+  [role="button"] path:focus:not(:focus-visible),
+  path[tabindex="0"]:focus:not(:focus-visible)
+  ) {
+  outline: 0!important;
+}

--- a/src/mapml/layers/FeatureLayer.js
+++ b/src/mapml/layers/FeatureLayer.js
@@ -13,33 +13,6 @@ export var MapMLFeatures = L.FeatureGroup.extend({
         // info: https://github.com/Leaflet/Leaflet/pull/4597
         L.DomUtil.addClass(this._container, 'leaflet-pane mapml-vector-container');
         L.setOptions(this.options.renderer, {pane: this._container});
-        let style = L.DomUtil.create("style", "mapml-feature-style", this._container);
-        style.innerHTML = `
-        g[role="link"]:focus,
-        g[role="link"]:hover,
-        g[role="link"]:focus path,
-        g[role="link"]:hover path,
-        g[role="link"] path:focus,
-        g[role="link"] path:hover,
-        g[role="button"]:focus,
-        g[role="button"]:hover,
-        g[role="button"]:focus path,
-        g[role="button"]:hover path,
-        g[role="button"] path:focus,
-        g[role="button"] path:hover,
-        path[tabindex="0"]:focus {
-          stroke: #0000EE!important;
-          stroke: LinkText!important;
-        }
-        g[role="link"]:focus:not(:focus-visible),
-        g[role="link"]:focus:not(:focus-visible) path,
-        g[role="link"] path:focus:not(:focus-visible),
-        g[role="button"]:focus:not(:focus-visible),
-        g[role="button"]:focus:not(:focus-visible) path,
-        g[role="button"] path:focus:not(:focus-visible),
-        path[tabindex="0"]:focus:not(:focus-visible) {
-          outline: 0!important;
-        }`;
       }
 
       this._layers = {};
@@ -325,7 +298,6 @@ export var MapMLFeatures = L.FeatureGroup.extend({
     _removeCSS: function(){
       let toDelete = this._container.querySelectorAll("link[rel=stylesheet],style");
       for(let i = 0; i < toDelete.length;i++){
-        if(toDelete[i].classList.contains("mapml-feature-style")) continue;
         this._container.removeChild(toDelete[i]);
       }
     },


### PR DESCRIPTION
ATM these styles are duplicated into each vector container. This change makes the feature styles more bandwidth friendly, and not add to the total DOM size.