### PR TITLE
Change the action to force addition of files and directories

### DIFF
--- a/.github/actions/sync-repo/entrypoint.sh
+++ b/.github/actions/sync-repo/entrypoint.sh
@@ -33,7 +33,7 @@ cp -rf $INPUT_SOURCE_FOLDER/. $CLONE_DIR/$INPUT_DESTINATION_FOLDER/
 cd "$CLONE_DIR"
 
 echo "Adding git commit"
-git add .
+git add -f .
 if git status | grep -q "Changes to be committed"
 then
   git commit --message "$INPUT_COMMIT_MSG"

--- a/src/geojson/geojson.js
+++ b/src/geojson/geojson.js
@@ -471,7 +471,7 @@ function mapml2geojson(element, options = {}) {
     metas.forEach((meta) => {
         let name = meta.getAttribute('name');
         if (name === "extent") {
-            let content = meta.getAttribute('content');;
+            let content = meta.getAttribute('content');
             let arr = content.split(",");
             let ex = {};
             for (let i=0; i<arr.length; i++) {


### PR DESCRIPTION
The /dist/ directory is in the remote repositories' .gitignore list, which prevents changes to the structure from being recognized.