### PR TITLE
Fix bug in query handling where map-meta in query response was

### DIFF
--- a/src/map-feature.js
+++ b/src/map-feature.js
@@ -345,7 +345,9 @@ export class MapFeature extends HTMLElement {
         let map = this._map,
           geometry = this.querySelector('map-geometry'),
           native = this._getNativeZoomAndCS(
-            this._layer._content || this._layer.metas
+            this._layer.queryMetas?.length
+              ? this._layer.queryMetas
+              : this._layer._content
           ),
           cs = geometry.getAttribute('cs') || native.cs,
           // zoom level that the feature rendered at

--- a/src/mapml/handlers/QueryHandler.js
+++ b/src/mapml/handlers/QueryHandler.js
@@ -113,8 +113,8 @@ export var QueryHandler = L.Handler.extend({
             features = Array.prototype.slice.call(
               mapmldoc.querySelectorAll('map-feature')
             );
-            // <map-meta> elements
-            layer.metas = Array.prototype.slice.call(
+            // <map-meta> elements for this query
+            layer.queryMetas = Array.prototype.slice.call(
               mapmldoc.querySelectorAll(
                 'map-meta[name=cs], map-meta[name=zoom], map-meta[name=projection]'
               )
@@ -298,7 +298,11 @@ export var QueryHandler = L.Handler.extend({
       layer.on('popupclose', function () {
         map.removeLayer(f);
       });
-      f.showPaginationFeature({ i: 0, popup: layer._popup, meta: layer.metas });
+      f.showPaginationFeature({
+        i: 0,
+        popup: layer._popup,
+        meta: layer.queryMetas
+      });
     }
   }
 });


### PR DESCRIPTION
inadvertently ignored. Rename _layer.metas to _layer.queryMetas for clarity.

Originally addressed in #854 