### PR TITLE
ZoomToLayer fix

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -337,42 +337,24 @@ export class MapLayer extends HTMLElement {
 
     let mapPCRS = L.bounds(mapTlPCRSNew, mapBrPCRSNew);
 
-    if(mapPCRS.contains(layerBounds)){
+    let zOffset = mapPCRS.contains(layerBounds) ? 1 : -1;
 
-    } else {
+    while((zOffset === -1 && !(mapPCRS.contains(layerBounds)) && (newZoom - 1) >= minZoom)  ||
+          (zOffset === 1 && mapPCRS.contains(layerBounds) && (newZoom + 1) <= maxZoom)) {
+      newZoom += zOffset;
 
+      scale = map.options.crs.scale(newZoom);
+      mapCenterTCRS = map.options.crs.transformation.transform(layerBounds.getCenter(true), scale);
+
+      mapTlNew = mapCenterTCRS.subtract(mapHalf).round();
+      mapBrNew = mapCenterTCRS.add(mapHalf).round();
+      mapTlPCRSNew = M.pixelToPCRSPoint(mapTlNew, newZoom, map.options.projection);
+      mapBrPCRSNew = M.pixelToPCRSPoint(mapBrNew, newZoom, map.options.projection);
+
+      mapPCRS = L.bounds(mapTlPCRSNew, mapBrPCRSNew);
     }
+    if(zOffset === 1 && newZoom - 1 >= 0) newZoom--;
 
-    if(mapPCRS.contains(layerBounds)){
-      while(mapPCRS.contains(layerBounds) && (newZoom + 1) <= maxZoom){
-        newZoom++;
-
-        scale = map.options.crs.scale(newZoom);
-        mapCenterTCRS = map.options.crs.transformation.transform(layerBounds.getCenter(true), scale);
-
-        mapTlNew = mapCenterTCRS.subtract(viewHalf).round();
-        mapBrNew = mapCenterTCRS.add(viewHalf).round();
-        mapTlPCRSNew = M.pixelToPCRSPoint(mapTlNew, newZoom, map.options.projection);
-        mapBrPCRSNew = M.pixelToPCRSPoint(mapBrNew, newZoom, map.options.projection);
-
-        mapPCRS = L.bounds(mapTlPCRSNew, mapBrPCRSNew);
-      }
-      if(newZoom - 1 >= 0) newZoom--;
-    } else {
-      while(!(mapPCRS.contains(layerBounds)) && (newZoom - 1) >= minZoom){
-        newZoom--;
-
-        scale = map.options.crs.scale(newZoom);
-        mapCenterTCRS = map.options.crs.transformation.transform(layerBounds.getCenter(true), scale);
-
-        mapTlNew = mapCenterTCRS.subtract(viewHalf).round();
-        mapBrNew = mapCenterTCRS.add(viewHalf).round();
-        mapTlPCRSNew = M.pixelToPCRSPoint(mapTlNew, newZoom, map.options.projection);
-        mapBrPCRSNew = M.pixelToPCRSPoint(mapBrNew, newZoom, map.options.projection);
-
-        mapPCRS = L.bounds(mapTlPCRSNew, mapBrPCRSNew);
-      }
-    }
     map.flyTo(center, newZoom);
   }
 }

--- a/src/layer.js
+++ b/src/layer.js
@@ -354,7 +354,6 @@ export class MapLayer extends HTMLElement {
       mapPCRS = L.bounds(mapTlPCRSNew, mapBrPCRSNew);
     }
     if(zOffset === 1 && newZoom - 1 >= 0) newZoom--;
-
-    map.flyTo(center, newZoom);
+    map.setView(center, newZoom, {animate: false});
   }
 }


### PR DESCRIPTION
Rather than zooming in/out and checking if a layer is within bounds repeatedly, calculate whether a layer would be in or out of bounds after a set number of zoom in/outs, ahead of time. 

Before: (flickering, instant movements)

https://user-images.githubusercontent.com/55214462/146052220-e0a7e713-5798-4aa4-948d-0c075418e5c1.mp4



After: (no flickering, removing repeated zoom in/out)

https://user-images.githubusercontent.com/55214462/146072850-70e84b9a-35f4-4a8e-855d-6987e96c7ec3.mp4


Closes issue with templatedFeatureLayer duplicates, although that issue may still remain in another form if the underlying bug wasn't the zoomToLayer feature but rather quick successive addition and removal of layers (which the old zoomToLayer feature would do).

Closes #634 

https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/612#issuecomment-982651989
