### PR TITLE
Add contextmenu for map-extent layercontrol

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
     <mapml-viewer projection="OSMTILE" zoom="14" lat="45.406314" lon="-75.6883335" controls controlslist="geolocation">
       <layer- data-testid="osm-layer" label="OpenStreetMap" checked >
         <map-link rel="license" title="© OpenStreetMap contributors CC BY-SA" href="https://www.openstreetmap.org/copyright"></map-link>
-        <map-extent units="OSMTILE" checked="checked" hidden="hidden">
+        <map-extent units="OSMTILE" checked="checked">
           <map-input name="z" type="zoom" value="18" min="0" max="18"></map-input>
           <map-input name="x" type="location" units="tilematrix" axis="column" min="0" max="262144"></map-input>
           <map-input name="y" type="location" units="tilematrix" axis="row" min="0" max="262144"></map-input>

--- a/src/map-extent.js
+++ b/src/map-extent.js
@@ -146,7 +146,7 @@ export class MapExtent extends HTMLElement {
         case 'label':
           if (oldValue !== newValue) {
             this._layerControlHTML.querySelector(
-              '.mapml-layer-item-name'
+              '.mapml-extent-item-name'
             ).innerHTML = newValue || M.options.locale.dfExtent;
           }
           break;

--- a/src/map-extent.js
+++ b/src/map-extent.js
@@ -71,6 +71,45 @@ export class MapExtent extends HTMLElement {
       ? getExtent(this)
       : getCalculatedExtent(this);
   }
+
+  getOuterHTML() {
+    let tempElement = this.cloneNode(true);
+
+    if (this.querySelector('map-link')) {
+      let mapLinks = tempElement.querySelectorAll('map-link');
+
+      mapLinks.forEach((mapLink) => {
+        if (mapLink.hasAttribute('href')) {
+          mapLink.setAttribute(
+            'href',
+            decodeURI(
+              new URL(
+                mapLink.attributes.href.value,
+                this.baseURI ? this.baseURI : document.baseURI
+              ).href
+            )
+          );
+        } else if (mapLink.hasAttribute('tref')) {
+          mapLink.setAttribute(
+            'tref',
+            decodeURI(
+              new URL(
+                mapLink.attributes.tref.value,
+                this.baseURI ? this.baseURI : document.baseURI
+              ).href
+            )
+          );
+        }
+      });
+    }
+
+    let outerLayer = tempElement.outerHTML;
+
+    tempElement.remove();
+
+    return outerLayer;
+  }
+
   zoomTo() {
     let extent = this.extent;
     let map = this.getMapEl()._map,

--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -426,6 +426,7 @@ export class MapViewer extends HTMLElement {
       collapsed: true,
       mapEl: this
     }).addTo(this._map);
+    this._map.on('movestart', this._layerControl.collapse, this._layerControl);
 
     let scaleValue = M.options.announceScale;
 

--- a/src/mapml/control/LayerControl.js
+++ b/src/mapml/control/LayerControl.js
@@ -117,6 +117,17 @@ export var LayerControl = L.Control.Layers.extend({
 
   //overrides collapse and conditionally collapses the panel
   collapse: function (e) {
+    // if layer control is not expanded, return
+    if (!this._container.className.includes('expanded')) {
+      return;
+    }
+    // return if layer contextmenu is still open
+    if (
+      !this._map.contextMenu._extentLayerMenu.hidden ||
+      !this._map.contextMenu._layerMenu.hidden
+    ) {
+      return;
+    }
     if (
       e.target.tagName === 'SELECT' ||
       (e.relatedTarget &&

--- a/src/mapml/elementSupport/extents/createLayerControlForExtent.js
+++ b/src/mapml/elementSupport/extents/createLayerControlForExtent.js
@@ -124,7 +124,7 @@ export var createLayerControlExtentHTML = function () {
 
   var extentItemNameSpan = L.DomUtil.create(
     'span',
-    'mapml-layer-item-name',
+    'mapml-extent-item-name',
     extentLabel
   );
   input.type = 'checkbox';

--- a/src/mapml/handlers/ContextMenu.js
+++ b/src/mapml/handlers/ContextMenu.js
@@ -148,12 +148,12 @@ export var ContextMenu = L.Handler.extend({
     this._extentLayerItems = [
       {
         // 0
-        text: 'Zoom to Sub Layer' + ' (<kbd>Z</kbd>)',
+        text: M.options.locale.lmZoomToExtent + ' (<kbd>Z</kbd>)',
         callback: this._zoomToMapExtent
       },
       {
         // 1
-        text: 'Copy Sub Layer' + ' (<kbd>L</kbd>)',
+        text: M.options.locale.lmCopyExtent + ' (<kbd>L</kbd>)',
         callback: this._copyMapExtent
       }
     ];
@@ -256,7 +256,7 @@ export var ContextMenu = L.Handler.extend({
 
     this._extentLayerMenu = L.DomUtil.create(
       'div',
-      'mapml-contextmenu mapml-layer-menu',
+      'mapml-contextmenu mapml-extent-menu',
       map.getContainer()
     );
     this._extentLayerMenu.setAttribute('hidden', '');
@@ -418,7 +418,7 @@ export var ContextMenu = L.Handler.extend({
     let context =
         e instanceof KeyboardEvent ? this._map.contextMenu : this.contextMenu,
       extentElem = context._layerClicked.extent;
-    context._copyData(extentElem.outerHTML);
+    context._copyData(extentElem.getOuterHTML());
   },
 
   _goForward: function (e) {

--- a/src/mapml/options.js
+++ b/src/mapml/options.js
@@ -18,6 +18,8 @@ export var Options = {
     cmViewSource: 'View Map Source',
     lmZoomToLayer: 'Zoom To Layer',
     lmCopyLayer: 'Copy Layer',
+    lmZoomToExtent: 'Zoom To Sub-layer',
+    lmCopyExtent: 'Copy Sub-layer',
     lcOpacity: 'Opacity',
     btnAttribution: 'Map data attribution',
     btnZoomIn: 'Zoom in',

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -474,6 +474,7 @@ export class WebMap extends HTMLMapElement {
       collapsed: true,
       mapEl: this
     }).addTo(this._map);
+    this._map.on('movestart', this._layerControl.collapse, this._layerControl);
 
     let scaleValue = M.options.announceScale;
 

--- a/test/e2e/core/ArrowKeyNavContextMenu.html
+++ b/test/e2e/core/ArrowKeyNavContextMenu.html
@@ -74,6 +74,15 @@
   <body>
     <mapml-viewer projection="CBMTILE" zoom="2" lat="45" lon="-90" controls>
       <layer- label="CBMT" src="tiles/cbmt/cbmt.mapml" checked></layer->
+      <layer- label="CBMT - INLINE" >
+      <map-link rel="license" title="Testing Inc."></map-link>
+      <map-extent units="CBMTILE" checked>
+        <map-input name="zoomLevel" type="zoom" value="3" min="0" max="3"></map-input>
+        <map-input name="row" type="location" axis="row" units="tilematrix" min="14" max="21"></map-input>
+        <map-input name="col" type="location" axis="column" units="tilematrix" min="14" max="19"></map-input>
+        <map-link rel="tile" tref="/data/cbmt/{zoomLevel}/c{col}_r{row}.png"></map-link>
+      </map-extent>
+    </layer->
     </mapml-viewer>
   </body>
 </html>

--- a/test/e2e/core/ArrowKeyNavContextMenu.test.js
+++ b/test/e2e/core/ArrowKeyNavContextMenu.test.js
@@ -71,6 +71,85 @@ test.describe('Using arrow keys to navigate context menu', () => {
     expect(hide).toEqual(true);
   });
 
+  test('Testing Extent layer contextmenu', async () => {
+    await page.pause()
+    await page.waitForTimeout(500);
+    await page.click('body > mapml-viewer');
+    await page.waitForTimeout(500);
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    // opening layer control
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(500);
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    // expanding layer to reveal extents
+    await page.keyboard.press('Enter');
+    // tabbing to extent layer
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+
+    await page.keyboard.press('Shift+F10');
+
+    let activeElement = await page.evaluate(
+      () => document.activeElement.shadowRoot.activeElement.innerHTML
+    );
+    expect(activeElement).toEqual('Zoom To Sub-layer (<kbd>Z</kbd>)');
+    await page.keyboard.press('Tab');
+    activeElement = await page.evaluate(
+      () => document.activeElement.shadowRoot.activeElement.innerHTML
+    );
+    expect(activeElement).toEqual('Copy Sub-layer (<kbd>L</kbd>)');
+    await page.keyboard.press('ArrowUp');
+    activeElement = await page.evaluate(
+      () => document.activeElement.shadowRoot.activeElement.innerHTML
+    );
+    expect(activeElement).toEqual('Zoom To Sub-layer (<kbd>Z</kbd>)');
+
+    await page.keyboard.press('Escape');
+    let hide = await page.$eval(
+      'body > mapml-viewer',
+      (viewer) => viewer._map.contextMenu._extentLayerMenu.hidden
+    );
+    expect(hide).toEqual(true);
+
+    await page.keyboard.press('Shift+F10');
+
+    await page.click('body > mapml-viewer');
+    hide = await page.$eval(
+      'body > mapml-viewer',
+      (viewer) => viewer._map.contextMenu._extentLayerMenu.hidden
+    );
+    expect(hide).toEqual(true);
+
+    // Ensuring the extent is still being revealed after layercontrol was closed and reopened
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    // opening layer control
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Shift+F10');
+    activeElement = await page.evaluate(
+      () => document.activeElement.shadowRoot.activeElement.innerHTML
+    );
+    expect(activeElement).toEqual('Zoom To Sub-layer (<kbd>Z</kbd>)');
+  });
+
   test('(partial) Up and Down Arrow keys to navigate the contextmenu', async () => {
     await page.click('body > mapml-viewer', { button: 'right' });
     await page.keyboard.press('ArrowDown');

--- a/test/e2e/core/ArrowKeyNavContextMenu.test.js
+++ b/test/e2e/core/ArrowKeyNavContextMenu.test.js
@@ -16,8 +16,8 @@ test.describe('Using arrow keys to navigate context menu', () => {
 
   test('Testing layer contextmenu', async () => {
     await page.waitForTimeout(500);
-    await page.click('body > mapml-viewer');
-    await page.waitForTimeout(500);
+    await page.locator('mapml-viewer').focus();
+    await page.keyboard.press('Tab');
     await page.keyboard.press('Tab');
 
     await page.keyboard.press('Tab');
@@ -62,18 +62,17 @@ test.describe('Using arrow keys to navigate context menu', () => {
     );
     expect(activeElement).toEqual('Copy Layer (<kbd>L</kbd>)');
 
-    await page.click('body > mapml-viewer');
+    await page.locator('mapml-viewer').click();
 
-    let hide = await page.$eval(
-      'body > mapml-viewer',
-      (viewer) => viewer._map.contextMenu._layerMenu.hidden
-    );
-    expect(hide).toEqual(true);
+    let hidden = await page
+      .locator('mapml-viewer')
+      .evaluate((viewer) => viewer._map.contextMenu._layerMenu.hidden);
+    expect(hidden).toEqual(true);
   });
 
   test('Testing Extent layer contextmenu', async () => {
     await page.waitForTimeout(500);
-    await page.click('body > mapml-viewer');
+    await page.locator('mapml-viewer').click();
     await page.waitForTimeout(500);
     await page.keyboard.press('Tab');
     await page.keyboard.press('Tab');
@@ -112,20 +111,18 @@ test.describe('Using arrow keys to navigate context menu', () => {
     expect(activeElement).toEqual('Zoom To Sub-layer (<kbd>Z</kbd>)');
 
     await page.keyboard.press('Escape');
-    let hide = await page.$eval(
-      'body > mapml-viewer',
-      (viewer) => viewer._map.contextMenu._extentLayerMenu.hidden
-    );
-    expect(hide).toEqual(true);
+    let hidden = await page
+      .locator('mapml-viewer')
+      .evaluate((viewer) => viewer._map.contextMenu._extentLayerMenu.hidden);
+    expect(hidden).toEqual(true);
 
     await page.keyboard.press('Shift+F10');
 
-    await page.click('body > mapml-viewer');
-    hide = await page.$eval(
-      'body > mapml-viewer',
-      (viewer) => viewer._map.contextMenu._extentLayerMenu.hidden
-    );
-    expect(hide).toEqual(true);
+    await page.locator('mapml-viewer').click();
+    hidden = await page
+      .locator('mapml-viewer')
+      .evaluate((viewer) => viewer._map.contextMenu._extentLayerMenu.hidden);
+    expect(hidden).toEqual(true);
 
     // Ensuring the extent is still being revealed after layercontrol was closed and reopened
     await page.keyboard.press('Tab');
@@ -143,6 +140,7 @@ test.describe('Using arrow keys to navigate context menu', () => {
     await page.keyboard.press('Tab');
     await page.keyboard.press('Tab');
     await page.keyboard.press('Shift+F10');
+    await page.waitForTimeout(500);
     activeElement = await page.evaluate(
       () => document.activeElement.shadowRoot.activeElement.innerHTML
     );
@@ -150,7 +148,7 @@ test.describe('Using arrow keys to navigate context menu', () => {
   });
 
   test('(partial) Up and Down Arrow keys to navigate the contextmenu', async () => {
-    await page.click('body > mapml-viewer', { button: 'right' });
+    await page.locator('mapml-viewer').click({ button: 'right' });
     await page.keyboard.press('ArrowDown');
 
     let activeElement = await page.evaluate(
@@ -192,7 +190,7 @@ test.describe('Using arrow keys to navigate context menu', () => {
   });
 
   test('Right and Left Arrow keys to navigate the contextmenu', async () => {
-    await page.click('body > mapml-viewer');
+    await page.locator('mapml-viewer').click();
     await page.keyboard.press('Shift+F10');
     await page.keyboard.press('ArrowDown');
 
@@ -262,16 +260,15 @@ test.describe('Using arrow keys to navigate context menu', () => {
     );
     expect(activeElement).toEqual('Copy (<kbd>C</kbd>)<span></span>');
 
-    let hide = await page.$eval(
-      'body > mapml-viewer',
-      (viewer) => viewer._map.contextMenu._copySubMenu.hidden
-    );
-    expect(hide).toEqual(true);
+    let hidden = await page
+      .locator('mapml-viewer')
+      .evaluate((viewer) => viewer._map.contextMenu._copySubMenu.hidden);
+    expect(hidden).toEqual(true);
   });
 
   test('(full) Up and Down Arrow keys to navigate the contextmenu', async () => {
     await page.waitForTimeout(500);
-    await page.click('body > mapml-viewer');
+    await page.locator('mapml-viewer').click();
     await page.keyboard.press('ArrowRight');
     await page.waitForTimeout(500);
     await page.keyboard.press('ArrowRight');

--- a/test/e2e/core/ArrowKeyNavContextMenu.test.js
+++ b/test/e2e/core/ArrowKeyNavContextMenu.test.js
@@ -72,7 +72,6 @@ test.describe('Using arrow keys to navigate context menu', () => {
   });
 
   test('Testing Extent layer contextmenu', async () => {
-    await page.pause()
     await page.waitForTimeout(500);
     await page.click('body > mapml-viewer');
     await page.waitForTimeout(500);

--- a/test/e2e/core/layerContextMenu.html
+++ b/test/e2e/core/layerContextMenu.html
@@ -25,7 +25,7 @@
   <mapml-viewer style="width: 1000px;height: 500px;" projection="CBMTILE" zoom="0" lat="47" lon="-92" controls>
     <layer- label="CBMT - INLINE" checked>
       <map-link rel="license" title="Testing Inc."></map-link>
-      <map-extent units="CBMTILE" checked hidden>
+      <map-extent units="CBMTILE" checked>
         <map-input name="zoomLevel" type="zoom" value="3" min="0" max="3"></map-input>
         <map-input name="row" type="location" axis="row" units="tilematrix" min="14" max="21"></map-input>
         <map-input name="col" type="location" axis="column" units="tilematrix" min="14" max="19"></map-input>

--- a/test/e2e/core/layerContextMenu.html
+++ b/test/e2e/core/layerContextMenu.html
@@ -61,7 +61,7 @@
     <layer- src="data/query/DouglasFir" label="Natural Resources Canada - Douglas Fir (Genus Pseudotsuga) 250m resolution"></layer->
   </mapml-viewer>
   <textarea id="messageExtent" name="messageExtent" rows="10" cols="100"></textarea>
-  <textarea id="messageLayer" name="messageLayer" rows="10" cols="100"></textarea>
+  <textarea data-testid="messageLayer" id="messageLayer" name="messageLayer" rows="10" cols="100"></textarea>
 </body>
 
 </html>

--- a/test/e2e/core/layerContextMenu.test.js
+++ b/test/e2e/core/layerContextMenu.test.js
@@ -73,7 +73,7 @@ test.describe('Playwright Layer Context Menu Tests', () => {
     );
 
     expect(copyLayer).toEqual(
-      '<layer- label="CBMT - INLINE" checked="">\n      <map-link rel="license" title="Testing Inc."></map-link>\n      <map-extent units="CBMTILE" checked="" hidden="">\n        <map-input name="zoomLevel" type="zoom" value="3" min="0" max="3"></map-input>\n        <map-input name="row" type="location" axis="row" units="tilematrix" min="14" max="21"></map-input>\n        <map-input name="col" type="location" axis="column" units="tilematrix" min="14" max="19"></map-input>\n        <map-link rel="tile" tref="http://localhost:30001/data/cbmt/{zoomLevel}/c{col}_r{row}.png"></map-link>\n      </map-extent>\n    </layer->'
+      '<layer- label="CBMT - INLINE" checked="">\n      <map-link rel="license" title="Testing Inc."></map-link>\n      <map-extent units="CBMTILE" checked="">\n        <map-input name="zoomLevel" type="zoom" value="3" min="0" max="3"></map-input>\n        <map-input name="row" type="location" axis="row" units="tilematrix" min="14" max="21"></map-input>\n        <map-input name="col" type="location" axis="column" units="tilematrix" min="14" max="19"></map-input>\n        <map-link rel="tile" tref="http://localhost:30001/data/cbmt/{zoomLevel}/c{col}_r{row}.png"></map-link>\n      </map-extent>\n    </layer->'
     );
   });
 
@@ -183,5 +183,91 @@ test.describe('Playwright Layer Context Menu Tests', () => {
     expect(copyLayer).toEqual(
       '<layer- src="http://localhost:30001/data/query/DouglasFir" label="Natural Resources Canada - Douglas Fir (Genus Pseudotsuga) 250m resolution"></layer->'
     );
+  });
+
+  test('Map Extent context menu shows when extent layer is right clicked', async () => {
+    await page.hover(
+      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div'
+    );
+    await page
+      .getByRole('group', { name: 'CBMT - INLINE' })
+      .getByTitle('Layer Settings')
+      .click();
+    await page
+      .getByRole('group', { name: 'Sub-layer' })
+      .locator('label')
+      .click({
+        button: 'right'
+      });
+
+    const aHandle = await page.evaluateHandle(() =>
+      document.querySelector('mapml-viewer')
+    );
+    const nextHandle = await page.evaluateHandle(
+      (doc) => doc.shadowRoot,
+      aHandle
+    );
+    const resultHandle = await page.evaluateHandle(
+      (root) => root.querySelector('.mapml-contextmenu.mapml-extent-menu'),
+      nextHandle
+    );
+
+    const menuDisplay = await (
+      await page.evaluateHandle(
+        (elem) => window.getComputedStyle(elem).getPropertyValue('display'),
+        resultHandle
+      )
+    ).jsonValue();
+
+    expect(menuDisplay).toEqual('block');
+    await page.keyboard.press('Escape');
+  });
+
+  test('Layer context menu - copy extent layer', async () => {
+    await page
+      .getByRole('group', { name: 'Sub-layer' })
+      .locator('label')
+      .click({
+        button: 'right'
+      });
+
+    await page.keyboard.press('l');
+    await page.click('body > textarea#messageLayer');
+    await page.keyboard.press('Control+a');
+    await page.keyboard.press('Control+v');
+    const copyLayer = await page.$eval(
+      'body > textarea#messageLayer',
+      (text) => text.value
+    );
+
+    expect(copyLayer).toEqual(
+      '<map-extent units="CBMTILE" checked="">\n        <map-input name="zoomLevel" type="zoom" value="3" min="0" max="3"></map-input>\n        <map-input name="row" type="location" axis="row" units="tilematrix" min="14" max="21"></map-input>\n        <map-input name="col" type="location" axis="column" units="tilematrix" min="14" max="19"></map-input>\n        <map-link rel="tile" tref="http://localhost:30001/data/cbmt/{zoomLevel}/c{col}_r{row}.png"></map-link>\n      </map-extent>'
+    );
+  });
+
+  test('Map zooms to extent layer', async () => {
+    await page.pause();
+    await page.hover(
+      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div'
+    );
+    await page
+      .getByRole('group', { name: 'Sub-layer' })
+      .locator('label')
+      .click({
+        button: 'right'
+      });
+    await page.keyboard.press('z');
+    await page.waitForTimeout(1000);
+    const mapZoom = await page
+      .locator('mapml-viewer')
+      .evaluate((viewer) => viewer.zoom);
+    expect(mapZoom).toEqual(0);
+    const mapLocation = await page
+      .locator('mapml-viewer')
+      .evaluate((viewer) => viewer._map.getPixelBounds());
+    expect(mapLocation).toEqual({
+      max: { x: 1374, y: 1177 },
+      min: { x: 374, y: 677 }
+    });
   });
 });

--- a/test/e2e/core/layerContextMenu.test.js
+++ b/test/e2e/core/layerContextMenu.test.js
@@ -10,26 +10,20 @@ test.describe('Playwright Layer Context Menu Tests', () => {
       context.pages().find((page) => page.url() === 'about:blank') ||
       (await context.newPage());
     await page.goto('layerContextMenu.html');
+    await page.waitForTimeout(250);
   });
 
   test.afterAll(async function () {
     await context.close();
   });
 
-  test.beforeEach(async () => {
-    await page.waitForTimeout(250);
-  });
   test('Layer context menu shows when layer is clicked', async () => {
-    await page.hover(
-      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div'
-    );
-    await page.click(
-      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div \n\
-      > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > \n\
-      div:nth-child(1) > label > span',
-      { button: 'right' }
-    );
+    const layerControl = page.locator('.leaflet-control-layers');
+    await layerControl.hover();
+    const cbmtLayer = await page.getByText('CBMT - INLINE');
+    cbmtLayer.click({ button: 'right' });
 
+    await page.waitForTimeout(200);
     const aHandle = await page.evaluateHandle(() =>
       document.querySelector('mapml-viewer')
     );
@@ -54,39 +48,34 @@ test.describe('Playwright Layer Context Menu Tests', () => {
   });
 
   test('Layer context menu copy layer', async () => {
-    await page.hover(
-      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div'
-    );
-    await page.click(
-      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div \n\
-      > section > div.leaflet-control-layers-overlays > fieldset:nth-child(1) > \n\
-      div:nth-child(1) > label > span',
-      { button: 'right' }
-    );
-
+    const layerControl = page.locator('.leaflet-control-layers');
+    await layerControl.hover();
+    const cbmtLayer = await page.getByText('CBMT - INLINE');
+    await cbmtLayer.click({ button: 'right' });
     await page.keyboard.press('l');
-    await page.click('body > textarea#messageLayer');
+    const mesageLayerArea = page.getByTestId('messageLayer');
+    await mesageLayerArea.focus();
     await page.keyboard.press('Control+v');
-    const copyLayer = await page.$eval(
-      'body > textarea#messageLayer',
-      (text) => text.value
-    );
-
+    const copyLayer = await mesageLayerArea.evaluate((text) => text.value);
     expect(copyLayer).toEqual(
-      '<layer- label="CBMT - INLINE" checked="">\n      <map-link rel="license" title="Testing Inc."></map-link>\n      <map-extent units="CBMTILE" checked="">\n        <map-input name="zoomLevel" type="zoom" value="3" min="0" max="3"></map-input>\n        <map-input name="row" type="location" axis="row" units="tilematrix" min="14" max="21"></map-input>\n        <map-input name="col" type="location" axis="column" units="tilematrix" min="14" max="19"></map-input>\n        <map-link rel="tile" tref="http://localhost:30001/data/cbmt/{zoomLevel}/c{col}_r{row}.png"></map-link>\n      </map-extent>\n    </layer->'
+      `<layer- label="CBMT - INLINE" checked="">
+      <map-link rel="license" title="Testing Inc."></map-link>
+      <map-extent units="CBMTILE" checked="">
+        <map-input name="zoomLevel" type="zoom" value="3" min="0" max="3"></map-input>
+        <map-input name="row" type="location" axis="row" units="tilematrix" min="14" max="21"></map-input>
+        <map-input name="col" type="location" axis="column" units="tilematrix" min="14" max="19"></map-input>
+        <map-link rel="tile" tref="http://localhost:30001/data/cbmt/{zoomLevel}/c{col}_r{row}.png"></map-link>
+      </map-extent>
+    </layer->`
     );
   });
 
   test('Map zooms in to layer 2', async () => {
-    await page.hover(
-      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div'
-    );
-    await page.click(
-      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div \n\
-      > section > div.leaflet-control-layers-overlays > fieldset:nth-child(2) > \n\
-      div:nth-child(1) > label > span',
-      { button: 'right', force: true }
-    );
+    const layerControl = page.locator('.leaflet-control-layers');
+    await layerControl.hover();
+    const layer2 = page.getByText('Layer 2');
+    await layer2.click({ button: 'right', force: true });
+
     await page.keyboard.press('z');
     await page.waitForTimeout(1000);
     const mapZoom = await page
@@ -103,15 +92,11 @@ test.describe('Playwright Layer Context Menu Tests', () => {
   });
 
   test('Map zooms out to layer 3', async () => {
-    await page.hover(
-      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div'
-    );
-    await page.click(
-      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > \n\
-      div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(3) \n\
-      > div:nth-child(1) > label > span',
-      { button: 'right', force: true }
-    );
+    const layerControl = page.locator('.leaflet-control-layers');
+    await layerControl.hover();
+    const layer3 = page.getByText('Layer 3');
+    await layer3.click({ button: 'right', force: true });
+
     await page.keyboard.press('z');
     await page.waitForTimeout(3000);
     const mapLocation = await page.$eval('body > mapml-viewer', (text) =>
@@ -130,15 +115,11 @@ test.describe('Playwright Layer Context Menu Tests', () => {
   });
 
   test('Map zooms out to layer 4', async () => {
-    await page.hover(
-      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div'
-    );
-    await page.click(
-      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > \n\
-      div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(4) \n\
-      > div:nth-child(1) > label > span',
-      { button: 'right', force: true }
-    );
+    const layerControl = page.locator('.leaflet-control-layers');
+    await layerControl.hover();
+    const layer4 = page.getByText('Layer 4');
+    await layer4.click({ button: 'right', force: true });
+
     await page.keyboard.press('z');
     await page.waitForTimeout(3000);
     const mapLocation = await page.$eval('body > mapml-viewer', (text) =>
@@ -157,28 +138,21 @@ test.describe('Playwright Layer Context Menu Tests', () => {
 
   test('Copy layer with relative src attribute', async () => {
     await page.reload();
-    await page.hover(
-      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div'
-    );
-    await page.click(
-      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > \n\
-      div > section > div.leaflet-control-layers-overlays > fieldset:nth-child(5) \n\
-      > div:nth-child(1) > label > span',
-      { button: 'right' }
-    );
+    const layerControl = page.locator('.leaflet-control-layers');
+    await layerControl.hover();
+    const pseudotsuga = await layerControl.getByText('Genus Pseudotsuga');
+    await pseudotsuga.click({ button: 'right' });
 
     await page.keyboard.press('l');
-    await page.click('body > textarea#messageLayer');
+    const mesageLayerArea = page.getByTestId('messageLayer');
+    await mesageLayerArea.focus();
     // reload is better than deleting text, because of cross-platform issue
     // with copy-pasting text on Windows/Linux
     //    await page.keyboard.press('Control+a');
     //    await page.keyboard.press('Backspace');
     await page.keyboard.press('Control+v');
     await page.waitForTimeout(1000);
-    const copyLayer = await page.$eval(
-      'body > textarea#messageLayer',
-      (text) => text.value
-    );
+    const copyLayer = await mesageLayerArea.evaluate((text) => text.value);
 
     expect(copyLayer).toEqual(
       '<layer- src="http://localhost:30001/data/query/DouglasFir" label="Natural Resources Canada - Douglas Fir (Genus Pseudotsuga) 250m resolution"></layer->'
@@ -186,9 +160,8 @@ test.describe('Playwright Layer Context Menu Tests', () => {
   });
 
   test('Map Extent context menu shows when extent layer is right clicked', async () => {
-    await page.hover(
-      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div'
-    );
+    const layerControl = page.locator('.leaflet-control-layers');
+    await layerControl.hover();
     await page
       .getByRole('group', { name: 'CBMT - INLINE' })
       .getByTitle('Layer Settings')
@@ -232,13 +205,11 @@ test.describe('Playwright Layer Context Menu Tests', () => {
       });
 
     await page.keyboard.press('l');
-    await page.click('body > textarea#messageLayer');
+    const mesageLayerArea = page.getByTestId('messageLayer');
+    await mesageLayerArea.focus();
     await page.keyboard.press('Control+a');
     await page.keyboard.press('Control+v');
-    const copyLayer = await page.$eval(
-      'body > textarea#messageLayer',
-      (text) => text.value
-    );
+    const copyLayer = await mesageLayerArea.evaluate((text) => text.value);
 
     expect(copyLayer).toEqual(
       '<map-extent units="CBMTILE" checked="">\n        <map-input name="zoomLevel" type="zoom" value="3" min="0" max="3"></map-input>\n        <map-input name="row" type="location" axis="row" units="tilematrix" min="14" max="21"></map-input>\n        <map-input name="col" type="location" axis="column" units="tilematrix" min="14" max="19"></map-input>\n        <map-link rel="tile" tref="http://localhost:30001/data/cbmt/{zoomLevel}/c{col}_r{row}.png"></map-link>\n      </map-extent>'
@@ -246,9 +217,8 @@ test.describe('Playwright Layer Context Menu Tests', () => {
   });
 
   test('Map zooms to extent layer', async () => {
-    await page.hover(
-      'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div'
-    );
+    const layerControl = page.locator('.leaflet-control-layers');
+    await layerControl.hover();
     await page
       .getByRole('group', { name: 'Sub-layer' })
       .locator('label')

--- a/test/e2e/core/layerContextMenu.test.js
+++ b/test/e2e/core/layerContextMenu.test.js
@@ -246,7 +246,6 @@ test.describe('Playwright Layer Context Menu Tests', () => {
   });
 
   test('Map zooms to extent layer', async () => {
-    await page.pause();
     await page.hover(
       'div > div.leaflet-control-container > div.leaflet-top.leaflet-right > div'
     );

--- a/test/e2e/core/layerContextMenuKeyboard.test.js
+++ b/test/e2e/core/layerContextMenuKeyboard.test.js
@@ -35,9 +35,7 @@ test.describe('Playwright Layer Context Menu Tests', () => {
     await page.locator('[aria-label="Zoom in"]').press('Tab');
     await page.locator('[aria-label="Zoom out"]').press('Tab');
     await page.locator('[aria-label="Reload"]').press('Tab');
-    // no fullscreen button on this page
-    // features are next tab stop
-    await page.locator('a[role="button"]').nth(2).press('Tab');
+
     // layer control is next tab stop, opened by hover or Enter key
     await page.locator('a[role="button"]').nth(3).press('Enter');
     // Shift+F10 generates contextmenu event

--- a/test/e2e/core/layerContextMenuKeyboard.test.js
+++ b/test/e2e/core/layerContextMenuKeyboard.test.js
@@ -32,9 +32,10 @@ test.describe('Playwright Layer Context Menu Tests', () => {
     await expect(zoom).toBe(0);
 
     await page.locator('mapml-viewer').press('Tab');
-    await page.locator('[aria-label="Zoom in"]').press('Tab');
-    await page.locator('[aria-label="Zoom out"]').press('Tab');
-    await page.locator('[aria-label="Reload"]').press('Tab');
+    await page.getByLabel('Zoom in').press('Tab');
+    await page.getByLabel('Zoom out').press('Tab');
+    await page.getByLabel('Reload').press('Tab');
+    await page.getByRole('button', { name: 'View Fullscreen' }).press('Tab');
 
     // layer control is next tab stop, opened by hover or Enter key
     await page.locator('a[role="button"]').nth(3).press('Enter');
@@ -70,8 +71,7 @@ test.describe('Playwright Layer Context Menu Tests', () => {
     await page.locator('[aria-label="Zoom out"]').press('Tab');
 
     await page.locator('[aria-label="Reload"]').press('Tab');
-    // tab past features, focus on layer control
-    await page.locator('a[role="button"]').nth(2).press('Tab');
+    await page.getByRole('button', { name: 'View Fullscreen' }).press('Tab');
     // Press Enter on layer control
     await page.locator('a[role="button"]').nth(3).press('Enter');
     // Press Shift+F10 to bring up layer context menu on first layer
@@ -104,8 +104,7 @@ test.describe('Playwright Layer Context Menu Tests', () => {
     await page.locator('[aria-label="Zoom in"]').press('Tab');
     await page.locator('[aria-label="Zoom out"]').press('Tab');
     await page.locator('[aria-label="Reload"]').press('Tab');
-    // tab past features, focus on layer control
-    await page.locator('a[role="button"]').nth(2).press('Tab');
+    await page.getByRole('button', { name: 'View Fullscreen' }).press('Tab');
     // Press Enter on layer control
     await page.locator('a[role="button"]').nth(3).press('Enter');
     // Press Shift+F10 to bring up layer context menu on first layer
@@ -143,8 +142,7 @@ test.describe('Playwright Layer Context Menu Tests', () => {
     await page.locator('[aria-label="Zoom in"]').press('Tab');
     await page.locator('[aria-label="Zoom out"]').press('Tab');
     await page.locator('[aria-label="Reload"]').press('Tab');
-    // tab past features, focus on layer control
-    await page.locator('a[role="button"]').nth(2).press('Tab');
+    await page.getByRole('button', { name: 'View Fullscreen' }).press('Tab');
     // Press Enter on layer control
     await page.locator('a[role="button"]').nth(3).press('Enter');
     // Press Shift+F10 to bring up layer context menu on first layer

--- a/test/e2e/core/popupTabNavigation.test.js
+++ b/test/e2e/core/popupTabNavigation.test.js
@@ -29,91 +29,52 @@ test.describe('Playwright Keyboard Navigation + Query Layer Tests', () => {
 
       await page.keyboard.press('Tab'); // focus feature
       await page.keyboard.press('Enter'); // display popup with link in it
-      const h = await page.evaluateHandle(() =>
-        document.querySelector('mapml-viewer')
+      const viewer = page.locator('mapml-viewer');
+      let f = await viewer.evaluate(
+        (viewer) => viewer.shadowRoot.activeElement.className
       );
-      const nh = await page.evaluateHandle((doc) => doc.shadowRoot, h);
-      const rh = await page.evaluateHandle((root) => root.activeElement, nh);
-      const f = await (
-        await page.evaluateHandle((elem) => elem.className, rh)
-      ).jsonValue();
       expect(f).toEqual('mapml-popup-content');
 
       await page.keyboard.press('Tab'); // focus link
-      const h2 = await page.evaluateHandle(() =>
-        document.querySelector('mapml-viewer')
+      let f2 = await viewer.evaluate(
+        (viewer) => viewer.shadowRoot.activeElement.tagName
       );
-      const nh2 = await page.evaluateHandle((doc) => doc.shadowRoot, h2);
-      const rh2 = await page.evaluateHandle((root) => root.activeElement, nh2);
-      const f2 = await (
-        await page.evaluateHandle((elem) => elem.tagName, rh2)
-      ).jsonValue();
       expect(f2.toUpperCase()).toEqual('A');
 
       await page.keyboard.press('Tab'); // focus on "zoom to here" link
-      const h3 = await page.evaluateHandle(() =>
-        document.querySelector('mapml-viewer')
+      let f3 = await viewer.evaluate(
+        (viewer) => viewer.shadowRoot.activeElement.tagName
       );
-      const nh3 = await page.evaluateHandle((doc) => doc.shadowRoot, h3);
-      const rh3 = await page.evaluateHandle((root) => root.activeElement, nh3);
-      const f3 = await (
-        await page.evaluateHandle((elem) => elem.tagName, rh3)
-      ).jsonValue();
       expect(f3.toUpperCase()).toEqual('A');
 
       await page.keyboard.press('Tab'); // focus on |< affordance
-      const h4 = await page.evaluateHandle(() =>
-        document.querySelector('mapml-viewer')
+      let f4 = await viewer.evaluate(
+        (viewer) => viewer.shadowRoot.activeElement.title
       );
-      const nh4 = await page.evaluateHandle((doc) => doc.shadowRoot, h4);
-      const rh4 = await page.evaluateHandle((root) => root.activeElement, nh4);
-      const f4 = await (
-        await page.evaluateHandle((elem) => elem.title, rh4)
-      ).jsonValue();
       expect(f4).toEqual('Focus Map');
 
       await page.keyboard.press('Tab'); // focus on < affordance
-      const h5 = await page.evaluateHandle(() =>
-        document.querySelector('mapml-viewer')
+      let f5 = await viewer.evaluate(
+        (viewer) => viewer.shadowRoot.activeElement.title
       );
-      const nh5 = await page.evaluateHandle((doc) => doc.shadowRoot, h5);
-      const rh5 = await page.evaluateHandle((root) => root.activeElement, nh5);
-      const f5 = await (
-        await page.evaluateHandle((elem) => elem.title, rh5)
-      ).jsonValue();
       expect(f5).toEqual('Previous Feature');
 
       await page.keyboard.press('Tab'); // focus on > affordance
-      const h6 = await page.evaluateHandle(() =>
-        document.querySelector('mapml-viewer')
+      let f6 = await viewer.evaluate(
+        (viewer) => viewer.shadowRoot.activeElement.title
       );
-      const nh6 = await page.evaluateHandle((doc) => doc.shadowRoot, h6);
-      const rh6 = await page.evaluateHandle((root) => root.activeElement, nh6);
-      const f6 = await (
-        await page.evaluateHandle((elem) => elem.title, rh6)
-      ).jsonValue();
       expect(f6).toEqual('Next Feature');
 
       await page.keyboard.press('Tab'); // focus on >| affordance
-      const h7 = await page.evaluateHandle(() =>
-        document.querySelector('mapml-viewer')
+      let f7 = await viewer.evaluate(
+        (viewer) => viewer.shadowRoot.activeElement.title
       );
-      const nh7 = await page.evaluateHandle((doc) => doc.shadowRoot, h7);
-      const rh7 = await page.evaluateHandle((root) => root.activeElement, nh7);
-      const f7 = await (
-        await page.evaluateHandle((elem) => elem.title, rh7)
-      ).jsonValue();
       expect(f7).toEqual('Focus Controls');
 
       await page.keyboard.press('Tab'); // focus on X dismiss popup affordance
-      const h8 = await page.evaluateHandle(() =>
-        document.querySelector('mapml-viewer')
+      let f8 = await viewer.evaluate(
+        (viewer) => viewer.shadowRoot.activeElement.className
       );
-      const nh8 = await page.evaluateHandle((doc) => doc.shadowRoot, h8);
-      const rh8 = await page.evaluateHandle((root) => root.activeElement, nh8);
-      const f8 = await (
-        await page.evaluateHandle((elem) => elem.className, rh8)
-      ).jsonValue();
       expect(f8).toEqual('leaflet-popup-close-button');
     });
 

--- a/test/e2e/core/popupTabNavigation.test.js
+++ b/test/e2e/core/popupTabNavigation.test.js
@@ -23,7 +23,8 @@ test.describe('Playwright Keyboard Navigation + Query Layer Tests', () => {
       await page.evaluateHandle(() =>
         document.getElementById('query').removeAttribute('checked')
       );
-      await page.click('body');
+      const body = page.locator('body');
+      await body.click();
       await page.keyboard.press('Tab'); // focus map
 
       await page.keyboard.press('Tab'); // focus feature
@@ -301,7 +302,8 @@ test.describe('Playwright Keyboard Navigation + Query Layer Tests', () => {
 
     test('Focus Controls focuses the first <button> child in control div', async () => {
       await page.waitForTimeout(1000);
-      await page.click('body > mapml-viewer');
+      const viewer = page.locator('mapml-viewer');
+      await viewer.click();
       await page.keyboard.press('Tab');
       await page.keyboard.press('Tab');
       await page.keyboard.press('Tab');
@@ -328,7 +330,8 @@ test.describe('Playwright Keyboard Navigation + Query Layer Tests', () => {
     });
 
     test('Zoom link zooms to the zoom level = zoom attribute', async () => {
-      await page.click('body');
+      const body = page.locator('body');
+      await body.click();
       await page.keyboard.press('Tab'); // focus map
       await page.keyboard.press('Tab'); // focus feature
       await page.keyboard.press('Enter'); // display popup with link in it
@@ -344,14 +347,15 @@ test.describe('Playwright Keyboard Navigation + Query Layer Tests', () => {
     });
 
     test('Zoom link zooms to the maximum zoom level that can show the feature completely when zoom attribute does not present', async () => {
-      await page.click('body');
+      const body = page.locator('body');
+      await body.click();
       await page.keyboard.press('Tab'); // focus map
       await page.keyboard.press('Tab'); // focus feature
       await page.keyboard.press('Tab');
       await page.keyboard.press('Tab');
       await page.keyboard.press('Enter'); // zoom out
       await page.waitForTimeout(200);
-      await page.click('body');
+      await body.click();
       await page.keyboard.press('Tab'); // focus map
       await page.keyboard.press('Tab');
       await page.keyboard.press('ArrowLeft'); // focus targeted feature

--- a/test/e2e/mapml-viewer/mapml-viewerScale.test.js
+++ b/test/e2e/mapml-viewer/mapml-viewerScale.test.js
@@ -16,26 +16,29 @@ test.describe('Announce movement test', () => {
   });
 
   test('Output values are correct during zoom in', async () => {
+    // focus the map
     await page.keyboard.press('Tab');
+    // focus the zoom in control
     await page.keyboard.press('Tab');
+    // activate zoom in -> zoom = 1
     await page.keyboard.press('Enter');
+    await page.waitForTimeout(1000);
+    // activate zoom in -> zoom = 2
     await page.keyboard.press('Enter');
     await page.waitForTimeout(1000);
 
-    const movedUp = await page.$eval(
-      'body > mapml-viewer div > output:nth-child(7)',
-      (output) => output.innerHTML
-    );
-    expect(movedUp).toEqual('2.6 centimeters to 2000 kilometers');
+    // screen reader output is slow...
+    const output = page.locator('.mapml-screen-reader-output-scale');
+    const movedUp = await output.evaluate((output) => output.innerHTML);
+    expect(movedUp).toEqual('2.1 centimeters to 1000 kilometers');
 
+    // go to zoom = 3
     await page.keyboard.press('Enter');
     await page.waitForTimeout(1000);
 
-    const movedUpAgain = await page.$eval(
-      'body > mapml-viewer div > output:nth-child(7)',
-      (output) => output.innerHTML
-    );
-    expect(movedUpAgain).toEqual('2.1 centimeters to 1000 kilometers');
+    const movedUpAgain = await output.evaluate((output) => output.innerHTML);
+    // zoom = 3
+    expect(movedUpAgain).toEqual('1.7 centimeters to 500 kilometers');
   });
 
   test('Output values are correct during zoom out', async () => {
@@ -43,19 +46,16 @@ test.describe('Announce movement test', () => {
     await page.keyboard.press('Enter');
     await page.waitForTimeout(1000);
 
-    const movedUp = await page.$eval(
-      'body > mapml-viewer div > output:nth-child(7)',
-      (output) => output.innerHTML
-    );
-    expect(movedUp).toEqual('2.6 centimeters to 2000 kilometers');
+    // screen reader output is slow...
+    const output = page.locator('.mapml-screen-reader-output-scale');
+    const movedUp = await output.evaluate((output) => output.innerHTML);
+    expect(movedUp).toEqual('2.1 centimeters to 1000 kilometers');
 
     await page.keyboard.press('Enter');
     await page.waitForTimeout(1000);
 
-    const movedUpAgain = await page.$eval(
-      'body > mapml-viewer div > output:nth-child(7)',
-      (output) => output.innerHTML
-    );
-    expect(movedUpAgain).toEqual('1.8 centimeters to 2000 kilometers');
+    const movedUpAgain = await output.evaluate((output) => output.innerHTML);
+    // zoom is now = 0
+    expect(movedUpAgain).toEqual('2.6 centimeters to 2000 kilometers');
   });
 });

--- a/test/e2e/web-map/mapScale.test.js
+++ b/test/e2e/web-map/mapScale.test.js
@@ -16,46 +16,51 @@ test.describe('Announce movement test', () => {
   });
 
   test('Output values are correct during zoom in', async () => {
+    // focus the map
     await page.keyboard.press('Tab');
+    // focus the zoom in control
     await page.keyboard.press('Tab');
+    // activate zoom in -> zoom = 3
     await page.keyboard.press('Enter');
+    await page.waitForTimeout(1000);
+    // activate zoom in -> zoom = 4
     await page.keyboard.press('Enter');
     await page.waitForTimeout(1000);
 
-    const movedUp = await page.$eval(
-      'body > map div > output:nth-child(7)',
-      (output) => output.innerHTML
-    );
-    expect(movedUp).toEqual('1.7 centimeters to 500 kilometers');
+    // screen reader output is slow...
+    const output = page.locator('.mapml-screen-reader-output-scale');
+    const movedUp = await output.evaluate((output) => output.innerHTML);
+    // zoom = 4 here (different start conditions that mapml-viewer.html)
+    expect(movedUp).toEqual('1.7 centimeters to 300 kilometers');
 
+    // nothing happens here because the zoom in is disabled...
     await page.keyboard.press('Enter');
     await page.waitForTimeout(1000);
 
-    const movedUpAgain = await page.$eval(
-      'body > map div > output:nth-child(7)',
-      (output) => output.innerHTML
-    );
+    const movedUpAgain = await output.evaluate((output) => output.innerHTML);
+    // zoom = 4 still
     expect(movedUpAgain).toEqual('1.7 centimeters to 300 kilometers');
   });
 
   test('Output values are correct during zoom out', async () => {
+    await page.pause();
+    // focus the zoom out control
     await page.keyboard.press('Tab');
+    // go back to zoom = 3
     await page.keyboard.press('Enter');
     await page.waitForTimeout(1000);
 
-    const movedUp = await page.$eval(
-      'body > map div > output:nth-child(7)',
-      (output) => output.innerHTML
-    );
+    // screen reader output is slow...
+    const output = page.locator('.mapml-screen-reader-output-scale');
+    const movedUp = await output.evaluate((output) => output.innerHTML);
     expect(movedUp).toEqual('1.7 centimeters to 500 kilometers');
 
+    // go to zoom = 2
     await page.keyboard.press('Enter');
     await page.waitForTimeout(1000);
 
-    const movedUpAgain = await page.$eval(
-      'body > map div > output:nth-child(7)',
-      (output) => output.innerHTML
-    );
+    const movedUpAgain = await output.evaluate((output) => output.innerHTML);
+    // zoom is now = 2
     expect(movedUpAgain).toEqual('2 centimeters to 1000 kilometers');
   });
 });


### PR DESCRIPTION
Closes #926

- [X] Add "Zoom to Sub Layer" + "Copy Sub Layer"
- [X] Add support for keyboard navigation
- [X] Add support for Keyboard shortcut
- [x] Add localization
- [x] Add missing localization for "Sub-Layer"
- [ ] ~Re-key copy layer/extent shortcut from 'L' to 'C'?~
- [x] when layer control context menu is open DO NOT collapse layer control?
- [x] Add tests

**Future work**
- Abiltiy to paste map-extent into layers?