### PR TITLE
Remove mismatching selectors in test files

### DIFF
--- a/test/e2e/core/debugMode.html
+++ b/test/e2e/core/debugMode.html
@@ -10,8 +10,7 @@
       height: 100%
     }
 
-    body,
-    map {
+    body {
       height: inherit
     }
 

--- a/test/e2e/core/fullscreenControlMapmlViewer.html
+++ b/test/e2e/core/fullscreenControlMapmlViewer.html
@@ -10,8 +10,7 @@
       height: 100%
     }
 
-    body,
-    map {
+    body {
       height: inherit
     }
 

--- a/test/e2e/core/layerContextMenu.html
+++ b/test/e2e/core/layerContextMenu.html
@@ -10,8 +10,7 @@
       height: 100%
     }
 
-    body,
-    map {
+    body {
       height: inherit
     }
 

--- a/test/e2e/core/metaDefault.html
+++ b/test/e2e/core/metaDefault.html
@@ -7,12 +7,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type="module" src="mapml-viewer.js"></script>
   <style>
-    [is=web-map] {
-      width: 100%;
-      height: 400px;
-      max-width: 100%;
-    }
-
     .transparency {
       opacity: 0.2;
     }

--- a/test/e2e/core/tms.html
+++ b/test/e2e/core/tms.html
@@ -5,7 +5,7 @@
         <meta charset="UTF-8">
             <script type="module" src="mapml-viewer.js"></script>
          <style>
-           html {height: 100%} body,map {height: inherit} * {margin: 0;padding: 0;}
+           html {height: 100%} body {height: inherit} * {margin: 0;padding: 0;}
         </style>
     </head>
     <body>

--- a/test/e2e/layers/clientTemplatedTileLayer.html
+++ b/test/e2e/layers/clientTemplatedTileLayer.html
@@ -10,8 +10,7 @@
       height: 100%
     }
 
-    body,
-    map {
+    body {
       height: inherit
     }
 

--- a/test/e2e/layers/mapMLTemplatedFeaturesFilter.html
+++ b/test/e2e/layers/mapMLTemplatedFeaturesFilter.html
@@ -7,12 +7,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type="module" src="mapml-viewer.js"></script>
   <style>
-    [is=web-map] {
-      width: 100%;
-      height: 400px;
-      max-width: 100%;
-    }
-
     .transparency {
       opacity: 0.2;
     }

--- a/test/e2e/layers/multipleExtents.html
+++ b/test/e2e/layers/multipleExtents.html
@@ -10,8 +10,7 @@
       height: 100%
     }
 
-    body,
-    map {
+    body {
       height: inherit
     }
 

--- a/test/e2e/layers/multipleHeterogeneousQueryExtents.html
+++ b/test/e2e/layers/multipleHeterogeneousQueryExtents.html
@@ -10,8 +10,7 @@
       height: 100%
     }
 
-    body,
-    map {
+    body {
       height: inherit
     }
 

--- a/test/e2e/layers/multipleQueryExtents.html
+++ b/test/e2e/layers/multipleQueryExtents.html
@@ -10,8 +10,7 @@
       height: 100%
     }
 
-    body,
-    map {
+    body {
       height: inherit
     }
 

--- a/test/e2e/mapml-viewer/mapml-viewer.html
+++ b/test/e2e/mapml-viewer/mapml-viewer.html
@@ -15,8 +15,7 @@
       height: 100%
     }
 
-    body,
-    map {
+    body {
       height: inherit
     }
 


### PR DESCRIPTION
Removing `map` and `[is="web-map"]` CSS selectors in `<mapml-viewer>` tests.