### PR TITLE
Add experiments grunt task, for convenience

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -123,11 +123,24 @@ module.exports = function(grunt) {
             dest: 'dist/images/'
           }
         ]
+      },
+      experiments: {
+        files: [
+          {
+            expand: true,
+            src: ['dist/*'],
+            dest: '../experiments'
+      }
+        ]
       }
     },
     clean: {
       dist: ['dist'],
-      tidyup: ['dist/leaflet-src.js','dist/proj4-src.js','dist/proj4leaflet.js']
+      tidyup: ['dist/leaflet-src.js','dist/proj4-src.js','dist/proj4leaflet.js'],
+      experiments: {
+        options: {force: true},
+        src: ['../experiments/dist']
+      }
     },
     rollup: {
       options: {
@@ -151,5 +164,6 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['jshint']);
   grunt.registerTask('default', ['clean:dist', 'copy', 'jshint', 'rollup', 
                                  'uglify', 'cssmin','clean:tidyup']);
+  grunt.registerTask('experiments',['clean:experiments','default','copy:experiments']);
 
 };


### PR DESCRIPTION
This will only be useful if you have an [experiments repo](https://github.com/Maps4HTML/experiments) as a sibling repo to your web-map-custom-element (this) repo.  Note this would potentially really bad if you had an experiments directory that wasn't the intended target of this task as a sibling directory to the directory from which this task executes, because it deletes the dist folder in that directory and replaces it with the built dist folder from web-map-custom-elements.

To build and copy the built 'dist' folder to the experiments repo: 

```console
$ grunt experiments
Running "clean:experiments" (clean) task
>> 1 path cleaned.

Running "clean:dist" (clean) task
>> 1 path cleaned.

Running "copy:main" (copy) task
PATCHING:  node_modules/proj4/dist/proj4-src.js
PATCHING:  node_modules/proj4leaflet/src/proj4leaflet.js
MODIFYING:  index.html
Copied 4 files

Running "copy:images" (copy) task
Copied 5 files

Running "copy:experiments" (copy) task
Created 1 directory, copied 4 files

Running "jshint:files" (jshint) task
>> 39 files lint free.

Running "rollup:main" (rollup) task

Running "uglify:dist" (uglify) task
>> 7 sourcemaps created.
>> 7 files created 1.09 MB → 441.97 kB

Running "cssmin:combine" (cssmin) task
>> 1 file created. 34.3 kB → 25.2 kB

Running "clean:tidyup" (clean) task
>> 3 paths cleaned.

Running "copy:experiments" (copy) task
Created 1 directory, copied 16 files

Done.

$
```