### PR TITLE
Place templated image layer at at (0,0) of CS when add it to map

### DIFF
--- a/src/mapml/layers/TemplatedImageLayer.js
+++ b/src/mapml/layers/TemplatedImageLayer.js
@@ -1,6 +1,7 @@
 export var TemplatedImageLayer =  L.Layer.extend({
     initialize: function(template, options) {
         this._template = template;
+        this._layer = options.pane.parentElement;
         this._container = L.DomUtil.create('div', 'leaflet-layer', options.pane);
         L.DomUtil.addClass(this._container, 'mapml-image-container');
         let inputData = M._extractInputBounds(template);
@@ -23,7 +24,10 @@ export var TemplatedImageLayer =  L.Layer.extend({
         this._onAdd();
         // make sure templatedImage Layer is placed at (0,0) of the cs
         // when it is added to the map (solve issue #759)
-        this.redraw();
+        if (this._layer.isUnChecked) {
+            this.redraw();
+            this._layer.isUnChecked = false;
+        }
     },
     redraw: function() {
         this._onMoveEnd();
@@ -135,6 +139,7 @@ export var TemplatedImageLayer =  L.Layer.extend({
     onRemove: function (map) {
       this._clearLayer();
       map._removeZoomLimit(this);
+      this._layer.isUnChecked = true;
       this._container = null;
     },
     getImageUrl: function(pixelBounds, zoom) {

--- a/src/mapml/layers/TemplatedImageLayer.js
+++ b/src/mapml/layers/TemplatedImageLayer.js
@@ -21,6 +21,9 @@ export var TemplatedImageLayer =  L.Layer.extend({
         this._map._addZoomLimit(this);  //used to set the zoom limit of the map
         this.setZIndex(this.options.zIndex);
         this._onAdd();
+        // make sure templatedImage Layer is placed at (0,0) of the cs
+        // when it is added to the map (solve issue #759)
+        this.redraw();
     },
     redraw: function() {
         this._onMoveEnd();

--- a/src/mapml/layers/TemplatedImageLayer.js
+++ b/src/mapml/layers/TemplatedImageLayer.js
@@ -47,7 +47,6 @@ export var TemplatedImageLayer =  L.Layer.extend({
             this._imageOverlay._overlayToRemove = overlayToRemove._url;
             this._imageOverlay.on('load error', function () {map.removeLayer(overlayToRemove);});
         }
-        this.location = loc;
     },
 
     _scaleImage: function (bounds, zoom) {
@@ -139,7 +138,6 @@ export var TemplatedImageLayer =  L.Layer.extend({
     onRemove: function (map) {
       this._clearLayer();
       map._removeZoomLimit(this);
-      this._layer.isUnChecked = true;
       this._container = null;
     },
     getImageUrl: function(pixelBounds, zoom) {

--- a/src/mapml/layers/TemplatedImageLayer.js
+++ b/src/mapml/layers/TemplatedImageLayer.js
@@ -14,7 +14,7 @@ export var TemplatedImageLayer =  L.Layer.extend({
     getEvents: function () {
         var events = {
             moveend: this._onMoveEnd,
-            zoomstart: this._clearLayer,
+            zoomstart: this._clearLayer
         };
         return events;
     },
@@ -225,7 +225,7 @@ export var TemplatedImageLayer =  L.Layer.extend({
         }
       }
       return extentVarNames;
-    },
+    }
 });
 export var templatedImageLayer = function(template, options) {
     return new TemplatedImageLayer(template, options);

--- a/src/mapml/layers/TemplatedImageLayer.js
+++ b/src/mapml/layers/TemplatedImageLayer.js
@@ -47,6 +47,7 @@ export var TemplatedImageLayer =  L.Layer.extend({
             this._imageOverlay._overlayToRemove = overlayToRemove._url;
             this._imageOverlay.on('load error', function () {map.removeLayer(overlayToRemove);});
         }
+        this.location = loc;
     },
 
     _scaleImage: function (bounds, zoom) {

--- a/src/mapml/layers/TemplatedImageLayer.js
+++ b/src/mapml/layers/TemplatedImageLayer.js
@@ -1,7 +1,6 @@
 export var TemplatedImageLayer =  L.Layer.extend({
     initialize: function(template, options) {
         this._template = template;
-        this._layer = options.pane.parentElement;
         this._container = L.DomUtil.create('div', 'leaflet-layer', options.pane);
         L.DomUtil.addClass(this._container, 'mapml-image-container');
         let inputData = M._extractInputBounds(template);

--- a/test/e2e/layers/templatedImageLayer.test.js
+++ b/test/e2e/layers/templatedImageLayer.test.js
@@ -52,11 +52,7 @@ test.describe("Playwright templatedImage Layer Tests", () => {
       (map) => {
         let layers = map._map._layers;
         let keys = Object.keys(layers);
-        for (let key of keys) {
-          if (layers[key]._imageOverlay) {
-            return layers[key].location;
-          }
-        }
+        return layers[keys[keys.length - 1]]._location;
       }
     );
     const expectedPos = {

--- a/test/e2e/layers/templatedImageLayer.test.js
+++ b/test/e2e/layers/templatedImageLayer.test.js
@@ -28,4 +28,41 @@ test.describe("Playwright templatedImage Layer Tests", () => {
   isVisible.test("templatedImageLayer.html", 2, 1);
   zoomLimit.test("templatedImageLayer.html", 1, 0);
   extentProperty.test("templatedImageLayer.html", expectedPCRS, expectedGCRS);
+
+  let page;
+  let context;
+  test.beforeAll(async () => {
+    context = await chromium.launchPersistentContext('', {slowMo: 250});
+    page = await context.newPage();
+    await page.goto("templatedImageLayer.html");
+  });
+
+  test("Templated image layer position when turn it off then on", async () => {
+    await page.click("body > map");
+    for (let i = 0; i < 5; ++i) {
+      await page.keyboard.press("ArrowUp");
+      await page.waitForTimeout(200);
+    }
+    await page.hover("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div");
+    await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > div:nth-child(1) > label > input");
+    await page.click("div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > div:nth-child(1) > label > input");
+    await page.waitForTimeout(500);
+    const imagePos = await page.$eval(
+      "body > map",
+      (map) => {
+        let layers = map._map._layers;
+        let keys = Object.keys(layers);
+        for (let key of keys) {
+          if (layers[key]._imageOverlay) {
+            return layers[key].location;
+          }
+        }
+      }
+    );
+    const expectedPos = {
+      x: 0,
+      y: -400
+    }
+    expect(imagePos).toEqual(expectedPos);
+  });
 });

--- a/test/e2e/layers/templatedImageLayer.test.js
+++ b/test/e2e/layers/templatedImageLayer.test.js
@@ -58,7 +58,7 @@ test.describe("Playwright templatedImage Layer Tests", () => {
     const expectedPos = {
       x: 0,
       y: -400
-    }
+    };
     expect(imagePos).toEqual(expectedPos);
   });
 });


### PR DESCRIPTION
Closes #759

- [x] fix bug that the templated image layer is misplaced when it is re-added to map
- [x] fix bug that the templated image layer is duplicated when zooming in/out
- [x] add a test