### PR TITLE
Handle null geometry in GeoJSON query responses

### DIFF
--- a/src/mapml/handlers/QueryHandler.js
+++ b/src/mapml/handlers/QueryHandler.js
@@ -188,6 +188,23 @@ export var QueryHandler = Handler.extend({
           ) {
             try {
               let json = JSON.parse(response.text);
+              // Replace null geometries with a point at the click location
+              // so geojson2mapml can process the features without error
+              let clickPoint = {
+                type: 'Point',
+                coordinates: [e.latlng.lng, e.latlng.lat]
+              };
+              if (json.type === 'FeatureCollection' && json.features) {
+                for (let f of json.features) {
+                  if (f.geometry === null || f.geometry === undefined) {
+                    f.geometry = clickPoint;
+                  }
+                }
+              } else if (json.type === 'Feature') {
+                if (json.geometry === null || json.geometry === undefined) {
+                  json.geometry = clickPoint;
+                }
+              }
               let mapmlLayer = M.geojson2mapml(json, {
                 projection: layer.options.projection
               });

--- a/test/e2e/data/geojson/geojsonNullGeometry.json
+++ b/test/e2e/data/geojson/geojsonNullGeometry.json
@@ -1,0 +1,15 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": null,
+            "properties": {
+                "Source": "PIEN",
+                "Ordre": "4",
+                "Superficie": "286350.56",
+                "Shape": "Polygon"
+            }
+        }
+    ]
+}

--- a/test/e2e/layers/queryGeoJSON.html
+++ b/test/e2e/layers/queryGeoJSON.html
@@ -43,6 +43,17 @@
         <map-input name="h" type="height"></map-input>
         <map-link rel="query" tref="data/query/geojsonProjectedNoCrs?{i}{j}{xmin}{ymin}{xmax}{ymax}{w}{h}"></map-link>
       </map-extent>
+      <map-extent label="GeoJSON null geometry" units="OSMTILE" checked>
+        <map-input name="i" type="location" units="map" axis="i"></map-input>
+        <map-input name="j" type="location" units="map" axis="j"></map-input>
+        <map-input name="xmin" type="location" units="gcrs" axis="longitude" position="top-left" min="-180" max="180"></map-input>
+        <map-input name="ymin" type="location" units="gcrs" axis="latitude" position="bottom-right" min="-90" max="90"></map-input>
+        <map-input name="xmax" type="location" units="gcrs" axis="longitude" position="bottom-right" min="-180" max="180"></map-input>
+        <map-input name="ymax" type="location" units="gcrs" axis="latitude" position="top-left" min="-90" max="90"></map-input>
+        <map-input name="w" type="width"></map-input>
+        <map-input name="h" type="height"></map-input>
+        <map-link rel="query" tref="data/query/geojsonNullGeometry?{i}{j}{xmin}{ymin}{xmax}{ymax}{w}{h}"></map-link>
+      </map-extent>
     </map-layer>
   </mapml-viewer>
 </body>

--- a/test/e2e/layers/queryGeoJSON.test.js
+++ b/test/e2e/layers/queryGeoJSON.test.js
@@ -15,28 +15,25 @@ test.describe('GeoJSON Query Response', () => {
   test.afterAll(async function () {
     await context.close();
   });
-  test('Query returns features from all three GeoJSON extents', async () => {
+  test('Query returns features from all four GeoJSON extents', async () => {
     await page.click('mapml-viewer');
     const popupContainer = page.locator('.mapml-popup-content > iframe');
     await expect(popupContainer).toBeVisible();
     const popupFeatureCount = page.locator('.mapml-feature-count');
-    await expect(popupFeatureCount).toHaveText('1/3', { useInnerText: true });
+    await expect(popupFeatureCount).toHaveText('1/4', { useInnerText: true });
   });
   test('Standard CRS:84 GeoJSON feature has cs meta set to gcrs', async () => {
     // The first feature comes from the CRS:84 extent (geojsonFeature)
     // Its meta should have cs=gcrs since coordinates are standard lon/lat
     let csMeta = await page.evaluate(() => {
-      let layer =
-        document.querySelector('mapml-viewer').layers[0]._layer;
+      let layer = document.querySelector('mapml-viewer').layers[0]._layer;
       let features = layer._mapmlFeatures;
       // find the feature from CRS:84 response (the polygon from geojsonFeature)
       let f = features.find(
         (feat) => feat.querySelector('map-polygon') !== null
       );
       if (f && f.meta) {
-        let cs = f.meta.find(
-          (m) => m.getAttribute('name') === 'cs'
-        );
+        let cs = f.meta.find((m) => m.getAttribute('name') === 'cs');
         return cs ? cs.getAttribute('content') : null;
       }
       return null;
@@ -47,8 +44,7 @@ test.describe('GeoJSON Query Response', () => {
     // The feature from geojsonProjectedWithCrs has a "crs" member
     // Its meta should have cs=pcrs
     let csMeta = await page.evaluate(() => {
-      let layer =
-        document.querySelector('mapml-viewer').layers[0]._layer;
+      let layer = document.querySelector('mapml-viewer').layers[0]._layer;
       let features = layer._mapmlFeatures;
       // find the feature with properties containing "Test Point with CRS"
       let f = features.find((feat) => {
@@ -56,9 +52,7 @@ test.describe('GeoJSON Query Response', () => {
         return props && props.innerHTML.includes('Test Point with CRS');
       });
       if (f && f.meta) {
-        let cs = f.meta.find(
-          (m) => m.getAttribute('name') === 'cs'
-        );
+        let cs = f.meta.find((m) => m.getAttribute('name') === 'cs');
         return cs ? cs.getAttribute('content') : null;
       }
       return null;
@@ -69,24 +63,43 @@ test.describe('GeoJSON Query Response', () => {
     // The feature from geojsonProjectedNoCrs has large coordinate values
     // but no "crs" member — the magnitude heuristic should detect this
     let csMeta = await page.evaluate(() => {
-      let layer =
-        document.querySelector('mapml-viewer').layers[0]._layer;
+      let layer = document.querySelector('mapml-viewer').layers[0]._layer;
       let features = layer._mapmlFeatures;
       // find the feature with properties containing "Test Point projected no CRS"
       let f = features.find((feat) => {
         let props = feat.querySelector('map-properties');
-        return (
-          props && props.innerHTML.includes('Test Point projected no CRS')
-        );
+        return props && props.innerHTML.includes('Test Point projected no CRS');
       });
       if (f && f.meta) {
-        let cs = f.meta.find(
-          (m) => m.getAttribute('name') === 'cs'
-        );
+        let cs = f.meta.find((m) => m.getAttribute('name') === 'cs');
         return cs ? cs.getAttribute('content') : null;
       }
       return null;
     });
     expect(csMeta).toBe('pcrs');
+  });
+  test('GeoJSON with null geometry is processed via geojson2mapml with synthesized click-point geometry', async () => {
+    // The feature from geojsonNullGeometry has geometry: null
+    // It should still be processed by geojson2mapml (properties as table)
+    // with a synthesized point geometry at the click location
+    let result = await page.evaluate(() => {
+      let layer = document.querySelector('mapml-viewer').layers[0]._layer;
+      let features = layer._mapmlFeatures;
+      // find the feature with properties containing "PIEN"
+      let f = features.find((feat) => {
+        let props = feat.querySelector('map-properties');
+        return props && props.innerHTML.includes('PIEN');
+      });
+      if (!f) return { found: false };
+      // check that properties are rendered as a table (geojson2mapml default)
+      let props = f.querySelector('map-properties');
+      let hasTable = props.querySelector('table') !== null;
+      // check that a point geometry was synthesized
+      let hasPoint = f.querySelector('map-geometry map-point') !== null;
+      return { found: true, hasTable: hasTable, hasPoint: hasPoint };
+    });
+    expect(result.found).toBe(true);
+    expect(result.hasTable).toBe(true);
+    expect(result.hasPoint).toBe(true);
   });
 });

--- a/test/server.js
+++ b/test/server.js
@@ -159,6 +159,17 @@ app.get('/data/query/geojsonProjectedNoCrs', (req, res, next) => {
     }
   );
 });
+app.get('/data/query/geojsonNullGeometry', (req, res, next) => {
+  res.sendFile(
+    __dirname + '/e2e/data/geojson/geojsonNullGeometry.json',
+    { headers: { 'Content-Type': 'application/geo+json' } },
+    (err) => {
+      if (err) {
+        res.status(403).send('Error.');
+      }
+    }
+  );
+});
 app.get('/data/query/geojsonFeature.geojson', (req, res, next) => {
   res.sendFile(
     __dirname + '/e2e/data/geojson/geojsonFeature.geojson',


### PR DESCRIPTION
Replace null/undefined geometries in GeoJSON query responses with a synthesized point at the click location before passing to geojson2mapml. This prevents geojson2mapml from crashing on null geometry and ensures feature properties are properly rendered as an HTML table (the default geojson2mapml behavior) rather than falling through to the raw HTML fallback which dumps the entire JSON response as text.

Adds test for null geometry scenario and updates existing test to account for the new fourth query extent (1/3 → 1/4).