### PR TITLE
Add map-projectionchange event. 

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -108,7 +108,7 @@ export class MapLayer extends HTMLElement {
     this._createLayerControlHTML = M._createLayerControlHTML.bind(this);
     // this._opacity is used to record the current opacity value (with or without updates),
     // the initial value of this._opacity should be set as opacity attribute value, if exists, or the default value 1.0
-    this._opacity = +(this.getAttribute('opacity') || 1.0);
+    this._opacity = this.opacity || 1.0;
     const doConnected = this._onAdd.bind(this);
     this.parentElement
       .whenReady()
@@ -345,25 +345,20 @@ export class MapLayer extends HTMLElement {
             '_mapmlvectors',
             '_templatedLayer'
           ];
-        if (layer.validProjection) {
-          for (let j = 0; j < layerTypes.length; j++) {
-            let type = layerTypes[j];
-            if (this.checked) {
-              if (type === '_templatedLayer' && mapExtents.length > 0) {
-                for (let i = 0; i < mapExtents.length; i++) {
-                  totalExtentCount++;
-                  if (mapExtents[i]._validateDisabled()) disabledExtentCount++;
-                }
-              } else if (layer[type]) {
-                // not a templated layer
+        for (let j = 0; j < layerTypes.length; j++) {
+          let type = layerTypes[j];
+          if (this.checked) {
+            if (type === '_templatedLayer' && mapExtents.length > 0) {
+              for (let i = 0; i < mapExtents.length; i++) {
                 totalExtentCount++;
-                if (!layer[type].isVisible) disabledExtentCount++;
+                if (mapExtents[i]._validateDisabled()) disabledExtentCount++;
               }
+            } else if (layer[type]) {
+              // not a templated layer
+              totalExtentCount++;
+              if (!layer[type].isVisible) disabledExtentCount++;
             }
           }
-        } else {
-          disabledExtentCount = 1;
-          totalExtentCount = 1;
         }
         // if all extents are not visible / disabled, set layer to disabled
         if (

--- a/src/map-extent.js
+++ b/src/map-extent.js
@@ -168,9 +168,11 @@ export class MapExtent extends HTMLElement {
     );
     this._changeHandler = this._handleChange.bind(this);
     this.parentLayer.addEventListener('map-change', this._changeHandler);
+    this.mapEl = this.parentLayer.closest('mapml-viewer,map[is=web-map]');
+    this.mapEl.addEventListener('map-projectionchange', this._changeHandler);
     // this._opacity is used to record the current opacity value (with or without updates),
     // the initial value of this._opacity should be set as opacity attribute value, if exists, or the default value 1.0
-    this._opacity = +(this.getAttribute('opacity') || 1.0);
+    this._opacity = this.opacity || 1.0;
     this._templatedLayer = M.templatedLayer(this._templateVars, {
       pane: this._layer._container,
       opacity: this.opacity,
@@ -522,6 +524,7 @@ export class MapExtent extends HTMLElement {
     this._layerControlHTML.remove();
     this._map.removeLayer(this._templatedLayer);
     this.parentLayer.removeEventListener('map-change', this._changeHandler);
+    this.mapEl.removeEventListener('map-projectionchange', this._changeHandler);
     delete this._templatedLayer;
     delete this.parentLayer.bounds;
   }

--- a/src/map-extent.js
+++ b/src/map-extent.js
@@ -140,6 +140,10 @@ export class MapExtent extends HTMLElement {
       this.attachShadow({ mode: 'open' });
     }
     await this.parentLayer.whenReady();
+    this.mapEl = this.parentLayer.closest('mapml-viewer,map[is=web-map]');
+    await this.mapEl.whenProjectionDefined(this.units).catch(() => {
+      throw new Error('Undefined projection:' + this.units);
+    });
     // when projection is changed, the parent layer-._layer is created (so whenReady is fulfilled) but then removed,
     // then the map-extent disconnectedCallback will be triggered by layer-._onRemove() (clear the shadowRoot)
     // even before connectedCallback is finished
@@ -168,7 +172,6 @@ export class MapExtent extends HTMLElement {
     );
     this._changeHandler = this._handleChange.bind(this);
     this.parentLayer.addEventListener('map-change', this._changeHandler);
-    this.mapEl = this.parentLayer.closest('mapml-viewer,map[is=web-map]');
     this.mapEl.addEventListener('map-projectionchange', this._changeHandler);
     // this._opacity is used to record the current opacity value (with or without updates),
     // the initial value of this._opacity should be set as opacity attribute value, if exists, or the default value 1.0

--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -377,9 +377,13 @@ export class MapViewer extends HTMLElement {
               this.zoomTo(lat, lon, zoom);
               if (M.options.announceMovement)
                 this._map.announceMovement.enable();
-              this.querySelectorAll('layer-').forEach((layer) => {
-                layer.dispatchEvent(new CustomEvent('map-change'));
-              });
+              // required to delay until map-extent.disabled is correctly set
+              // which happens as a result of layer-._validateDisabled()
+              // which happens so much we have to delay until they calls are
+              // completed
+              setTimeout(() => {
+                this.dispatchEvent(new CustomEvent('map-projectionchange'));
+              }, 0);
             });
           }
         };

--- a/src/mapml/handlers/ContextMenu.js
+++ b/src/mapml/handlers/ContextMenu.js
@@ -798,7 +798,6 @@ export var ContextMenu = L.Handler.extend({
               .closest('fieldset')
               .parentNode.parentNode.parentNode.querySelector('span')
           : elem.querySelector('span');
-      if (!elem.layer.validProjection) return;
       this._layerClicked = elem;
       this._layerMenu.removeAttribute('hidden');
       this._showAtPoint(e.containerPoint, e, this._layerMenu);

--- a/src/mapml/layers/MapMLLayer.js
+++ b/src/mapml/layers/MapMLLayer.js
@@ -43,17 +43,6 @@ export var MapMLLayer = L.Layer.extend({
     // OR use the extent of the content provided
 
     this._initialize(local ? layerEl : mapml);
-
-    // a default extent can't be correctly set without the map to provide
-    // its bounds , projection, zoom range etc, so if that stuff's not
-    // established by metadata in the content, we should use map properties
-    // to set the extent, but the map won't be available until the <layer>
-    // element is attached to the <map> element, wait for that to happen.
-    // weirdness.  options is actually undefined here, despite the hardcoded
-    // options above. If you use this.options, you see the options defined
-    // above.  Not going to change this, but failing to understand ATM.
-    // may revisit some time.
-    this.validProjection = true;
   },
   setZIndex: function (zIndex) {
     this.options.zIndex = zIndex;
@@ -98,11 +87,6 @@ export var MapMLLayer = L.Layer.extend({
   },
 
   onAdd: function (map) {
-    // probably don't need it except for layer context menu usage
-    if (this._properties && !this._validProjection(map)) {
-      this.validProjection = false;
-      return;
-    }
     this._map = map;
     if (this._mapmlvectors) map.addLayer(this._mapmlvectors);
 
@@ -216,26 +200,6 @@ export var MapMLLayer = L.Layer.extend({
       this.bounds = bounds;
       this.zoomBounds = zoomBounds;
     }
-  },
-
-  _validProjection: function (map) {
-    const mapExtents = this._layerEl.querySelectorAll('map-extent');
-    let noLayer = false;
-    if (this._properties && mapExtents.length > 0) {
-      for (let i = 0; i < mapExtents.length; i++) {
-        if (mapExtents[i]._templateVars) {
-          for (let template of mapExtents[i]._templateVars)
-            if (
-              !template.projectionMatch &&
-              template.projection !== map.options.projection
-            ) {
-              noLayer = true; // if there's a single template where projections don't match, set noLayer to true
-              break;
-            }
-        }
-      }
-    }
-    return !(noLayer || this.getProjection() !== map.options.projection);
   },
 
   addTo: function (map) {

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -422,9 +422,13 @@ export class WebMap extends HTMLMapElement {
               this.zoomTo(lat, lon, zoom);
               if (M.options.announceMovement)
                 this._map.announceMovement.enable();
-              this.querySelectorAll('layer-').forEach((layer) => {
-                layer.dispatchEvent(new CustomEvent('map-change'));
-              });
+              // required to delay until map-extent.disabled is correctly set
+              // which happens as a result of layer-._validateDisabled()
+              // which happens so much we have to delay until they calls are
+              // completed
+              setTimeout(() => {
+                this.dispatchEvent(new CustomEvent('map-projectionchange'));
+              }, 0);
             });
           }
         };

--- a/test/e2e/api/events/map-projectionchange.html
+++ b/test/e2e/api/events/map-projectionchange.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>map-projectionchange event</title>
+    <!-- the layer in this map should continue to be visible when you change
+    the viewer projection from OSMTILE to CBMTILE.  -->
+    <script type="module" src="/mapml-viewer.js"></script>
+  </head>
+  <body>
+  <mapml-viewer zoom="2" lon="-75.703611" lat="45.411105" width="500" height="500" controls projection="OSMTILE">
+    <layer- label="Projection changer"  checked>
+      <map-extent label="National Geographic" units="OSMTILE" checked >
+        <map-input name="TileMatrix" type="zoom" value="18" min="0" max="18"></map-input>
+        <map-input name="TileCol" type="location" units="tilematrix" axis="column" min="0" max="262144"></map-input>
+        <map-input name="TileRow" type="location" units="tilematrix" axis="row" min="0" max="262144"></map-input>
+        <map-link rel="tile" tref="https://server.arcgisonline.com/arcgis/rest/services/NatGeo_World_Map/MapServer/WMTS/tile/1.0.0/NatGeo_World_Map/default/default028mm/{TileMatrix}/{TileRow}/{TileCol}.jpg"></map-link>
+      </map-extent>
+      <map-extent label="Canada Base Map - Transportation" units="CBMTILE" checked >
+        <map-input name="z" type="zoom" min="0" max="18"></map-input>
+        <map-input name="y" type="location" units="tilematrix" axis="row"></map-input>
+        <map-input name="x" type="location" units="tilematrix" axis="column"></map-input>
+        <map-link rel="tile" tref="/tiles/cbmt/{z}/c{x}_r{y}.png" ></map-link>
+      </map-extent>    
+    </layer->
+  </mapml-viewer>
+  <script>
+    function changeProjection() {
+      const prj = document.body.querySelector('mapml-viewer').projection;
+      if (document.body.querySelector('mapml-viewer').projection === "OSMTILE") {
+        document.body.querySelector('mapml-viewer').projection = "CBMTILE";
+      } else {
+        document.body.querySelector('mapml-viewer').projection = "OSMTILE";
+      }
+    }
+  </script>
+</body>
+</html>

--- a/test/e2e/api/events/map-projectionchange.test.js
+++ b/test/e2e/api/events/map-projectionchange.test.js
@@ -8,6 +8,10 @@ test.describe('map-projectionchange test ', () => {
     page =
       context.pages().find((page) => page.url() === 'about:blank') ||
       (await context.newPage());
+
+  });
+  
+  test.beforeEach(async function() {
     await page.goto('events/map-projectionchange.html');
   });
 
@@ -15,24 +19,41 @@ test.describe('map-projectionchange test ', () => {
     await context.close();
   });
 
-  test('do something and test it', async () => {
+  test('Multiple map-extents in different projections adapt to map-projectionchange', async () => {
     const viewer = await page.locator('mapml-viewer');
-    expect(await viewer.evaluate((v)=>v.projection)).toEqual('OSMTILE');
-    expect(await viewer.evaluate((v)=>{
-      return v.querySelector('map-extent[units=OSMTILE]').disabled;
-    })).toBe(false);
-    expect(await viewer.evaluate((v)=>{
-      return v.querySelector('map-extent[units=CBMTILE]').disabled;
-    })).toBe(true);
-    await viewer.evaluate(()=> changeProjection());
+    expect(await viewer.evaluate((v) => v.projection)).toEqual('OSMTILE');
+    expect(
+      await viewer.evaluate((v) => {
+        return v.querySelector('map-extent[units=OSMTILE]').disabled;
+      })
+    ).toBe(false);
+    expect(
+      await viewer.evaluate((v) => {
+        return v.querySelector('map-extent[units=CBMTILE]').disabled;
+      })
+    ).toBe(true);
+    await viewer.evaluate(() => changeProjection());
     await page.waitForTimeout(500);
-    expect(await viewer.evaluate((v)=> v.projection)).toEqual('CBMTILE');
-    expect(await viewer.evaluate((v)=>{
-      return v.querySelector('map-extent[units=OSMTILE]').disabled;
-    })).toBe(true);
-    expect(await viewer.evaluate((v)=>{
-      return v.querySelector('map-extent[units=CBMTILE]').disabled;
-    })).toBe(false);
-    
+    expect(await viewer.evaluate((v) => v.projection)).toEqual('CBMTILE');
+    expect(
+      await viewer.evaluate((v) => {
+        return v.querySelector('map-extent[units=OSMTILE]').disabled;
+      })
+    ).toBe(true);
+    expect(
+      await viewer.evaluate((v) => {
+        return v.querySelector('map-extent[units=CBMTILE]').disabled;
+      })
+    ).toBe(false);
+  });
+  test('History is empty after map-projectionchange', async () => {
+    const viewer = await page.locator('mapml-viewer');
+    expect(await viewer.evaluate((v) => v.projection)).toEqual('OSMTILE');
+    await viewer.evaluate(() => changeProjection());
+    await page.waitForTimeout(1000);
+    expect(await viewer.evaluate((v) => v.projection)).toEqual('CBMTILE');
+    const reload = await page.getByLabel('Reload');
+    expect(await reload.evaluate((button)=>button.ariaDisabled)).toBe('true');
+
   });
 });

--- a/test/e2e/api/events/map-projectionchange.test.js
+++ b/test/e2e/api/events/map-projectionchange.test.js
@@ -1,0 +1,38 @@
+import { test, expect, chromium } from '@playwright/test';
+
+test.describe('map-projectionchange test ', () => {
+  let page;
+  let context;
+  test.beforeAll(async () => {
+    context = await chromium.launchPersistentContext('');
+    page =
+      context.pages().find((page) => page.url() === 'about:blank') ||
+      (await context.newPage());
+    await page.goto('events/map-projectionchange.html');
+  });
+
+  test.afterAll(async function () {
+    await context.close();
+  });
+
+  test('do something and test it', async () => {
+    const viewer = await page.locator('mapml-viewer');
+    expect(await viewer.evaluate((v)=>v.projection)).toEqual('OSMTILE');
+    expect(await viewer.evaluate((v)=>{
+      return v.querySelector('map-extent[units=OSMTILE]').disabled;
+    })).toBe(false);
+    expect(await viewer.evaluate((v)=>{
+      return v.querySelector('map-extent[units=CBMTILE]').disabled;
+    })).toBe(true);
+    await viewer.evaluate(()=> changeProjection());
+    await page.waitForTimeout(500);
+    expect(await viewer.evaluate((v)=> v.projection)).toEqual('CBMTILE');
+    expect(await viewer.evaluate((v)=>{
+      return v.querySelector('map-extent[units=OSMTILE]').disabled;
+    })).toBe(true);
+    expect(await viewer.evaluate((v)=>{
+      return v.querySelector('map-extent[units=CBMTILE]').disabled;
+    })).toBe(false);
+    
+  });
+});

--- a/test/e2e/api/events/map-projectionchange.test.js
+++ b/test/e2e/api/events/map-projectionchange.test.js
@@ -61,8 +61,12 @@ test.describe('map-projectionchange test ', () => {
     const viewer = await page.locator('mapml-viewer');
     const layer = await page.locator('layer-');
     await page.pause();
-    await layer.evaluate((layer) => layer.opacity = 0.5);
-    expect(await layer.evaluate((layer) => {return layer.opacity;})).toBe(0.5);
+    await layer.evaluate((layer) => (layer.opacity = 0.5));
+    expect(
+      await layer.evaluate((layer) => {
+        return layer.opacity;
+      })
+    ).toBe(0.5);
     const osmtileExtent = await page.locator('map-extent[units=OSMTILE]');
     await osmtileExtent.evaluate((e) => (e.opacity = 0.4));
     const cbmtileExtent = await page.locator('map-extent[units=CBMTILE]');
@@ -71,6 +75,10 @@ test.describe('map-projectionchange test ', () => {
     await page.waitForTimeout(1000);
     expect(await osmtileExtent.evaluate((e) => e.opacity)).toBe(0.4);
     expect(await cbmtileExtent.evaluate((e) => e.opacity)).toBe(0.3);
-    expect(await layer.evaluate((layer) => {return layer.opacity;})).toBe(0.5);
+    expect(
+      await layer.evaluate((layer) => {
+        return layer.opacity;
+      })
+    ).toBe(0.5);
   });
 });

--- a/test/e2e/api/events/map-projectionchange.test.js
+++ b/test/e2e/api/events/map-projectionchange.test.js
@@ -8,10 +8,9 @@ test.describe('map-projectionchange test ', () => {
     page =
       context.pages().find((page) => page.url() === 'about:blank') ||
       (await context.newPage());
-
   });
-  
-  test.beforeEach(async function() {
+
+  test.beforeEach(async function () {
     await page.goto('events/map-projectionchange.html');
   });
 
@@ -50,10 +49,22 @@ test.describe('map-projectionchange test ', () => {
     const viewer = await page.locator('mapml-viewer');
     expect(await viewer.evaluate((v) => v.projection)).toEqual('OSMTILE');
     await viewer.evaluate(() => changeProjection());
-    await page.waitForTimeout(1000);
+    await page.waitForTimeout(500);
     expect(await viewer.evaluate((v) => v.projection)).toEqual('CBMTILE');
     const reload = await page.getByLabel('Reload');
-    expect(await reload.evaluate((button)=>button.ariaDisabled)).toBe('true');
-
+    expect(await reload.evaluate((button) => button.ariaDisabled)).toBe('true');
+  });
+  test('Opacity is maintained on layer- and map-extent after map-projectionchange', async () => {
+    const layer = await page.locator('layer-');
+    await layer.evaluate((l) => (l.opacity = 0.5));
+    const osmtileExtent = await page.locator('map-extent[units=OSMTILE]');
+    await osmtileExtent.evaluate((e) => (e.opacity = 0.4));
+    const cbmtileExtent = await page.locator('map-extent[units=CBMTILE]');
+    await cbmtileExtent.evaluate((e) => (e.opacity = 0.3));
+    await page.evaluate(() => changeProjection());
+    await page.waitForTimeout(500);
+    expect(await osmtileExtent.evaluate((e) => e.opacity)).toBe(0.4);
+    expect(await cbmtileExtent.evaluate((e) => e.opacity)).toBe(0.3);
+    expect(await layer.evaluate((l) => l.opacity)).toBe(0.5);
   });
 });

--- a/test/e2e/elements/map-extent/map-extent.html
+++ b/test/e2e/elements/map-extent/map-extent.html
@@ -33,6 +33,12 @@
         <map-input name="col" type="location" axis="column" units="tilematrix" min="14" max="19"></map-input>
         <map-link rel='tile' tref='/data/cbmt/{zoomLevel}/c{col}_r{row}.png'></map-link>
       </map-extent>
+      <map-extent data-testid="ext4" label="User-generated label - 4" units="foo" checked>
+        <map-input name="zoomLevel" type="zoom" value="3" min="0" max="3"></map-input>
+        <map-input name="row" type="location" axis="row" units="tilematrix" min="14" max="21"></map-input>
+        <map-input name="col" type="location" axis="column" units="tilematrix" min="14" max="19"></map-input>
+        <map-link rel='tile' tref='/data/cbmt/{zoomLevel}/c{col}_r{row}.png'></map-link>
+      </map-extent>
   </template>
 </head>
 

--- a/test/e2e/elements/map-extent/map-extent.test.js
+++ b/test/e2e/elements/map-extent/map-extent.test.js
@@ -3,106 +3,104 @@ import { test, expect, chromium } from '@playwright/test';
 test.describe('map-extent tests', () => {
   let page;
   let context;
-  test.describe('attribute tests', () => {
-    test.beforeEach(async function () {
-      context = await chromium.launchPersistentContext('', { slowMo: 500 });
-      page =
-        context.pages().find((page) => page.url() === 'about:blank') ||
-        (await context.newPage());
-      await page.goto('map-extent.html');
+  test.beforeEach(async function () {
+    context = await chromium.launchPersistentContext('', { slowMo: 500 });
+    page =
+      context.pages().find((page) => page.url() === 'about:blank') ||
+      (await context.newPage());
+    await page.goto('map-extent.html');
+  });
+  test('Basic hidden functionality and API', async () => {
+    const extent = await page.getByTestId('ext1');
+    let hiddenInLayerControl = await extent.evaluate((extent) => {
+      return !extent._layerControlHTML.isConnected;
     });
-    test('Basic hidden functionality and API', async () => {
-      const extent = await page.getByTestId('ext1');
-      let hiddenInLayerControl = await extent.evaluate((extent) => {
-        return !extent._layerControlHTML.isConnected;
-      });
-      expect(hiddenInLayerControl).toBe(true);
+    expect(hiddenInLayerControl).toBe(true);
 
-      await extent.evaluate((extent) => {
-        extent.hidden = false;
-      });
-      hiddenInLayerControl = await extent.evaluate((extent) => {
-        return !extent._layerControlHTML.isConnected;
-      });
-      expect(hiddenInLayerControl).toBe(false);
+    await extent.evaluate((extent) => {
+      extent.hidden = false;
+    });
+    hiddenInLayerControl = await extent.evaluate((extent) => {
+      return !extent._layerControlHTML.isConnected;
+    });
+    expect(hiddenInLayerControl).toBe(false);
 
-      let labelProperty = await extent.evaluate((extent) => {
-        return extent.label;
-      });
-      expect(labelProperty === 'User-generated label').toBe(true);
+    let labelProperty = await extent.evaluate((extent) => {
+      return extent.label;
+    });
+    expect(labelProperty === 'User-generated label').toBe(true);
 
-      let labelInLayerControl = await extent.evaluate((extent) => {
-        return extent._layerControlLabel.innerText;
-      });
-      expect(labelInLayerControl === labelProperty).toBe(true);
+    let labelInLayerControl = await extent.evaluate((extent) => {
+      return extent._layerControlLabel.innerText;
+    });
+    expect(labelInLayerControl === labelProperty).toBe(true);
 
-      await extent.evaluate((extent) => {
-        extent.removeAttribute('label');
-      });
-
-      await page.waitForTimeout(500);
-      const labelChangesToDefaultAndLayerNotHidden = await extent.evaluate(
-        (extent) => {
-          return (
-            extent.label === 'Sub-layer' &&
-            !extent.hidden &&
-            extent._layerControlLabel.innerText === extent.label
-          );
-        }
-      );
-      expect(labelChangesToDefaultAndLayerNotHidden).toBe(true);
+    await extent.evaluate((extent) => {
+      extent.removeAttribute('label');
     });
 
-    test('hidden DOM order maintained when unhiding', async () => {
-      const t = await page.getByTestId('template');
-      await t.evaluate((t) => {
-        let extents = t.content.cloneNode(true);
-        let l = document.querySelector('#cbmt1');
-        l.appendChild(extents);
-      });
-      await page.waitForTimeout(500);
-      const layer = await page.getByTestId('cbmt1');
-      let unhiddenMapExtentCount = await layer.evaluate((layer) => {
-        return layer._propertiesGroupAnatomy.childElementCount;
-      });
-      // all hidden extents
-      expect(unhiddenMapExtentCount).toEqual(0);
-      await layer.evaluate((layer) => {
-        return layer.whenElemsReady();
-      });
-      await layer.evaluate((layer) => {
-        layer.querySelector('[data-testid="ext3"]').hidden = false;
-      });
-      await layer.evaluate((layer) => {
-        layer.querySelector('[data-testid="ext1"]').hidden = false;
-      });
-      await layer.evaluate((layer) => {
-        layer.querySelector('[data-testid="ext2"]').hidden = false;
-      });
-      unhiddenMapExtentCount = await layer.evaluate((layer) => {
-        return layer._propertiesGroupAnatomy.childElementCount;
-      });
-      // no hidden extents
-      expect(unhiddenMapExtentCount).toBe(3);
+    await page.waitForTimeout(500);
+    const labelChangesToDefaultAndLayerNotHidden = await extent.evaluate(
+      (extent) => {
+        return (
+          extent.label === 'Sub-layer' &&
+          !extent.hidden &&
+          extent._layerControlLabel.innerText === extent.label
+        );
+      }
+    );
+    expect(labelChangesToDefaultAndLayerNotHidden).toBe(true);
+  });
 
-      const orderOfDOMExtentsEqualsLayerControlOrder = await layer.evaluate(
-        (layer) => {
-          let extents = layer.querySelectorAll('map-extent');
-          let match = true;
-          for (let i = 0; i < extents.length; i++) {
-            if (
-              extents[i]._layerControlHTML !==
-              layer._propertiesGroupAnatomy.children[i]
-            ) {
-              match = false;
-              break;
-            }
+  test('hidden DOM order maintained when unhiding', async () => {
+    const t = await page.getByTestId('template');
+    await t.evaluate((t) => {
+      let extents = t.content.cloneNode(true);
+      let l = document.querySelector('#cbmt1');
+      l.appendChild(extents);
+    });
+    await page.waitForTimeout(500);
+    const layer = await page.getByTestId('cbmt1');
+    let unhiddenMapExtentCount = await layer.evaluate((layer) => {
+      return layer._propertiesGroupAnatomy.childElementCount;
+    });
+    // all hidden extents
+    expect(unhiddenMapExtentCount).toEqual(0);
+    await layer.evaluate((layer) => {
+      return layer.whenElemsReady();
+    });
+    await layer.evaluate((layer) => {
+      layer.querySelector('[data-testid="ext3"]').hidden = false;
+    });
+    await layer.evaluate((layer) => {
+      layer.querySelector('[data-testid="ext1"]').hidden = false;
+    });
+    await layer.evaluate((layer) => {
+      layer.querySelector('[data-testid="ext2"]').hidden = false;
+    });
+    unhiddenMapExtentCount = await layer.evaluate((layer) => {
+      return layer._propertiesGroupAnatomy.childElementCount;
+    });
+    // no hidden extents
+    expect(unhiddenMapExtentCount).toBe(3);
+
+    const orderOfDOMExtentsEqualsLayerControlOrder = await layer.evaluate(
+      (layer) => {
+        let extents = layer.querySelectorAll('map-extent');
+        let match = true;
+        for (let i = 0; i < extents.length; i++) {
+          if (
+            extents[i]._layerControlHTML !==
+            layer._propertiesGroupAnatomy.children[i]
+          ) {
+            match = false;
+            break;
           }
-          return match;
         }
-      );
-      expect(orderOfDOMExtentsEqualsLayerControlOrder).toBe(true);
-    });
+        return match;
+      }
+    );
+    expect(orderOfDOMExtentsEqualsLayerControlOrder).toBe(true);
   });
   test('Basic checked functionality and API', async () => {
     // extent ext2-1 starts life checked and hidden
@@ -153,5 +151,28 @@ test.describe('map-extent tests', () => {
     expect(checkedInLayerControl).toBe(false);
     expect(visibleOnMap).toBe(false);
     expect(checkedProperty).toBe(false);
+  });
+  test('Ensure that undefined projection throws exception', async () => {
+    let errorLogs = [];
+    page.on('pageerror', (err) => {
+      errorLogs.push(err.message);
+    });
+    const viewer = page.getByTestId('firstmap');
+    await viewer.evaluate((viewer) => {
+      const l = document.createElement('layer-');
+      l.label = 'Layer';
+      const e = document
+        .querySelector('template')
+        .content.querySelector('[data-testid=ext4]')
+        .cloneNode(true);
+      l.checked = true;
+      l.appendChild(e);
+      viewer.appendChild(l);
+    });
+    // map-extent.connectedCallback does an await map.whenProjectionDefined('foo')
+    // which has a timeout of 5 seconds
+    await page.waitForTimeout(5500);
+    expect(errorLogs.length).toBe(1);
+    expect(errorLogs[0]).toBe("Undefined projection:foo");
   });
 });

--- a/test/e2e/elements/map-extent/map-extent.test.js
+++ b/test/e2e/elements/map-extent/map-extent.test.js
@@ -3,7 +3,7 @@ import { test, expect, chromium } from '@playwright/test';
 test.describe('map-extent tests', () => {
   let page;
   let context;
-  test.beforeEach(async function () {
+  test.beforeAll(async function () {
     context = await chromium.launchPersistentContext('', { slowMo: 500 });
     page =
       context.pages().find((page) => page.url() === 'about:blank') ||
@@ -50,6 +50,10 @@ test.describe('map-extent tests', () => {
       }
     );
     expect(labelChangesToDefaultAndLayerNotHidden).toBe(true);
+    await extent.evaluate((extent) => {
+      // restore original state
+      extent.hidden = true;
+    });
   });
 
   test('hidden DOM order maintained when unhiding', async () => {
@@ -173,6 +177,6 @@ test.describe('map-extent tests', () => {
     // which has a timeout of 5 seconds
     await page.waitForTimeout(5500);
     expect(errorLogs.length).toBe(1);
-    expect(errorLogs[0]).toBe("Undefined projection:foo");
+    expect(errorLogs[0]).toBe('Undefined projection:foo');
   });
 });

--- a/test/e2e/layers/multipleExtents.test.js
+++ b/test/e2e/layers/multipleExtents.test.js
@@ -352,7 +352,7 @@ test.describe('Multiple Extents Bounds Tests', () => {
     const alabamaExtentItem = page.getByText('alabama_feature');
     await expect(alabamaExtentItem).toHaveCount(1);
     await expect(alabamaExtentItem).toHaveCSS('font-style', 'normal');
-    
+
     const alabamaMapExtent = page.locator('map-extent[label=alabama_feature]');
     await expect(alabamaMapExtent).toHaveCount(1);
     await expect(alabamaMapExtent).not.toHaveAttribute('disabled');

--- a/test/e2e/mapml-viewer/customTCRS.test.js
+++ b/test/e2e/mapml-viewer/customTCRS.test.js
@@ -17,7 +17,7 @@ test.describe('Playwright Custom TCRS Tests', () => {
   });
 
   test('Simple Custom TCRS, tiles load, mismatched layer disabled', async () => {
-    await page.waitForTimeout(100);
+    await page.waitForTimeout(500);
     const misMatchedLayerDisabled = await page.$eval(
       'body > mapml-viewer:nth-child(1)',
       (map) => map.querySelectorAll('layer-')[0].hasAttribute('disabled')


### PR DESCRIPTION
Closes #910 

- [x] Delete map projection attrChgCallbk from triggering map-change event. Allow map-extent to react to  map-projectionchange event, enable/disable according to projection match.
- [x] Change initialization logic for opacity, so that layer- and map-extent opacity value is maintained through map-projectionchange event.
- [x] Remove MapMLLayer.validProjection attribute and flawed logic.
- [x] Prettier formatting change only in multipleExtents.test.js
- [x] Remove use of validProjection by layer context menu, was wrong anyway(?)
- [x] Add waitfortimeout of 500ms in customTCRS.test.js (100ms was not enough)
- [x] Add test for simple projection change.
- [x] Add test for opacity through map-projectionchange - quite laggy, needed to waitfortimeout(1000) (at least)
- [ ] ~~Fix history after map-projectionchange~~ not possible need to rewrite history
- [x] Update map-extent connectedCallback to throw if the units="projection_name" projection_name value is not a defined projection via `mapml-viewer.defineCustomProjection`