### PR TITLE
Layer drag border styles + clickable area fix

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -713,6 +713,8 @@ button.mapml-button:disabled,
 label.mapml-layer-item-toggle {
   display: inline-flex;
   align-items: center;
+  width: 100%; /* have the clickable area take up all available width */
+  min-height: 44px;
 }
 
 .mapml-layer-item-name {

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -214,7 +214,6 @@
 }
 
 .leaflet-control-layers fieldset {
-  border: none;
   margin: 0;
   padding: 0;
   min-height: 44px;
@@ -237,10 +236,6 @@
 
 .mapml-layer-item-style input {
   margin-inline-start: 0;
-}
-
-.leaflet-control-layers-list .leaflet-control-layers-overlays > :not(:last-of-type) {
-  border-bottom: 1px solid #e3e3e3;
 }
 
 .leaflet-control .leaflet-control-layers-toggle {
@@ -487,7 +482,6 @@ summary {
 .mapml-draggable,
 .mapml-draggable * {
   cursor: row-resize;
-  background-color: white;
 }
 
 .leaflet-crosshair {
@@ -651,20 +645,31 @@ button.mapml-button:disabled,
 }
 
 .mapml-layer-item,
-.mapml-layer-item *,
-.mapml-layer-item ::before,
-.mapml-layer-item ::after {
+.mapml-layer-item * {
   box-sizing: border-box;
 }
 
 .mapml-layer-item {
-  border: 0;
+  background-color: #fff;
+  border: 1px solid #fff;
   margin: 0;
   padding: 0;
 }
 
 .mapml-layer-item:not(:last-of-type) {
   border-bottom: 1px solid #e3e3e3;
+}
+.mapml-layer-item[aria-grabbed="true"] {
+  border: 1px solid #e3e3e3;
+  border-radius: 0;
+}
+.mapml-layer-item:first-of-type {
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+.mapml-layer-item:last-of-type {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
 }
 
 .mapml-layer-item-properties {


### PR DESCRIPTION
- [x] https://github.com/Maps4HTML/Web-Map-Custom-Element/commit/4ac3de7983057229f78eb3fdb1c0b6e4bf4e03be:
   - sets borders on the layer items during drag
   - fixes an issue with square corners on the container (and each fieldset) when dragging
- [x] https://github.com/Maps4HTML/Web-Map-Custom-Element/commit/80b91f1d588b9907e2da4bbd294a5153273f67b1: makes the clickable area larger (again! @ahmadayubi had requested this in https://github.com/Maps4HTML/Web-Map-Custom-Element/pull/531#pullrequestreview-783792175, and I had later removed those styles in [#565 `ed8687d`](https://github.com/Maps4HTML/Web-Map-Custom-Element/commit/ed8687db9e4438303ad0d1008bb9fe1fa06e895e) thinking they were redundant, adding them back now, sorry!) 

## Preview

### Before

https://user-images.githubusercontent.com/26493779/144581829-2ce46807-f062-48d2-af44-5d405d7e3bee.mp4

### After

https://user-images.githubusercontent.com/26493779/144582317-c441dbda-63bf-4a67-bc03-670a0f78c16a.mp4



