### PR TITLE
Feature outline visual issues

### DIFF
--- a/src/mapml/features/geometry.js
+++ b/src/mapml/features/geometry.js
@@ -178,6 +178,8 @@ export var Geometry = L.FeatureGroup.extend({
       ) &&
       e.type === 'keyup'
     ) {
+      this.options.group.parentNode.appendChild(this.options.group);
+      this.options.group.focus();
       this.openTooltip();
     } else if (e.keyCode === 13 || e.keyCode === 32) {
       this.closeTooltip();

--- a/src/mapml/layers/FeatureLayer.js
+++ b/src/mapml/layers/FeatureLayer.js
@@ -150,6 +150,18 @@ export var FeatureLayer = L.FeatureGroup.extend({
       // hide/display features based on the their zoom limits
       this._validateRendering();
     }
+    layerToAdd.options.group.addEventListener('mouseover', function () {
+      // Move hovered element to the end of its parent container
+      this.parentNode.appendChild(this);
+    });
+    //layerToAdd.options.group.addEventListener('mouseout', function () {
+    //  // bring g element back to it's original location
+    //  const originalPosition = Array.prototype.slice
+    //    .call(this.parentNode.children)
+    //    .indexOf(layerToAdd.options.group);
+    //  let beforeElement = this.parentNode.children[originalPosition + 1];
+    //  this.parentNode.insertBefore(this, beforeElement);
+    //});
     return this;
   },
   addRendering: function (featureToAdd) {


### PR DESCRIPTION
closes #940 
closes #919 

_Creating draft PR so I don't lose track of this._

The result of this PR is best visualized in the following experiment - https://maps4html.org/experiments/api/geojson/

**TODO** - Need to add a standalone container for storing outlines (with `pointer-events: none;`) instead of changing g element locations (which is what is currently being done) to ensure the outline of the feature being hovered or selected by keyboard is not being overlapped by any other features.