### PR TITLE
Fix disabled contextmenu styling

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -117,8 +117,11 @@
 }
 
 button.mapml-button:disabled,
-.mapml-button[aria-disabled="true"],
-.mapml-layer-item:disabled button.mapml-button {
+.mapml-button[aria-disabled="true"] {
+  color: #bbb;
+}
+
+button.mapml-contextmenu-item:disabled {
   opacity: .3;
 }
 

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -117,8 +117,9 @@
 }
 
 button.mapml-button:disabled,
-.mapml-button[aria-disabled="true"] {
-  color: #bbb;
+.mapml-button[aria-disabled="true"],
+.mapml-layer-item:disabled button.mapml-button {
+  opacity: .3;
 }
 
 .leaflet-control-layers-toggle {


### PR DESCRIPTION
Adds styling to disabled contextmenu buttons -
Before:
![image](https://user-images.githubusercontent.com/55751566/233421300-194b79af-109e-4c9b-9c75-360a2d0854e5.png)

Now:
![image](https://user-images.githubusercontent.com/55751566/233420668-541c6071-e7f2-43ef-bc2f-b95f87b122e5.png)
