### PR TITLE
Announce zoom

### DIFF
--- a/src/mapml/handlers/AnnounceMovement.js
+++ b/src/mapml/handlers/AnnounceMovement.js
@@ -28,8 +28,8 @@ export var AnnounceMovement = L.Handler.extend({
 
              let mapZoom = mapEl._map.getZoom();
              let location = M._gcrsToTileMatrix(mapEl);
-             let standard = M.options.locale.amZoom + " " + mapZoom; //+ " " + M.options.locale.amColumn + " " + location[0] + " " + M.options.locale.amRow + " " + location[1]; (for coordinates)
-
+             let standard = M.options.locale.amZoom + " " + mapZoom; 
+             
              if(mapZoom === mapEl._map._layersMaxZoom){
                  standard = M.options.locale.amMaxZoom + " " + standard;
              }
@@ -62,7 +62,7 @@ export var AnnounceMovement = L.Handler.extend({
 
         //GCRS to TileMatrix
         let location = M._gcrsToTileMatrix(this);
-        let standard = M.options.locale.amZoom + " " + mapZoom;// + " " + M.options.locale.amColumn + " " + location[0] + " " + M.options.locale.amRow + " " + location[1]; (for coordinates)
+        let standard = M.options.locale.amZoom + " " + mapZoom;
 
         if(!visible){
             let outOfBoundsPos = this._history[this._historyIndex];

--- a/src/mapml/handlers/AnnounceMovement.js
+++ b/src/mapml/handlers/AnnounceMovement.js
@@ -20,7 +20,7 @@ export var AnnounceMovement = L.Handler.extend({
         this._map.options.mapEl.removeEventListener('mapfocused', this.focusAnnouncement);
     },
 
-     focusAnnouncement: function () {
+    focusAnnouncement: function () {
          let mapEl = this;
          setTimeout(function (){
              let el = mapEl.querySelector(".mapml-web-map") ? mapEl.querySelector(".mapml-web-map").shadowRoot.querySelector(".leaflet-container") :
@@ -28,7 +28,7 @@ export var AnnounceMovement = L.Handler.extend({
 
              let mapZoom = mapEl._map.getZoom();
              let location = M._gcrsToTileMatrix(mapEl);
-             let standard = M.options.locale.amZoom + " " + mapZoom + " " + M.options.locale.amColumn + " " + location[0] + " " + M.options.locale.amRow + " " + location[1];
+             let standard = M.options.locale.amZoom + " " + mapZoom; //+ " " + M.options.locale.amColumn + " " + location[0] + " " + M.options.locale.amRow + " " + location[1]; (for coordinates)
 
              if(mapZoom === mapEl._map._layersMaxZoom){
                  standard = M.options.locale.amMaxZoom + " " + standard;
@@ -37,10 +37,10 @@ export var AnnounceMovement = L.Handler.extend({
                  standard = M.options.locale.amMinZoom + " " + standard;
              }
 
-             el.setAttribute("aria-roledescription", "region " + standard);
-             setTimeout(function () {
-                 el.removeAttribute("aria-roledescription");
-             }, 2000);
+            //  el.setAttribute("aria-roledescription", "region " + standard);
+            //  setTimeout(function () {
+            //      el.removeAttribute("aria-roledescription");
+            //  }, 2000);
          }, 0);
      },
 
@@ -62,7 +62,7 @@ export var AnnounceMovement = L.Handler.extend({
 
         //GCRS to TileMatrix
         let location = M._gcrsToTileMatrix(this);
-        let standard = M.options.locale.amZoom + " " + mapZoom + " " + M.options.locale.amColumn + " " + location[0] + " " + M.options.locale.amRow + " " + location[1];
+        let standard = M.options.locale.amZoom + " " + mapZoom;// + " " + M.options.locale.amColumn + " " + location[0] + " " + M.options.locale.amRow + " " + location[1]; (for coordinates)
 
         if(!visible){
             let outOfBoundsPos = this._history[this._historyIndex];

--- a/src/mapml/handlers/AnnounceMovement.js
+++ b/src/mapml/handlers/AnnounceMovement.js
@@ -37,10 +37,10 @@ export var AnnounceMovement = L.Handler.extend({
                  standard = M.options.locale.amMinZoom + " " + standard;
              }
 
-            //  el.setAttribute("aria-roledescription", "region " + standard);
-            //  setTimeout(function () {
-            //      el.removeAttribute("aria-roledescription");
-            //  }, 2000);
+             el.setAttribute("aria-roledescription", "region " + standard);
+             setTimeout(function () {
+                 el.removeAttribute("aria-roledescription");
+             }, 2000);
          }, 0);
      },
 

--- a/test/e2e/core/announceMovement.test.js
+++ b/test/e2e/core/announceMovement.test.js
@@ -23,7 +23,7 @@ test.﻿describe("Announce movement test", ()=> {
             "body > mapml-viewer div > output",
             (output) => output.innerHTML
         );
-        expect(movedUp).toEqual("zoom level 0 column 3 row 3");
+        expect(movedUp).toEqual("zoom level 0");
 
         for(let i = 0; i < 2; i++){
             await page.keyboard.press("ArrowLeft");
@@ -34,7 +34,7 @@ test.﻿describe("Announce movement test", ()=> {
             "body > mapml-viewer div > output",
             (output) => output.innerHTML
         );
-        expect(movedLeft).toEqual("zoom level 0 column 2 row 3");
+        expect(movedLeft).toEqual("zoom level 0");
 
         await page.keyboard.press("Equal");
         await page.waitForTimeout(1000);
@@ -43,11 +43,33 @@ test.﻿describe("Announce movement test", ()=> {
             "body > mapml-viewer div > output",
             (output) => output.innerHTML
         );
-        expect(zoomedIn).toEqual("zoom level 1 column 4 row 6");
+        expect(zoomedIn).toEqual("zoom level 1");
+
+        await page.keyboard.press("Minus");
+        await page.waitForTimeout(1000);
+
+        const zoomedOut = await page.$eval(
+            "body > mapml-viewer div > output",
+            (output) => output.innerHTML
+        );
+        expect(zoomedOut).toEqual("At minimum zoom level, zoom out disabled zoom level 0");
+        // testing + button
+        await page.keyboard.press("Tab");
+        await page.keyboard.press("Enter");
+        await page.waitForTimeout(1000);
+
+        const zoomedBackIn = await page.$eval(
+            "body > mapml-viewer div > output",
+            (output) => output.innerHTML
+        );
+        expect(zoomedBackIn).toEqual("zoom level 1");
+
+        
     });
 
     test("Output values are correct at bounds and bounces back", async ()=>{
         //Zoom out to min layer bound
+        await page.keyboard.press("Shift+Tab");
         await page.keyboard.press("Minus");
         await page.waitForTimeout(1000);
 
@@ -55,7 +77,7 @@ test.﻿describe("Announce movement test", ()=> {
             "body > mapml-viewer div > output",
             (output) => output.innerHTML
         );
-        expect(minZoom).toEqual("At minimum zoom level, zoom out disabled zoom level 0 column 2 row 3");
+        expect(minZoom).toEqual("At minimum zoom level, zoom out disabled zoom level 0");
 
         //Pan out of west bounds, expect the map to bounce back
         for(let i = 0; i < 4; i++){
@@ -74,7 +96,7 @@ test.﻿describe("Announce movement test", ()=> {
             "body > mapml-viewer div > output",
             (output) => output.innerHTML
         );
-        expect(bouncedBack).toEqual("zoom level 0 column 1 row 3");
+        expect(bouncedBack).toEqual("zoom level 0");
 
         //Zoom in out of bounds, expect the map to zoom back
         await page.keyboard.press("Equal");
@@ -90,7 +112,7 @@ test.﻿describe("Announce movement test", ()=> {
             "body > mapml-viewer div > output",
             (output) => output.innerHTML
         );
-        expect(zoomedBack).toEqual("zoom level 0 column 1 row 3");
+        expect(zoomedBack).toEqual("zoom level 0");
 
     });
 });


### PR DESCRIPTION
closes #664
- [x] Update Web-Map-Custom-Element to audibly render zoom in output by default i.e. on by default
- [x] Update MapML-Extension to reflect the fact that the option to audibly render zoom is on by default, provide option to turn it off.  "Announce movement for screen readers" -> "Announce Zoom"
- [x] Update Web-Map-Doc.
- [x] Change the name of [this experiment](https://maps4html.org/experiments/screenreader/announce-pan-zoom/).  We should add the pan/zoom control to that map, as well as a \<map-caption>Paris, the City of Light\</map-caption>