### PR TITLE
make map move when setters used for lat/lon/zoom

### DIFF
--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -51,6 +51,9 @@ export class MapViewer extends HTMLElement {
   set lat(val) {
     if (val) {
       this.setAttribute("lat", val);
+      if (this._mapZoomLocationAPI) {
+        this.zoomTo(val,this.lon,this.zoom);
+      }
     }
   }
   get lon() {
@@ -59,6 +62,9 @@ export class MapViewer extends HTMLElement {
   set lon(val) {
     if (val) {
       this.setAttribute("lon", val);
+      if (this._mapZoomLocationAPI) {
+        this.zoomTo(this.lat,val,this.zoom);
+      }
     }
   }
   get projection() {
@@ -86,6 +92,9 @@ export class MapViewer extends HTMLElement {
       var parsedVal = parseInt(val,10);
       if (!isNaN(parsedVal) && (parsedVal >= 0 && parsedVal <= 25)) {
         this.setAttribute('zoom', parsedVal);
+        if (this._mapZoomLocationAPI) {
+          this.zoomTo(this.lat,this.lon,parsedVal);
+        }
       }
   }
   get layers() {
@@ -126,6 +135,8 @@ export class MapViewer extends HTMLElement {
     this._history = [];
     this._historyIndex = -1;
     this._traversalCall = false;
+    // keeps track of when the zoom, lon, and lat are being set using the API
+    this._mapZoomLocationAPI = true;
   }
   connectedCallback() {
 
@@ -687,16 +698,15 @@ export class MapViewer extends HTMLElement {
     zoom = Number.isInteger(+zoom) ? +zoom : this.zoom;
     let location = new L.LatLng(+lat, +lon);
     this._map.setView(location, zoom);
-    this.zoom = zoom;
-    this.lat = location.lat;
-    this.lon = location.lng;
   }
   _updateMapCenter() {
     // remember to tell Leaflet event handler that 'this' in here refers to
     //  something other than the map in this case the custom polymer element
+    this._mapZoomLocationAPI = false;
     this.lat = this._map.getCenter().lat;
     this.lon = this._map.getCenter().lng;
     this.zoom = this._map.getZoom();
+    this._mapZoomLocationAPI = true;
   }
 
   /**

--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -6,7 +6,7 @@ import { MapCaption } from './map-caption.js';
 
 export class MapViewer extends HTMLElement {
   static get observedAttributes() {
-    return ['lat', 'lon', 'zoom', 'projection', 'width', 'height', 'controls', 'static', 'controlslist'];
+    return ['projection', 'width', 'height', 'controls', 'static', 'controlslist'];
   }
   // see comments below regarding attributeChangedCallback vs. getter/setter
   // usage.  Effectively, the user of the element must use the property, not

--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -51,9 +51,6 @@ export class MapViewer extends HTMLElement {
   set lat(val) {
     if (val) {
       this.setAttribute("lat", val);
-      if (this._mapZoomLocationAPI) {
-        this.zoomTo(val,this.lon,this.zoom);
-      }
     }
   }
   get lon() {
@@ -62,9 +59,6 @@ export class MapViewer extends HTMLElement {
   set lon(val) {
     if (val) {
       this.setAttribute("lon", val);
-      if (this._mapZoomLocationAPI) {
-        this.zoomTo(this.lat,val,this.zoom);
-      }
     }
   }
   get projection() {
@@ -92,9 +86,6 @@ export class MapViewer extends HTMLElement {
       var parsedVal = parseInt(val,10);
       if (!isNaN(parsedVal) && (parsedVal >= 0 && parsedVal <= 25)) {
         this.setAttribute('zoom', parsedVal);
-        if (this._mapZoomLocationAPI) {
-          this.zoomTo(this.lat,this.lon,parsedVal);
-        }
       }
   }
   get layers() {
@@ -327,6 +318,21 @@ export class MapViewer extends HTMLElement {
           this._hideControls();
         } else if (oldValue === null && newValue !== null) {
           this._showControls();
+        }
+      break;
+      case 'lat':
+        if (this._mapZoomLocationAPI && oldValue !== null) {
+          this.zoomTo(newValue, this.lon, this.zoom);
+        }
+      break;
+      case 'lon':
+        if (this._mapZoomLocationAPI && oldValue !== null) {
+          this.zoomTo(this.lat, newValue, this.zoom);
+        }
+      break;
+      case 'zoom':
+        if (this._mapZoomLocationAPI && oldValue !== null) {
+          this.zoomTo(this.lat, this.lon, newValue);
         }
       break;
       case 'height': 

--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -46,19 +46,19 @@ export class MapViewer extends HTMLElement {
     this.setAttribute("height", val);
   }
   get lat() {
-    return this.hasAttribute("lat") ? this.getAttribute("lat") : "0";
+    return this._map.getCenter().lat;
   }
   set lat(val) {
     if (val) {
-      this.setAttribute("lat", val);
+      this.zoomTo(val, this.lon, this.zoom);
     }
   }
   get lon() {
-    return this.hasAttribute("lon") ? this.getAttribute("lon") : "0";
+    return this._map.getCenter().lng;
   }
   set lon(val) {
     if (val) {
-      this.setAttribute("lon", val);
+      this.zoomTo(this.lat, val, this.zoom);
     }
   }
   get projection() {
@@ -80,12 +80,12 @@ export class MapViewer extends HTMLElement {
     } else throw new Error("Undefined Projection");
   }
   get zoom() {
-    return this.hasAttribute("zoom") ? this.getAttribute("zoom") : 0;
+    return this._map.getZoom();
   }
   set zoom(val) {
       var parsedVal = parseInt(val,10);
       if (!isNaN(parsedVal) && (parsedVal >= 0 && parsedVal <= 25)) {
-        this.setAttribute('zoom', parsedVal);
+        this.zoomTo(this.lat, this.lon, parsedVal);
       }
   }
   get layers() {
@@ -126,8 +126,6 @@ export class MapViewer extends HTMLElement {
     this._history = [];
     this._historyIndex = -1;
     this._traversalCall = false;
-    // keeps track of when the zoom, lon, and lat are being set using the API
-    this._mapZoomLocationAPI = true;
   }
   connectedCallback() {
 
@@ -249,8 +247,10 @@ export class MapViewer extends HTMLElement {
   }
   _createMap() {
     if (!this._map) {
+      let lat = this.hasAttribute("lat") ? this.getAttribute("lat") : "0";
+      let lon = this.hasAttribute("lon") ? this.getAttribute("lon") : "0";
       this._map = L.map(this._container, {
-        center: new L.LatLng(this.lat, this.lon),
+        center: new L.LatLng(lat, lon),
         projection: this.projection,
         query: true,
         contextMenu: true,
@@ -258,7 +258,7 @@ export class MapViewer extends HTMLElement {
         featureIndex: true,
         mapEl: this,
         crs: M[this.projection],
-        zoom: this.zoom,
+        zoom: this.hasAttribute("zoom") ? this.getAttribute("zoom") : 0,
         zoomControl: false,
         // because the M.MapMLLayer invokes _tileLayer._onMoveEnd when
         // the mapml response is received the screen tends to flash.  I'm sure
@@ -318,21 +318,6 @@ export class MapViewer extends HTMLElement {
           this._hideControls();
         } else if (oldValue === null && newValue !== null) {
           this._showControls();
-        }
-      break;
-      case 'lat':
-        if (this._mapZoomLocationAPI && oldValue !== null) {
-          this.zoomTo(newValue, this.lon, this.zoom);
-        }
-      break;
-      case 'lon':
-        if (this._mapZoomLocationAPI && oldValue !== null) {
-          this.zoomTo(this.lat, newValue, this.zoom);
-        }
-      break;
-      case 'zoom':
-        if (this._mapZoomLocationAPI && oldValue !== null) {
-          this.zoomTo(this.lat, this.lon, newValue);
         }
       break;
       case 'height': 
@@ -611,38 +596,32 @@ export class MapViewer extends HTMLElement {
       }, this);
     this._map.on('movestart',
       function () {
-        this._updateMapCenter();
         this.dispatchEvent(new CustomEvent('movestart', {detail:
           {target: this}}));
       }, this);
     this._map.on('move',
       function () {
-        this._updateMapCenter();
         this.dispatchEvent(new CustomEvent('move', {detail:
           {target: this}}));
       }, this);
     this._map.on('moveend',
       function () {
-        this._updateMapCenter();
         this._addToHistory();
         this.dispatchEvent(new CustomEvent('moveend', {detail:
           {target: this}}));
       }, this);
     this._map.on('zoomstart',
       function () {
-        this._updateMapCenter();
         this.dispatchEvent(new CustomEvent('zoomstart', {detail:
           {target: this}}));
       }, this);
     this._map.on('zoom',
       function () {
-        this._updateMapCenter();
         this.dispatchEvent(new CustomEvent('zoom', {detail:
           {target: this}}));
       }, this);
     this._map.on('zoomend',
       function () {
-        this._updateMapCenter();
         this.dispatchEvent(new CustomEvent('zoomend', {detail:
           {target: this}}));
       }, this);
@@ -705,16 +684,6 @@ export class MapViewer extends HTMLElement {
     let location = new L.LatLng(+lat, +lon);
     this._map.setView(location, zoom);
   }
-  _updateMapCenter() {
-    // remember to tell Leaflet event handler that 'this' in here refers to
-    //  something other than the map in this case the custom polymer element
-    this._mapZoomLocationAPI = false;
-    this.lat = this._map.getCenter().lat;
-    this.lon = this._map.getCenter().lng;
-    this.zoom = this._map.getZoom();
-    this._mapZoomLocationAPI = true;
-  }
-
   /**
    * Adds to the maps history on moveends
    * @private

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -52,6 +52,9 @@ export class WebMap extends HTMLMapElement {
   set lat(val) {
     if (val) {
       this.setAttribute("lat", val);
+      if (this._mapZoomLocationAPI) {
+        this.zoomTo(val,this.lon,this.zoom);
+      }
     }
   }
   get lon() {
@@ -60,6 +63,9 @@ export class WebMap extends HTMLMapElement {
   set lon(val) {
     if (val) {
       this.setAttribute("lon", val);
+      if (this._mapZoomLocationAPI) {
+        this.zoomTo(this.lat,val,this.zoom);
+      }
     }
   }
   get projection() {
@@ -87,6 +93,9 @@ export class WebMap extends HTMLMapElement {
     var parsedVal = parseInt(val,10);
     if (!isNaN(parsedVal) && (parsedVal >= 0 && parsedVal <= 25)) {
       this.setAttribute('zoom', parsedVal);
+      if (this._mapZoomLocationAPI) {
+        this.zoomTo(this.lat,this.lon,parsedVal);
+      }
     }
   }
   get layers() {
@@ -130,6 +139,8 @@ export class WebMap extends HTMLMapElement {
     this._history = [];
     this._historyIndex = -1;
     this._traversalCall = false;
+    // keeps track of when the zoom, lon, and lat are being set using the API
+    this._mapZoomLocationAPI = true;
   }
   connectedCallback() {
 
@@ -730,16 +741,15 @@ export class WebMap extends HTMLMapElement {
     zoom = Number.isInteger(+zoom) ? +zoom : this.zoom;
     let location = new L.LatLng(+lat, +lon);
     this._map.setView(location, zoom);
-    this.zoom = zoom;
-    this.lat = location.lat;
-    this.lon = location.lng;
   }
   _updateMapCenter() {
     // remember to tell Leaflet event handler that 'this' in here refers to
     //  something other than the map in this case the custom polymer element
+    this._mapZoomLocationAPI = false;
     this.lat = this._map.getCenter().lat;
     this.lon = this._map.getCenter().lng;
     this.zoom = this._map.getZoom();
+    this._mapZoomLocationAPI = true;
   }
 
   /**

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -7,7 +7,7 @@ import { MapCaption } from './map-caption.js';
 
 export class WebMap extends HTMLMapElement {
   static get observedAttributes() {
-    return ['lat', 'lon', 'zoom', 'projection', 'width', 'height', 'controls', 'static', 'controlslist'];
+    return ['projection', 'width', 'height', 'controls', 'static', 'controlslist'];
   }
   // see comments below regarding attributeChangedCallback vs. getter/setter
   // usage.  Effectively, the user of the element must use the property, not

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -52,9 +52,6 @@ export class WebMap extends HTMLMapElement {
   set lat(val) {
     if (val) {
       this.setAttribute("lat", val);
-      if (this._mapZoomLocationAPI) {
-        this.zoomTo(val,this.lon,this.zoom);
-      }
     }
   }
   get lon() {
@@ -63,9 +60,6 @@ export class WebMap extends HTMLMapElement {
   set lon(val) {
     if (val) {
       this.setAttribute("lon", val);
-      if (this._mapZoomLocationAPI) {
-        this.zoomTo(this.lat,val,this.zoom);
-      }
     }
   }
   get projection() {
@@ -93,9 +87,6 @@ export class WebMap extends HTMLMapElement {
     var parsedVal = parseInt(val,10);
     if (!isNaN(parsedVal) && (parsedVal >= 0 && parsedVal <= 25)) {
       this.setAttribute('zoom', parsedVal);
-      if (this._mapZoomLocationAPI) {
-        this.zoomTo(this.lat,this.lon,parsedVal);
-      }
     }
   }
   get layers() {
@@ -371,6 +362,21 @@ export class WebMap extends HTMLMapElement {
         } else if (oldValue === null && newValue !== null) {
           this._showControls();
         } 
+      break;
+      case 'lat':
+        if (this._mapZoomLocationAPI && oldValue !== null) {
+          this.zoomTo(newValue, this.lon, this.zoom);
+        }
+      break;
+      case 'lon':
+        if (this._mapZoomLocationAPI && oldValue !== null) {
+          this.zoomTo(this.lat, newValue, this.zoom);
+        }
+      break;
+      case 'zoom':
+        if (this._mapZoomLocationAPI && oldValue !== null) {
+          this.zoomTo(this.lat, this.lon, newValue);
+        }
       break;
       case 'height': 
         if (oldValue !== newValue) {

--- a/test/e2e/api/domApi-mapml-viewer.test.js
+++ b/test/e2e/api/domApi-mapml-viewer.test.js
@@ -424,3 +424,63 @@ test.describe("mapml-viewer DOM API Tests", () => {
   });
 
 });
+
+test.describe("Properties Getter and Setter", () => {
+  let page;
+  let context;
+  test.beforeAll(async function() {
+    context = await chromium.launchPersistentContext('');
+    page = context.pages().find((page) => page.url() === 'about:blank') || await context.newPage();
+    await page.goto("propertiesApi-mapml-viewer.html");
+  });
+
+  test.afterAll(async function () {
+    await context.close();
+  });
+
+  test("zoom getter and setter test", async () => {
+    const viewerHandle = await page.evaluateHandle(() => document.querySelector('mapml-viewer'));
+    let leafletZoom = await page.evaluate( viewer => viewer._map.getZoom(), viewerHandle);
+    let mapZoom = await page.evaluate( viewer => viewer.zoom, viewerHandle);
+    expect(mapZoom).toEqual(leafletZoom);
+    expect(leafletZoom).toEqual(0);
+
+    await page.evaluate( viewer => viewer.zoom = 5, viewerHandle);
+
+    leafletZoom = await page.evaluate( viewer => viewer._map.getZoom(), viewerHandle);
+    mapZoom = await page.evaluate( viewer => viewer.zoom, viewerHandle);
+    expect(mapZoom).toEqual(leafletZoom);
+    expect(leafletZoom).toEqual(5);
+  });
+
+  test("lon getter and setter test", async () => {
+    const viewerHandle = await page.evaluateHandle(() => document.querySelector('mapml-viewer'));
+    let leafletLon = await page.evaluate( viewer => viewer._map.getCenter().lng, viewerHandle);
+    let mapLon = await page.evaluate( viewer => viewer.lon, viewerHandle);
+    expect(mapLon).toEqual(leafletLon);
+    expect(leafletLon).toEqual(-92);
+
+    await page.evaluate( viewer => viewer.lon = -70, viewerHandle);
+
+    leafletLon = await page.evaluate( viewer => viewer._map.getCenter().lng, viewerHandle);
+    mapLon = await page.evaluate( viewer => viewer.lon, viewerHandle);
+    expect(mapLon).toEqual(leafletLon);
+    expect(leafletLon).toEqual(-70);
+  });
+
+  test("lat getter and setter test", async () => {
+    const viewerHandle = await page.evaluateHandle(() => document.querySelector('mapml-viewer'));
+    let leafletLat = await page.evaluate( viewer => viewer._map.getCenter().lat, viewerHandle);
+    let mapLat = await page.evaluate( viewer => viewer.lat, viewerHandle);
+    expect(mapLat).toEqual(leafletLat);
+    expect(leafletLat).toEqual(47);
+
+    await page.evaluate( viewer => viewer.lat = 30, viewerHandle);
+
+    leafletLat = await page.evaluate( viewer => viewer._map.getCenter().lat, viewerHandle);
+    mapLat = await page.evaluate( viewer => viewer.lat, viewerHandle);
+    expect(mapLat).toEqual(leafletLat);
+    expect(leafletLat).toEqual(30);
+  });
+
+})

--- a/test/e2e/api/domApi-web-map.test.js
+++ b/test/e2e/api/domApi-web-map.test.js
@@ -429,3 +429,63 @@ test.describe("web-map DOM API Tests", () => {
   });
 
 });
+
+test.describe("Properties Getter and Setter", () => {
+  let page;
+  let context;
+  test.beforeAll(async function() {
+    context = await chromium.launchPersistentContext('');
+    page = context.pages().find((page) => page.url() === 'about:blank') || await context.newPage();
+    await page.goto("propertiesApi-map.html");
+  });
+
+  test.afterAll(async function () {
+    await context.close();
+  });
+
+  test("zoom getter and setter test", async () => {
+    const mapHandle = await page.evaluateHandle(() => document.querySelector('map'));
+    let leafletZoom = await page.evaluate( viewer => viewer._map.getZoom(), mapHandle);
+    let mapZoom = await page.evaluate( viewer => viewer.zoom, mapHandle);
+    expect(mapZoom).toEqual(leafletZoom);
+    expect(leafletZoom).toEqual(0);
+
+    await page.evaluate( viewer => viewer.zoom = 5, mapHandle);
+
+    leafletZoom = await page.evaluate( viewer => viewer._map.getZoom(), mapHandle);
+    mapZoom = await page.evaluate( viewer => viewer.zoom, mapHandle);
+    expect(mapZoom).toEqual(leafletZoom);
+    expect(leafletZoom).toEqual(5);
+  });
+
+  test("lon getter and setter test", async () => {
+    const mapHandle = await page.evaluateHandle(() => document.querySelector('map'));
+    let leafletLon = await page.evaluate( viewer => viewer._map.getCenter().lng, mapHandle);
+    let mapLon = await page.evaluate( viewer => viewer.lon, mapHandle);
+    expect(mapLon).toEqual(leafletLon);
+    expect(leafletLon).toEqual(-92);
+
+    await page.evaluate( viewer => viewer.lon = -70, mapHandle);
+
+    leafletLon = await page.evaluate( viewer => viewer._map.getCenter().lng, mapHandle);
+    mapLon = await page.evaluate( viewer => viewer.lon, mapHandle);
+    expect(mapLon).toEqual(leafletLon);
+    expect(leafletLon).toEqual(-70);
+  });
+
+  test("lat getter and setter test", async () => {
+    const mapHandle = await page.evaluateHandle(() => document.querySelector('map'));
+    let leafletLat = await page.evaluate( viewer => viewer._map.getCenter().lat, mapHandle);
+    let mapLat = await page.evaluate( viewer => viewer.lat, mapHandle);
+    expect(mapLat).toEqual(leafletLat);
+    expect(leafletLat).toEqual(47);
+
+    await page.evaluate( viewer => viewer.lat = 30, mapHandle);
+
+    leafletLat = await page.evaluate( viewer => viewer._map.getCenter().lat, mapHandle);
+    mapLat = await page.evaluate( viewer => viewer.lat, mapHandle);
+    expect(mapLat).toEqual(leafletLat);
+    expect(leafletLat).toEqual(30);
+  });
+
+})

--- a/test/e2e/api/propertiesApi-map.html
+++ b/test/e2e/api/propertiesApi-map.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>Basic Mapml-Viewer</title>
+  <meta charset="UTF-8">
+  <script>
+    let options = document.createElement("map-options");
+    options.innerHTML = '{"announceMovement":true}';
+    document.head.appendChild(options);
+  </script>
+  <script type="module" src="web-map.js"></script>
+  <style>
+    html {
+      height: 100%
+    }
+
+    body {
+      height: inherit
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <map is="web-map" width="500" height="500" projection="CBMTILE" zoom="0" lat="47" lon="-92" controls>
+  	<layer- label="CBMT - INLINE" checked>
+      <map-extent units="CBMTILE">
+        <map-input name="zoomLevel" type="zoom" value="3" min="0" max="3" ></map-input>
+        <map-input name="row" type="location" axis="row" units="tilematrix" min="14" max="21" ></map-input>
+        <map-input name="col" type="location" axis="column" units="tilematrix" min="14" max="19" ></map-input>
+        <map-link rel='tile' tref='/data/cbmt/{zoomLevel}/c{col}_r{row}.png' ></map-link>
+      </map-extent>
+    </layer->
+  </map>
+</body>
+</html>

--- a/test/e2e/api/propertiesApi-mapml-viewer.html
+++ b/test/e2e/api/propertiesApi-mapml-viewer.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>Basic Mapml-Viewer</title>
+  <meta charset="UTF-8">
+  <script>
+    let options = document.createElement("map-options");
+    options.innerHTML = '{"announceMovement":true}';
+    document.head.appendChild(options);
+  </script>
+  <script type="module" src="mapml-viewer.js"></script>
+  <style>
+    html {
+      height: 100%
+    }
+
+    body {
+      height: inherit
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <mapml-viewer width="500" height="500" projection="CBMTILE" zoom="0" lat="47" lon="-92" controls>
+    <layer- label="CBMT - INLINE" checked>
+      <map-extent units="CBMTILE">
+        <map-input name="zoomLevel" type="zoom" value="3" min="0" max="3" ></map-input>
+        <map-input name="row" type="location" axis="row" units="tilematrix" min="14" max="21" ></map-input>
+        <map-input name="col" type="location" axis="column" units="tilematrix" min="14" max="19" ></map-input>
+        <map-link rel='tile' tref='/data/cbmt/{zoomLevel}/c{col}_r{row}.png' ></map-link>
+      </map-extent>
+    </layer->
+  </mapml-viewer>
+</body>
+</html>


### PR DESCRIPTION
- [X] Pan/zoom the map when lat/lon/zoom are set.
- [x] Add tests
- [ ] update [documentation](https://github.com/Maps4HTML/web-map-doc/issues/56)
- [x] Update [Spec](https://github.com/Maps4HTML/MapML/pull/239)

resolves #588.