### PR TITLE
Update _removeEvents call

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -302,9 +302,7 @@ export class MapLayer extends HTMLElement {
   }
   _removeEvents() {
     if (this._layer) {
-      this._layer.off('loadstart', false, this);
-      this._layer.off('changestyle', false, this);
-      this._layer.off('add remove', this._onLayerChange,  this);
+      this._layer.off();
     }
   }
   _setUpEvents() {

--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -364,8 +364,7 @@ export class MapViewer extends HTMLElement {
   }
   _removeEvents() {
     if (this._map) {
-      this._map.off('preclick click dblclick mousemove mouseover mouseout mousedown mouseup contextmenu', false, this);
-      this._map.off('load movestart move moveend zoomstart zoom zoomend', false, this);
+      this._map.off();
       this.removeEventListener("drop", this._dropHandler, false);
       this.removeEventListener("dragover", this._dragoverHandler, false);
     }

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -404,8 +404,7 @@ export class WebMap extends HTMLMapElement {
   }
   _removeEvents() {
     if (this._map) {
-      this._map.off('preclick click dblclick mousemove mouseover mouseout mousedown mouseup contextmenu', false, this);
-      this._map.off('load movestart move moveend zoomstart zoom zoomend', false, this);
+      this._map.off();
       this.removeEventListener("drop", this._dropHandler, false);
       this.removeEventListener("dragover", this._dragoverHandler, false);
     }


### PR DESCRIPTION
Fixes .off() call as upgrade to leaflet 1.9.3 changed the way to use the .off() function. Stops leaflet warnings from occurring in the console.
closes #755.