### PR TITLE
Allow svg element for vector tiles to overflow via css overflow: visible

### DIFF
--- a/src/mapml.css
+++ b/src/mapml.css
@@ -963,3 +963,7 @@ label.mapml-layer-item-toggle {
   padding: 0;
   list-style-type:none;
 }
+
+.mapml-tile-group > svg { 
+    overflow: visible;
+}


### PR DESCRIPTION
Closes #929