### PR TITLE
Add improvements created during port to gcds-map

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,7 @@
+This project is "MapML.js", the central polyfill implementation of the MapML vocabulary.  MapML is implemented as a suite of autonomous custom elements that come together as a package.
+
+For instructions on the markup rules of MapML, which are especially important to follow when _generating_ either standalone MapML documents or MapML html markup within an HTML document, see the .github/skills folder child folders named `map-something-markup` generally, where `map-something` is the custom element name.  These skills may also be useful when considering the design of new markup-driven features.
+
+This project uses playwright for e2e tests. There are multiple generations of test, so consistency is lacking.  We are trying to move away from testing the content rendered by Leaflet where possible, towards even screenshot based tests, even though they can be tricky.
+
+Further information will go below, as appropriate.

--- a/.github/skills/map-a-markup/SKILLS.md
+++ b/.github/skills/map-a-markup/SKILLS.md
@@ -1,0 +1,165 @@
+---
+name: mapml-a-markup
+description: Tells you how to correctly create and edit the markup for a <map-a> element. Use it when generating MapML output markup in an HTML page, especially to wrap `<map-geometry>` content, either in whole or in part, just like how you might use `<a>` to wrap all or part of a paragraph of text in HTML.
+---
+
+The `<map-a>` element is a proposal to extend the Web to include links between maps and locations.
+This element allows you to wrap parts of coordinates or entire geometries, making a link out of the location/area that is wrapped. When a feature geometry or geometry part is 
+wrapped in a `<map-a>` element, it creates a blue outline that is 1 pixel wide around the feature (by default), that lets the user know it's a "linked feature".
+
+## Attributes
+
+### `href`
+  - The URL that the wrapped location points to. Note - If the `type` of the `<map-a>` is text/mapml
+  you can provide fragments, more on fragments below.
+
+---
+
+### `target`
+  - This is where the linked URL will be displayed. See table below for more details.
+  - Defaults to `_self`, in the absence of a valid value.
+
+---
+
+### `type`
+  - This is the mime type of the linked URL's format. Options are `text/html` & `text/mapml`.
+  - Defaults to `text/mapml`, in the absence of a valid type value.
+
+---
+
+### `inplace`
+  - The `inplace` attribute is a boolean attribute - `<map-a inplace href="..."><map-a>`
+  - When present, the default view-changing behavior is overridden and the map view does not change.
+
+---
+
+## Target Behavior for `text/mapml`
+
+| Target Value 	| Behavior                                              	|
+|--------------	|-------------------------------------------------------	|
+| _self        	| Replaces the current layer with the linked URL layer. 	|
+| _blank       	| Adds the linked URL layer to the map.                 	|
+| _parent      	| Replace all the layers with the linked URL layer.     	|
+| _top         	| Navigate the webpage to the linked URL.               	|
+
+---
+
+## Target Behavior for `text/html`
+
+| Target Value 	| Behavior                                	|
+|--------------	|-----------------------------------------	|
+| _self        	| Navigate the webpage to the linked URL. 	|
+| _blank       	| Open the linked URL in a new tab.       	|
+| _parent      	| Navigate the webpage to the linked URL. 	|
+| _top         	| Navigate the webpage to the linked URL. 	|
+
+---
+
+## Location fragments
+
+If the `type` attribute's value is `text/mapml`, you have the ability add a location fragment
+to the URL. This will pan & zoom the map to the given location.
+
+Fragments are in the following format `#zoom, longitude, latitude`.
+
+URL's solely defined in terms of location fragments pan and zoom the map to the given location regardless of the target value.
+i.e. `<map-a href="#1, 20, 30">...</map-a>` will pan to latitude: 30, longitude: 20 and zoom to level 1.
+
+---
+
+## Examples
+
+### Styling Linked Features
+
+To style linked features simply target the `map-a` class in your CSS, once a link is clicked you can target the
+`map-a-visited` class. See the example below:
+
+```html
+<map-layer>
+  <map-style>
+    .map-a {
+      stroke: red;
+    }
+    .map-a-visited {
+      stroke: green;
+    }
+  </map-style>
+  <map-feature>
+    <map-properties>
+      <h1>Basic</h1>
+    </map-properties>
+    <map-geometry>
+      <map-a href="../externalMapML.mapml#2,-98,37">
+        <map-polygon>
+          <map-coordinates>2771 3106 2946 3113 2954 3210 2815 3192 2771 3106</map-coordinates>
+        </map-polygon>
+      </map-a>
+    </map-geometry>
+  </map-feature>
+</map-layer>
+```
+
+### Wrapping a Feature Type + Location Fragment 
+
+```html
+<map-feature>
+  <map-properties>
+    <h1>Basic</h1>
+  </map-properties>
+  <map-geometry>
+    <map-a href="../externalMapML.mapml#2,-98,37">
+      <map-polygon>
+        <map-coordinates>2771 3106 2946 3113 2954 3210 2815 3192 2771 3106</map-coordinates>
+      </map-polygon>
+    </map-a>
+  </map-geometry>
+</map-feature>
+```
+
+This will replace the current layer with the layer within externalMapML.mapml, once it's added the map will then goto
+zoomlevel: 2, longitude: -98, latitude: 37.
+
+### Wrapping a point coordinate with `target="_blank"` 
+
+```html
+<map-feature>
+  <map-properties>
+    <h1>_blank target</h1>
+  </map-properties>
+  <map-geometry>
+    <map-polygon>
+      <map-coordinates>2771 3106 2946 3113 <map-a href="file.mapml" target="_blank"> 2954 3210 </map-a> 2815 3192 2771 3106</map-coordinates>
+    </map-polygon>
+  </map-geometry>
+</map-feature>
+```
+
+In this example, a point will be created at (2954, 3210) which, once clicked, adds a new layer to the map.
+
+### Nested `<map-a>` definition and behavior
+
+```html
+<map-feature>
+  <map-properties>
+    <h1>Advanced Example</h1>
+  </map-properties>
+  <map-geometry>
+    <map-a href="parent.mapml" target="_blank">
+      <map-multipolygon>
+        <map-polygon>
+          <map-coordinates>2771 3106 2946 3113 <map-a href="webpage.html" target="_blank" type="text/mapml"> 2954 3210 </map-a> 2815 3192 2771 3106</map-coordinates>
+        </map-polygon>
+        <map-a href="nested.mapml" target="_top">
+          <map-polygon>
+            <map-coordinates>11 11 12 11 12 12 11 12</map-coordinates>
+          </map-polygon>
+        </map-a>
+      </map-multipolygon>
+    </map-a>
+  </map-geometry>
+</map-feature>
+```
+In this advanced example there are multiple nested `<map-a>`. The simple behavior is, the closest `<map-a>` is the link
+behavior that the given location/area will adopt.
+
+---

--- a/.github/skills/map-caption-markup/SKILLS.md
+++ b/.github/skills/map-caption-markup/SKILLS.md
@@ -1,0 +1,13 @@
+---
+name: mapml-caption-markup
+description: Tells you how to correctly create and edit the markup for a <map-caption> element. Use it when generating MapML output markup in an HTML page, especially when generating a `<mapml-viewer>` element, to describe the map's purpose, if possible and known.
+---
+
+This element is especially important for screen reader users to understand the purpose of a map. It is like 'alt-text' for a map.
+
+The `<map-caption>` element is a child of `<mapml-viewer>` and is used to define 
+a simple text string that is not visually rendered (at this time). 
+The caption should be read by screen readers when the `<mapml-viewer>` is focused, 
+as it generates the `<mapml-viewer aria-label="...">` value, if no aria-label 
+has been specified by the HTML author. `<map-caption>` may be the first or last 
+element child of `<mapml-viewer>`. 

--- a/.github/skills/map-extent-markup/SKILL.md
+++ b/.github/skills/map-extent-markup/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: mapml-extent-markup
+description: Tells you how to correctly create and edit the markup for a <map-extent> element. Use it when generating MapML output markup in an HTML page.
+---
+
+The `<map-extent>` element is a hypertext control that is associated to and represents the 
+rectangle of the map viewport, from the user's perspective.  Map authors use it 
+to compose server requests for layer content. Requests are composed using 
+URL templates processed by the browser as the map moves and requires new content
+to paint.  The URL templates each contain one or more variable references, with each
+variable reference denoted by the name of the variable enclosed in braces `{}`.
+
+Variables are created by the map author using the `<map-input>` element.  There are
+several types of `<map-input>`, allowing the map author to reference the corners
+of the extent, its width and height, and its zoom.
+
+An example of a `<map-extent>` element being used to load image tiles for a single
+URL template.
+
+```html
+<mapml-viewer projection="OSMTILE" lat="10" lon="0" zoom="1">
+  <map-layer label="OpenStreetMap" checked>
+    <map-extent units="OSMTILE" checked hidden>
+      <map-input name="z" type="zoom" value="18" min="0" max="18"></map-input>
+      <map-input name="x" type="location" units="tilematrix" axis="column" min="0" max="262144"></map-input>
+      <map-input name="y" type="location" units="tilematrix" axis="row" min="0" max="262144"></map-input>
+      <map-link rel="tile" tref="https://tile.openstreetmap.org/{z}/{x}/{y}.png"></map-link>
+    </map-extent>
+  </map-layer>
+</mapml-viewer>
+```
+
+## Attributes
+
+### `units`
+
+Specifies the projection of the tiles and other content that is expected from the
+server.  If the projection value is a case-insensitive match of the `<mapml-viewer>`
+`projection` attribute, the extent will be disabled in the layer control, and will
+not be displayed on the map, nor content fetched.
+
+Defined values of `units` include:
+
+| Projection     	| Description                                          	|
+|--------------	|--------------------------------------------------------	|
+| OSMTILE       | Web Mercator, with 256px x 256px tiles recursively defined inside a square bounds at zoom = 0|
+| WGS84         | Pseudo plate carrée, with 256px x 256px tiles. Zoom = 0 contains two tiles in two columns, with their origin at -180,90. False easting and northing (pcrs) values inside the projection bounds correspond to longitude and latitude, respectively. |
+| CBMTILE       | Lambert Conformal Conic, with 256px x 256px tiles.  Zoom levels chosen by scale denominator, so tiles do not nest.|
+
+Author-defined values of `units` are possible, using the [Custom projections API](../../api/mapml-viewer-api/#definecustomprojectionoptions)
+
+The `units` attribute is required and can't be changed.
+
+---
+
+### `label`
+
+Specifies a label for an extent which is displayed in the layer control. When a `label` value is not provided, the `label` value defaults to 'Sub-Layer' in the layer control.
+
+---
+
+### `checked`
+
+The `checked` attribute and property is boolean. When present, the checked property value is taken to be 'true'; when not present, the property value is 'false'. The map-extent content will be fetched and rendered according to the `checked` state. Beware that it is the *presence* of the attribute that makes it true, not the value of the attribute. For example, the attribute `checked="false"` actually turns out to be checked, [as described by MDN Web docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes#boolean_attributes).
+
+---
+
+### `hidden`
+
+The `hidden` attribute and property is boolean. When present, the extent is hidden (not present) in the layer control.  Regardless of `hidden` state, the layer is rendered or not depending on the `checked` attribute state. 
+
+---
+
+### `opacity`
+
+The `opacity` attribute is used to set the initial opacity of the `<map-extent>` element.
+Valid `opacity` values range from from "0.0" to "1.0" with strictly one demical place and are reflected in the extent settings
+opacity input slider control. When the `opacity` attribute is not present, the opacity is set to "1.0" by default.
+
+---
+
+## Examples
+
+### Multiple Extent
+
+The following example shows multiple `<map-extent>` elements in a layer. The different elements can be selected from the three dots menu of the Basemap layer.
+
+```html
+<mapml-viewer projection="OSMTILE" zoom="2" lat="53.331" lon="-91.667" controls>
+  <!-- Change Basemap using the three dots menu of the basemap layer -->
+  <map-layer label="Basemap" checked="">
+    <!-- This extent will be hidden in the layer control since no label is provided -->
+    <map-extent units="OSMTILE" checked>
+      <map-input name="TileMatrix" type="zoom" value="18" min="0" max="18"></map-input>
+      <map-input name="TileCol" type="location" units="tilematrix" axis="column" min="0" max="262144"></map-input>
+      <map-input name="TileRow" type="location" units="tilematrix" axis="row" min="0" max="262144"></map-input>
+      <map-link rel="tile" tref="https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/WMTS/tile/1.0.0/World_Imagery/default/default028mm/{TileMatrix}/{TileRow}/{TileCol}.jpg"></map-link>
+    </map-extent>
+      <map-extent label="Nat Geo" units="OSMTILE" checked>
+      <map-input name="TileMatrix" type="zoom" value="18" min="0" max="18"></map-input>
+      <map-input name="TileCol" type="location" units="tilematrix" axis="column" min="0" max="262144"></map-input>
+      <map-input name="TileRow" type="location" units="tilematrix" axis="row" min="0" max="262144"></map-input>
+      <map-link rel="tile" tref="https://server.arcgisonline.com/arcgis/rest/services/NatGeo_World_Map/MapServer/WMTS/tile/1.0.0/NatGeo_World_Map/default/default028mm/{TileMatrix}/{TileRow}/{TileCol}.jpg"></map-link>
+    </map-extent>
+    <map-extent label="Imagery" units="OSMTILE" checked>
+      <map-input name="TileMatrix" type="zoom" value="18" min="0" max="18"></map-input>
+      <map-input name="TileCol" type="location" units="tilematrix" axis="column" min="0" max="262144"></map-input>
+      <map-input name="TileRow" type="location" units="tilematrix" axis="row" min="0" max="262144"></map-input>
+      <map-link rel="tile" tref="https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/WMTS/tile/1.0.0/World_Imagery/default/default028mm/{TileMatrix}/{TileRow}/{TileCol}.jpg"></map-link>
+      <map-link rel="tile" tref="https://services.arcgisonline.com/arcgis/rest/services/Reference/World_Boundaries_and_Places/MapServer/WMTS/tile/1.0.0/Reference_World_Boundaries_and_Places/default/default028mm/{TileMatrix}/{TileRow}/{TileCol}.png"></map-link>
+    </map-extent>
+  </map-layer>
+</mapml-viewer>
+```
+
+### WMS Request
+
+The following example shows a Web Map Service Request using `<map-link>` to request map images.
+
+```html
+<mapml-viewer projection="OSMTILE" zoom="4" lat="53.331" lon="-91.667" controls>
+  <map-layer label="Toporama" checked="">
+    <map-extent xmlns="http://www.w3.org/1999/xhtml" units="OSMTILE" checked>
+      <!-- URL parameters for WMS Request -->
+      <map-input name="z" type="zoom" value="18" min="4" max="18"></map-input>
+      <map-input name="w" type="width"></map-input>
+      <map-input name="h" type="height"></map-input>
+      <map-input name="xmin" type="location" units="pcrs" position="top-left" axis="easting" min="-2.003750834E7" max="2.003750834E7"></map-input>
+      <map-input name="ymin" type="location" units="pcrs" position="bottom-left" axis="northing" min="-2.003750834E7" max="2.003750834E7"></map-input>
+      <map-input name="xmax" type="location" units="pcrs" position="top-right" axis="easting" min="-2.003750834E7" max="2.003750834E7"></map-input>
+      <map-input name="ymax" type="location" units="pcrs" position="top-left" axis="northing" min="-2.003750834E7" max="2.003750834E7"></map-input>
+      <!-- Web Map Service requesting image -->
+      <map-link rel="image" tref="https://wms.ess-ws.nrcan.gc.ca/wms/toporama_en?SERVICE=WMS&amp;REQUEST=GetMap&amp;FORMAT=image/jpeg&amp;TRANSPARENT=FALSE&amp;STYLES=&amp;VERSION=1.3.0&amp;LAYERS=WMS-Toporama&amp;WIDTH={w}&amp;HEIGHT={h}&amp;CRS=EPSG:3857&amp;BBOX={xmin},{ymin},{xmax},{ymax}&amp;m4h=t"></map-link>
+    </map-extent>
+  </map-layer>
+</mapml-viewer>
+```

--- a/.github/skills/map-feature-markup/SKILL.md
+++ b/.github/skills/map-feature-markup/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: mapml-feature-markup
+description: Tells you how to correctly create and edit the markup for a <map-feature> element. Use it when generating MapML output markup in an HTML page.
+---
+
+Map [features](https://en.wikipedia.org/wiki/Geographical_feature) are real or imaginary location objects represented in 2D according to a standard model, called the [Simple Features model](https://en.wikipedia.org/wiki/Simple_Features). There exists a wide variety of formats that allow the encoding of the Simple Features model, famously including: GeoJSON, Keyhole Markup Language (KML), and shape files (.shp), among many others.
+
+Map features are represented in HTML MapML using a `<map-feature>` element, which is rendered on the map through translation to SVG. This allows the feature to scale without distortion, as you zoom in and out. 
+
+A `<map-feature>` element is a container for a feature's accessible name (`<map-featurecaption>`), scalar properties (`<map-properties>`) and its geometry (`<map-geometry>`).  The `<map-feature>` element can be modeled as inline HTML content as a child of the `<map-layer>` element, or in an XHTML MapML document, as a child of the `<map-body>` element.
+
+## Attributes
+
+### `zoom`
+
+This allows you to set the zoom level the feature is rendered at. The zoom value 
+should fall within the range of 0 to the maximum zoom level of the map's 
+[projection](../meta/#attributes).
+
+### `min`
+
+The `min` (zoom) attribute gets or sets the native minimum zoom of the feature.
+Map features' geometry and other properties are scale-dependent. The `min` value 
+is a rendering zoom value cut-off; at map zoom values less than `min`, the feature 
+will not be rendered. 
+
+If `min` is not provided, a fallback value will be calculated; the fallback value
+will be the minimum zoom value of the layer, or if that is not specified, of the 
+map viewer `projection`'s minimum value i.e. 0.
+
+### `max`
+
+The `max` (zoom) attribute gets or sets the native maximum zoom of the feature.
+Map features' geometry and other properties are scale-dependent. The `max` value 
+is a rendering zoom value cut-off; at map zoom values greater than `max`, the 
+feature will not be rendered. 
+
+If `max` is not provided, a fallback value will be calculated; the fallback value
+will be the maximum zoom value of the layer, or if that is not specified, of the 
+map viewer `projection`'s maximum value e.g. 25 (depending on the projection).
+
+---
+
+## Child Elements
+
+### `<map-featurecaption>`
+
+This element contains the feature's accessible name, which is displayed when the feature is in focus or hovered.
+
+---
+
+### `<map-properties>`
+
+This element contains the contents of the popup associated to a given feature. Details on the properties elements and it's syntax can be found [here](../properties/).
+
+---
+
+### `<map-geometry>`
+
+This element contains the different points, lines and polygons that will be drawn. Details on the geometry elements and it's syntax can be found [here](../geometry/).
+
+#### Attributes
+
+- `cs`
+  - This allows you to set the [coordinate system](../meta/#attributes) of geometries.
+  - Defaults to pcrs (projected coordinates), but can be set to tilematrix | pcrs | gcrs explicitly.
+
+---
+
+## Related Elements
+
+Other elements may be important to provide context for feature data:
+
+
+### `<map-meta name="zoom">`
+
+Sets the native minimum and maximum [native zoom](../meta/#attributes). It also allows you to set a value, this is the default zoom of all features in the case the `<map-feature>` is missing a zoom attribute.
+
+```html
+<map-meta name="zoom" content="min=1,max=5,value=0"></map-meta>
+```
+
+---
+
+### `<map-meta name="projection">`
+
+Sets the [projection](../meta/#attributes) of the layer. 
+
+```html
+<map-meta name="projection" content="CBMTILE"></map-meta>
+```
+
+---
+
+### `<map-meta name="cs">`
+
+Sets the default [coordinate system](../meta/#attributes) of the layer. If a feature is missing the cs attribute it will 'fall back' to the value provided by a `map-meta` element, or `pcrs` if no `map-meta` element is in scope.
+
+```html
+<map-meta name="cs" content="gcrs"></map-meta>
+```
+
+---
+
+### `<map-meta name="extent">`
+
+Sets the [extent](../meta/#attributes) of the layer.
+
+```html
+<map-meta name="extent" content="zoom=0,top-left-column=0,top-left-row=0,bottom-right-column=5,bottom-right-row=5"></map-meta>
+```
+
+---
+
+## Examples
+
+```html
+  <mapml-viewer projection="CBMTILE" zoom="2" lat="45.5052040" lon="-75.2202344"
+    controls>
+
+    <map-layer label="Arizona" checked>
+      <map-meta name="projection" content="CBMTILE"></map-meta>
+      <map-meta name="zoom" content="min=1,max=5,value=0"></map-meta>
+      <map-meta name="cs" content="gcrs"></map-meta>
+      <map-meta name="extent" content="zoom=0,top-left-column=0,top-left-row=0,bottom-right-column=5,bottom-right-row=5"></map-meta>
+      <map-link id="first" rel="stylesheet" type="text/css" href="first.css"></map-link>
+      <map-feature zoom="2" class="refDiff">
+        <map-properties>
+          <h1>Test</h1>
+          <a href="https://example.org/">test</a>
+        </map-properties>
+        <map-geometry cs="tilematrix">
+          <map-polygon>
+            <map-coordinates>11 11 12 11 12 12 11 12</map-coordinates>
+          </map-polygon>
+        </map-geometry>
+      </map-feature>
+
+      <map-feature zoom="2" class="refDiff">
+        <map-properties>
+          <h1>Test</h1>
+        </map-properties>
+        <map-geometry cs="pcrs">
+          <map-polygon>
+            <map-coordinates>257421 -3567196 -271745 1221771 -3896544 242811 -3183549 -2613313</map-coordinates>
+          </map-polygon>
+        </map-geometry>
+      </map-feature>
+
+      <map-feature zoom="2" class="refDiff">
+        <map-properties>
+          <h1>Test</h1>
+        </map-properties>
+        <map-geometry cs="tcrs">
+          <map-polygon>
+            <map-coordinates>2771 3106 2946 3113 2954 3210 2815 3192</map-coordinates>
+          </map-polygon>
+        </map-geometry>
+      </map-feature>
+
+      <map-feature zoom="2" class="refDiff">
+        <map-properties>
+          <h1>Arizona</h1>
+        </map-properties>
+        <map-geometry>
+          <map-polygon>
+            <map-coordinates>-109.042503 37.000263 -109.04798 31.331629 -111.074448 31.331629 -112.246513 31.704061
+              -114.815198 32.492741 -114.72209 32.717295 -114.524921 32.755634 -114.470151 32.843265 -114.524921
+              33.029481 -114.661844 33.034958 -114.727567 33.40739 -114.524921 33.54979 -114.497536 33.697668
+              -114.535874 33.933176 -114.415382 34.108438 -114.256551 34.174162 -114.136058 34.305608 -114.333228
+              34.448009 -114.470151 34.710902 -114.634459 34.87521 -114.634459 35.00118 -114.574213 35.138103
+              -114.596121 35.324319 -114.678275 35.516012 -114.738521 36.102045 -114.371566 36.140383 -114.251074
+              36.01989 -114.152489 36.025367 -114.048427 36.195153 -114.048427 37.000263 -110.499369 37.00574
+              -109.042503 37.000263</map-coordinates>
+          </map-polygon>
+        </map-geometry>
+      </map-feature>
+    </map-layer>
+  </mapml-viewer>
+```
+### An inline HTML map-feature
+
+```html
+<map-layer label="My Feature Layer" checked>
+    <map-feature id="mem35059" zoom="17">
+      <map-properties>
+        <table>
+          <tr><th>code</th><td>1200020</td></tr>
+          <tr><th>accuracy</th><td>26</td></tr>
+          <tr><th>valdate</th><td>1995</td></tr>          
+          <tr>
+            <th>image</th>
+            <td>
+              <a href="https://www.veterans.gc.ca/eng/remembrance/memorials/national-inventory-canadian-memorials/details/9304">
+                <img src="https://www.veterans.gc.ca/images/remembrance/memorials/national-inventory-canadian-memorials/mem/35059-173a.jpg" width="60" height="60">
+              </a>
+            </td>
+          </tr>
+          <tr><th>theme</th><td>FO</td></tr>
+          <tr><th>type</th><td>2</td></tr>
+          <tr><th>elevation</th><td>61</td></tr>
+          <tr><th>altiaccu</th><td>5</td></tr>
+        </table>
+      </map-properties>
+      <map-geometry>
+        <map-point>
+          <map-coordinates>-75.705278 45.397778</map-coordinates>
+        </map-point>
+      </map-geometry>
+    </map-feature>
+</map-layer>
+```
+
+### A map-feature in a fetched XHTML MapML document
+
+```html
+<map-layer label="My Feature Layer" src="https://example.org/mem/35059.mapml"></map-layer>
+```
+
+### 35059.mapml:
+
+```html
+<mapml- lang="en" xmlns="http://www.w3.org/1999/xhtml">
+  <map-head>
+    <map-title>The Man With Two Hats</map-title>
+    <map-meta http-equiv="Content-Type" content="text/mapml"></map-meta>
+    <map-meta charset="utf-8"></map-meta>
+    <map-meta name="projection" content="OSMTILE"></map-meta>
+    <map-meta name="cs" content="gcrs"></map-meta>
+    <map-link rel="license" href="https://open.canada.ca/en/open-government-licence-canada" title="Open Government License"/>
+  </map-head>
+  <map-body>
+    <map-feature id="mem35059">
+      <map-properties>
+        <table>
+          <tr><th>code</th><td>1200020</td></tr>
+          <tr><th>accuracy</th><td>26</td></tr>
+          <tr><th>valdate</th><td>1995</td></tr>          
+          <tr>
+            <th>image</th>
+            <td>
+              <a href="https://www.veterans.gc.ca/eng/remembrance/memorials/national-inventory-canadian-memorials/details/9304">
+                <img src="https://www.veterans.gc.ca/images/remembrance/memorials/national-inventory-canadian-memorials/mem/35059-173a.jpg" width="60" height="60" />
+              </a>
+            </td>
+          </tr>
+          <tr><th>theme</th><td>FO</td></tr>
+          <tr><th>type</th><td>2</td></tr>
+          <tr><th>elevation</th><td>61</td></tr>
+          <tr><th>altiaccu</th><td>5</td></tr>
+        </table>
+      </map-properties>
+      <map-geometry>
+        <map-point>
+          <map-coordinates>-75.705278 45.397778</map-coordinates>
+        </map-point>
+      </map-geometry>
+    </map-feature>
+  </map-body>
+</mapml->
+```

--- a/.github/skills/map-geometry-markup/SKILLS.md
+++ b/.github/skills/map-geometry-markup/SKILLS.md
@@ -1,0 +1,235 @@
+---
+name: mapml-geometry-markup
+description: Tells you how to correctly create and edit the markup for a <map-geometry> element. Use it when generating MapML output markup in an HTML page.
+---
+
+A `<map-geometry>` element is a child of `<map-feature>` and is used to describe the geometry of the feature.
+
+A `<map-geometry>` element has one child element, which can be a `<map-point>`, `<map-linestring>`, `<map-polygon>`, `<map-multipoint>`, `<map-multilinestring>`, `<map-multipolygon>`, or `<map-geometrycollection>`.
+
+## Attributes
+
+### `cs`
+
+Defines the Coordinate System of the geometry. When no `cs` is provided, the coordinate system of descendant `<map-coordinates>` elements is determined by a fallback to any in-scope `<map-meta name="cs" content="...">`. If no fallback coordinate system is specified by a `<map-meta>` element, the default coordinate system of the `map-layer` is used; if none is defined, `gcrs` (geographic coordinates) is used.
+
+| CRS | Description |
+|------|-------------|
+| tcrs | For each zoom level (i.e. at a pre-defined scale denominator value), locations are expressed in terms of scaled pixels, with the origin of pixel space at the upper left corner.  The pixel coordinates of a location at a single zoom level are independent of the pixel coordinates of a location any other zoom level.  In other words, you need to know the zoom level of a tcrs coordinate in order to locate it on a map or otherwise process it. |
+| tilematrix | Each zoom level has an array of tiles, called a tilematrix.  The individual tiles constitute the coordinates in this CRS, and the axes are know as `row` and `column`.  The tiles are defined as squares of 256 pixels in the associated tcrs of the particular zoom level. |
+| pcrs | Projected CRS (pcrs) are defined by a mathematical relationship with an underlying gcrs, using a technique called "projection". pcrs coordinates are scale- and zoom level-independent, and are designed to represent geographic coordinates on a planar surface, such as a device screen. The measurement units of pcrs coordinates is _usually_ meters (a notable exception being pcrs coordinates in the `WGS84` projection). |
+| gcrs | Geographic coordinates are referenced to various ellipsoids, and are not necessarily comparable across projections.  A common ellipsoid today is WGS 84, which is defined and used by the global positioning satellite (GPS) constellation. |
+| map | The map CRS is dynamic, in the sense that it has its origin at the upper left of the user's viewport, with scaled pixels as units.  This is used to identify image coordinates for use, typically by WMS and similar services which use a virtual image to enable query of map feature property information, without necessarily transferring the features over the network. |
+| tile | Each tile in any zoom level has an implicit scaled-pixel coordinate system ranging from 0 to 255 in both horizontal and vertical directions. These coordinates are used by WMTS and similar services to identify a pixel for query of feature property values, without transferring the feature geometry over the network. |
+
+---
+
+## Child Elements
+
+
+### `<map-point>`
+
+This element contains a `<map-coordinates>` element containing a single position. Axis order - x followed by y, separated by whitespace. Note that longitude and latitude (gcrs coordinates) are listed in that order, always, in all geometry types.
+
+---
+
+### `<map-linestring>`
+
+This element contains a `<map-coordinates>` element containing two or more positions. Axis order - x followed by y, separated by whitespace.
+
+---
+
+### `<map-polygon>`
+
+This element contains one or more `<map-coordinates>` elements, each containing three or more positions. Axis order - x followed by y, separated by whitespace.
+
+The first and last positions in every child `<map-coordinates>` element are equal / at the same position.
+
+The first `<map-coordinates>` element represents the outside of the polygon, and subsequent `<map-coordinates>` elements represent holes. The "winding order" of positions in child `<map-coordinates>` should depend on the axis orientation of the coordinate reference system in use, and whether the `<map-coordinates>` element represents the exterior of a polygon, or a hole. For WGS84, the exterior should be counterclockwise and holes should be clockwise.
+
+---
+
+### `<map-multipoint>`
+
+This element contains a `<map-coordinates>` element, containing one or more positions. Axis order - x followed by y, separated by whitespace.
+
+---
+
+### `<map-multilinestring>`
+
+This element contains one or more `<map-coordinates>` elements, each containing two or more positions. Axis order - x followed by y, separated by whitespace.
+
+---
+
+### `<map-multipolygon>`
+
+This element contains the contents one or more `<map-polygon>` elements. Axis order - x followed by y, separated by whitespace.
+
+For each member polygon, the same non-schema constraints apply to multipolygon descendant `<map-coordinates>` elements, as for polygon `<map-coordinates>` descendant elements.
+
+---
+
+### `<map-geometrycollection>`
+
+This element contains one or more `<map-point>`, `<map-linestring>`, `<map-polygon>`, `<map-multipoint>`, `<map-multilinestring>`, `<map-multipolygon>` elements.
+
+For each member geometry, the same non-schema constraints apply as to the unique geometry type above.
+
+---
+
+
+## Examples
+
+### Point
+```html
+<mapml-viewer projection="OSMTILE" zoom="10" lon="-75.7" lat="45.4" controls>
+  <map-layer label="OpenStreetMap" src="../data/osm.mapml" checked></map-layer>
+  <map-layer label="Point Geometry" checked>
+    <map-meta name="projection" content="OSMTILE"></map-meta>
+    <map-feature>
+      <map-featurecaption>Point</map-featurecaption>
+      <map-geometry cs="gcrs">
+        <map-point class="point">
+          <map-coordinates>-75.6916809 45.4186964</map-coordinates>
+        </map-point>
+      </map-geometry>
+      <map-properties><h2>This is a Point</h2></map-properties>
+    </map-feature>
+  </map-layer>
+</mapml-viewer>
+```
+
+### LineString
+
+```html
+<mapml-viewer projection="OSMTILE" zoom="10" lon="-75.7" lat="45.4" controls>
+  <map-layer label="OpenStreetMap" src="../data/osm.mapml" checked></map-layer>
+  <map-layer label="Line Geometry" checked>
+    <map-meta name="projection" content="OSMTILE"></map-meta>
+    <map-feature>
+      <map-featurecaption>Line</map-featurecaption>
+      <map-geometry cs="gcrs">
+        <map-linestring class="line">
+          <map-coordinates>-75.6168365 45.471929 -75.6855011 45.458445 -75.7016373 45.4391764 -75.7030106 45.4259255 -75.7236099 45.4208652 -75.7565689 45.4117074 -75.7833481 45.384225 -75.8197403 45.3714435 -75.8516693 45.377714</map-coordinates>
+        </map-linestring>
+      </map-geometry>
+      <map-properties><h2>This is a Line</h2></map-properties>
+    </map-feature>
+  </map-layer>
+</mapml-viewer>
+```
+
+### Polygon
+
+```html
+<mapml-viewer projection="OSMTILE" zoom="10" lon="-75.7" lat="45.4" controls>
+  <map-layer label="OpenStreetMap" src="../data/osm.mapml" checked></map-layer>
+  <map-layer label="Polygon Geometry" checked>
+    <map-meta name="projection" content="OSMTILE"></map-meta>
+    <map-feature>
+      <map-featurecaption>Polygon</map-featurecaption>
+      <map-geometry cs="gcrs">
+        <map-polygon class="polygon">
+          <map-coordinates>-75.5859375 45.4656690 -75.6813812 45.4533876 -75.6961441 45.4239978 -75.7249832 45.4083331 -75.7792282 45.3772317 -75.7534790 45.3294614 -75.5831909 45.3815724 -75.6024170 45.4273712 -75.5673981 45.4639834 -75.5859375 45.4656690</map-coordinates>
+          <map-coordinates>-75.6596588 45.4211062 -75.6338958 45.4254436 -75.6277127 45.4066458 -75.6572542 45.4097792 -75.6596588 45.4211062</map-coordinates>
+        </map-polygon>
+      </map-geometry>
+      <map-properties><h2>This is a Polygon</h2></map-properties>
+    </map-feature>
+  </map-layer>
+</mapml-viewer>
+```
+
+### MultiPoint
+
+```html
+<mapml-viewer projection="OSMTILE" zoom="10" lon="-75.7" lat="45.4" controls>
+  <map-layer label="OpenStreetMap" src="../data/osm.mapml" checked></map-layer>
+  <map-layer label="MultiPoint Geometry" checked>
+    <map-meta name="projection" content="OSMTILE"></map-meta>
+    <map-feature>
+      <map-featurecaption>MultiPoint</map-featurecaption>
+      <map-geometry cs="gcrs">
+        <map-multipoint class="point">
+          <map-coordinates>-75.7016373 45.4391764 -75.7236099 45.4208652 -75.7833481 45.384225</map-coordinates>
+        </map-multipoint>
+      </map-geometry>
+      <map-properties><h2>This is a multipoint</h2></map-properties>
+    </map-feature>
+  </map-layer>
+</mapml-viewer>
+```
+
+### MultiLineString
+
+```html
+<mapml-viewer projection="OSMTILE" zoom="10" lon="-75.7" lat="45.4" controls>
+  <map-layer label="OpenStreetMap" src="../data/osm.mapml" checked></map-layer>
+  <map-layer label="MultiLineString Geometry" checked>
+    <map-meta name="projection" content="OSMTILE"></map-meta>
+    <map-feature>
+      <map-featurecaption>MultiLineString</map-featurecaption>
+      <map-geometry cs="gcrs">
+        <map-multilinestring class="line">
+          <map-coordinates>-75.6168365 45.471929 -75.6855011 45.458445 -75.7016373 45.4391764 -75.7030106 45.4259255</map-coordinates>
+          <map-coordinates>-75.7565689 45.4117074 -75.7833481 45.384225 -75.8197403 45.3714435 -75.8516693 45.377714</map-coordinates>
+        </map-multilinestring>
+      </map-geometry>
+      <map-properties><h2>This is a MultiLineString</h2></map-properties>
+    </map-feature>
+  </map-layer>
+</mapml-viewer>
+```
+
+### MultiPolygon
+
+```html
+<mapml-viewer projection="OSMTILE" zoom="10" lon="-75.7" lat="45.4" controls>
+  <map-layer label="OpenStreetMap" src="../data/osm.mapml" checked></map-layer>
+  <map-layer label="MultiPolygon Geometry" checked>
+    <map-meta name="projection" content="OSMTILE"></map-meta>
+    <map-feature>
+      <map-featurecaption>MultiPolygon</map-featurecaption>
+      <map-geometry cs="gcrs">
+        <map-multipolygon class="polygon">
+          <map-polygon>
+          	<map-coordinates>-75.5859375 45.4656690 -75.6813812 45.4533876 -75.6961441 45.4239978 -75.7249832 45.4083331 -75.7792282 45.3772317 -75.7534790 45.3294614 -75.5831909 45.3815724 -75.6024170 45.4273712 -75.5673981 45.4639834 -75.5859375 45.4656690</map-coordinates>
+          </map-polygon>
+          <map-polygon>
+          	<map-coordinates>-75.6744295 45.4728920 -75.7053451 45.4439942 -75.7063756 45.4249616 -75.7489704 45.4177324 -75.7788555 45.4003785 -75.7943133 45.4321899 -75.6744295 45.4728920</map-coordinates>
+          </map-polygon>
+        </map-multipolygon>
+      </map-geometry>
+      <map-properties><h2>This is a MultiPolygon</h2></map-properties>
+    </map-feature>
+  </map-layer>
+</mapml-viewer>
+```
+
+### GeometryCollection
+
+```html
+<mapml-viewer projection="OSMTILE" zoom="10" lon="-75.7" lat="45.4" controls>
+  <map-layer label="OpenStreetMap" src="../data/osm.mapml" checked></map-layer>
+  <map-layer label="Geometry Collection" checked>
+    <map-meta name="projection" content="OSMTILE"></map-meta>
+    <map-feature>
+      <map-featurecaption>Geometry Collection</map-featurecaption>
+      <map-geometry cs="gcrs">
+        <map-geometrycollection>
+          <map-polygon class="polygon">
+            <map-coordinates>-75.5859375 45.4656690 -75.6813812 45.4533876 -75.6961441 45.4239978 -75.7249832 45.4083331 -75.7792282 45.3772317 -75.7534790 45.3294614 -75.5831909 45.3815724 -75.6024170 45.4273712 -75.5673981 45.4639834 -75.5859375 45.4656690</map-coordinates>
+          </map-polygon>
+          <map-linestring class="line">
+            <map-coordinates>-75.6168365 45.471929 -75.6855011 45.458445 -75.7016373 45.4391764 -75.7030106 45.4259255 -75.7236099 45.4208652 -75.7565689 45.4117074 -75.7833481 45.384225 -75.8197403 45.3714435 -75.8516693 45.377714</map-coordinates>
+          </map-linestring>
+          <map-point class="point">
+            <map-coordinates>-75.6916809 45.4186964</map-coordinates>
+          </map-point>
+        </map-geometrycollection>
+      </map-geometry>
+      <map-properties><h2>This is a Geometry Collection</h2></map-properties>
+    </map-feature>
+  </map-layer>
+</mapml-viewer>
+```

--- a/.github/skills/map-input-markup/SKILL.md
+++ b/.github/skills/map-input-markup/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: mapml-input-markup
+description: Tells you how to correctly create and edit the markup for a <map-input> element. Use it when generating MapML output markup in an HTML page.
+---
+
+
+The `<map-input>` element is an extended HTML `input` by `type` for use in Web 
+map `<map-extent>` elements.  The attributes that apply to the input depend on
+the `type` attribute.  There are several types of `<map-input>` that can be used.
+
+The `<map-input>` declares a variable that will be set and used by the polyfill 
+according to its attributes, as the map changes viewport extent in response to 
+user gestures.
+
+## Attributes
+
+### `name`
+Sets the name of the variable created by the input. The variable can then be 
+referenced by the URL template `<map-link>` [tref attribute](../link#tref), 
+using the `{name}` variable reference notation.
+
+---
+### `type`
+  Sets the **type** of the input.
+
+| Type          | Description                                          	|
+|--------------	|--------------------------------------------------------	|
+| zoom          | Integer value that ranges from 0 to some fixed number of values, depending on the projection, less than or equal to 25.|
+| location      | A location input captures **one** `axis` value of a two-dimensional point ( represented by a coordinate pair) from the map extent, e.g. `top-right`, or, for server queries, the location in the map where the user clicks or touches. |
+| width         | A width input captures the width of the map viewport's extent in standardized pixels  |
+| height        | A height input captures the height of the map viewport's extent in standardized pixels |
+| hidden        | Establishes a variable that may be used to pass a fixed value to the server when requesting map resources. |
+---
+
+### `value`
+In general, the `value` is set and used by the polyfill when generating URLs from
+[URL templates](../link#tref), for fetching server resources such as tiles, images 
+and map documents.
+
+In particular, `value` is used by authors  to specify values for inputs of 
+`type="zoom"`. In the case of `type="zoom"`, `value` defines the zoom level of 
+_associated_ **sibling** `<map-input type="location">` elements' `min` and `max`
+attribute values.  Allows authors to establish native / server resource bounds, 
+on a per-`<map-link tref="...">` basis.
+
+Inputs are _associated_ by their variables being referenced by a 
+`<map-link tref="https://example.org/{z}/{col}/{row}/" ...>` value.  The `{z}`, 
+`{row}`, and `{col}` variable references in the above example associate the 
+variables (`<map-input>`'s) named **z**, **row** and **col**.
+
+---
+### `axis`
+This attribute applies only to inputs of `type="location"`. It establishes the axis 
+of the coordinate to be serialized as [a named variable](#). This value also 
+identifies the axis that the `min` and `max` attributes apply to, so that the 
+polyfill will not make requests for spatial resources (tiles etc) outside the 
+native axis bounds. Possible values of `axis` are:
+
+| Axis name | CRS | Description                                          	|
+|-----------|-----|------------------------------------------------------	|
+|`row`      | tilematrix |Vertical axis, positive down the screen. The origin is at the upper left. Units are tiles. Each zoom level is a distinct tilematrix crs, so coordinate values apply only to that zoom level. |
+|`column`   | tilematrix |Horizontal axis, positive to the right. The origin is at the upper left. Units are tiles. Each zoom level is a distinct tilematrix crs, so coordinate values apply only to that zoom level.|
+|`easting`  | pcrs |Horizontal axis, positive to the right. The origin is defined a geographic location. Units are ususally meters, although for some projections (specifically WGS84), the transformation from geographic CRS, i.e. from longitude to easting is the [identity transformation](https://www.thefreedictionary.com/Identity+transformation), in which case the easting values could be _said_ to be in decimal degrees. **pcrs** stands for "projected coordinate reference system". Note that because pcrs is an 'infinite canvas', there exist locations for which a transformation from pcrs coordinates to gcrs coordinates is undefined. |
+|`northing` | pcrs |Vertical axis, positive to the right. The origin is defined a geographic location. Units are ususally meters, although for some projections (specifically WGS84), the transformation from geographic CRS, i.e. from latitude to northing is the [identity transformation](https://www.thefreedictionary.com/Identity+transformation), in which case the northing values could be _said_ to be decimal degrees. Note that because pcrs is an 'infinite canvas', there exist locations for which a transformation from pcrs coordinates to gcrs coordinates is undefined.|
+|`latitude` | gcrs | The latitude of a point on an ellipsoid is the angle between a line perpendicular to the surface of the ellipsoid at the given point and the plane of the equator. **gcrs** stands for "geographic coordinate reference system".|
+|`longitude`| gcrs | The longitude of a point specifies its east–west position on the reference body's (Earth's) surface.| 
+|`x`        | tcrs | Horizontal axis, positive to the right. The origin is at the upper left. Units are defined-size pixels. Each zoom level is a distinct tcrs, so coordinate values apply only to that zoom level. **tcrs** stands for "tiled coordinate reference system".  The tiles of each **tilematrix** crs are defined as aggregations of pixels in the corresponding zoom level **tcrs**.|
+|`y`        | tcrs | Vertical axis, positive down the screen. The origin is at the upper left. Units are defined-size pixels. The origin is at the upper left. Units are scaled pixels. Each zoom level is a distinct tcrs, so coordinate values apply only to that zoom level.|
+|`i`        | tile, map | Horizontal axis, positive to the right. Each tile, and the map viewport, has a defined-size pixel-based crs that has its origin at the upper left (of each tile in the case of the **tile** crs, and of the map viewport, in the case of the **map** crs). |
+|`j`        | tile, map | Vertical axis, positive down the screen. Each individual tile, and the map viewport has a defined-size pixel-based crs that has its origin at the upper left (of each tile in the case of the **tile** crs, and of the map viewport, in the case of the **map** crs).|
+
+When requesting a the coordinate axis of whole tile in the `OSMTILE` projection, 
+a location input might use a `<map-input name="y" type="location" units="tilematrix" axis="row">` 
+input to establish a variable named **y**, referenced by `{y}` in an associated URL template, 
+which would serialize the **tilematrix** crs `row` axis values.  A series of 
+location events is genereated by the polyfill as required by the map to cover 
+the viewport in tiles.  
+
+---
+### `units`
+
+Identifies the associated specific coordinate reference system that a location 
+input event is referred to.  The term "projection" in MapML is synonymous with the set
+of CRS that are related together by the projection name. In all cases for any projection,
+there exist a set of CRS that are related mathematically. These CRS are known
+and identified within the namespace of the projection name by the following
+table of keyword values:
+
+
+| CRS | Description |
+|------|-------------|
+| tcrs | For each zoom level (i.e. at a pre-defined scale denominator value), locations are expressed in terms of scaled pixels, with the origin of pixel space at the upper left corner.  The pixel coordinates of a location at a single zoom level are independent of the pixel coordinates of a location any other zoom level.  In other words, you need to know the zoom level of a tcrs coordinate in order to locate it on a map or otherwise process it. |
+| tilematrix | Each zoom level has an array of tiles, called a tilematrix.  The individual tiles constitute the coordinates in this CRS, and the axes are know as `row` and `column`.  The tiles are defined as squares of 256 pixels in the associated tcrs of the particular zoom level. |
+| pcrs | Projected CRS (pcrs) are defined by a mathematical relationship with an underlying gcrs, using a technique called "projection". pcrs coordinates are scale- and zoom level-independent, and are designed to represent geographic coordinates on a planar surface, such as a device screen. The measurement units of pcrs coordinates is _usually_ meters (a notable exception being pcrs coordinates in the `WGS84` projection). |
+| gcrs | Geographic coordinates are referenced to various ellipsoids, and are not necessarily comparable across projections.  A common ellipsoid today is WGS 84, which is defined and used by the global positioning satellite (GPS) constellation. |
+| map | The map CRS is dynamic, in the sense that it has its origin at the upper left of the user's viewport, with scaled pixels as units.  This is used to identify image coordinates for use, typically by WMS and similar services which use a virtual image to enable query of map feature property information, without necessarily transferring the features over the network. |
+| tile | Each tile in any zoom level has an implicit scaled-pixel coordinate system ranging from 0 to 255 in both horizontal and vertical directions. These coordinates are used by WMTS and similar services to identify a pixel for query of feature property values, without transferring the feature geometry over the network. |
+
+Sometimes, location inputs are used to generate "brownie-cutter" (square) requests 
+for tiles from WMS and similar un-tiled services.  In such a case, it is possible 
+for the `units` to be specified as `tilematrix`, implying that the location event 
+expected is that of a tile, and the `position` keyword is then used to describe
+the corner of the tile for which the coordinate should be serialized.  In such a
+case, the `axis` value may be specified as `easting` or other axis name  
+associated with the projection, to obtain coordinate of the corner of the tile 
+that is being processed by the polyfill: 
+
+`<map-input name="xmin" type="location" units="tilematrix" position="top-left" axis="easting">`
+
+Internally, the crs of the requested coordinate is deduced from the axis 
+name, instead of requiring the author to explicitly specify the axis' crs as an 
+additional attribute of the `<map-input>`. 
+
+---
+
+### `position`
+
+Allows the author to specify a predefined corner of the viewport or tile to be used
+as the location value to be serialized. If `position` is not present, the input
+location coordinates will be generated by user click or touch on the map, which 
+is used to generate interactive server queries.
+
+| position keyword | keyword description|
+|------------------|--------------------|
+| top-left | Identifies the location at the top left corner of the tile or viewport |
+| top-right | Identifies the location at the top right corner of the tile or viewport |
+| bottom-left | Identifies the location at the bottom left corner of the tile or viewport |
+| bottom-right | Identifies the location at the bottom right corner of the tile or viewport |
+
+Other values of `position` are possible, but are not implemented yet.
+
+---
+### `rel`
+
+Specifies the entity to which the `position` applies. Possible values are `tile` and `image`.
+The default value, if unspecified, is `image`.  It is used to help identify what crs the 
+coordinate serialized by the input exists in. 
+
+---
+### `min`
+Establishes the minimum of the axis on the server .  Requests for coordinates less than
+this value will not be created by the polyfill. 
+
+---
+### `max`
+Establishes the maximum of the axis on the server.  Requests for coordinates greater than
+this value will not be created by the polyfill.
+
+---
+### `step`
+Sets the zoom interval according to which resources will be requested within the
+zoom range. The step is always calculated from a base value of 0.  At zoom values 
+that fall within a step interval, resources will be requested as required, and
+scaled to the current zoom level.  For example, with a min=0 and a max=7 for 
+a given zoom input with a step=4, tiles will be requested at only zoom=0 and scaled
+to zoom values of 1, 2 and 3 as the map is rendered at those levels.  Use of this
+attribute can conserve user bandwidth while having little visual effect, depending
+on the nature of the content.
+
+---
+## Examples
+
+### Input step
+
+```html
+<mapml-viewer projection="OSMTILE" zoom="0" lat="45.409071" lon="-75.703411" controls>
+  <map-layer label="OpenStreetMap" checked>
+    <map-extent units="OSMTILE" checked>
+      <map-input name="z" type="zoom"  value="18" min="0" max="18" step="3"></map-input>
+      <map-input name="x" type="location" units="tilematrix" axis="column" min="0"  max="262144" ></map-input>
+      <map-input name="y" type="location" units="tilematrix" axis="row" min="0"  max="262144" ></map-input>
+      <map-link rel="tile" tref="https://tile.openstreetmap.org/{z}/{x}/{y}.png" ></map-link>
+    </map-extent>
+  </map-layer>
+</mapml-viewer>
+```
+
+### Input rel=tile to generate WMS requests for tiles
+
+WMS behaviour can seem slow, even when it is fast. Painting the map using tiles
+generated by individual WMS GetMap requests can improve users' impression of your
+map, although it is not advisable when the layer being requested contains text
+labels, which may be duplicated on adjacent tiles many times over.
+
+```html
+<mapml-viewer projection="CBMTILE" lat="60" lon="-95" zoom="2" controls>
+  <map-layer label="Tiled WMS GetMap" checked>
+    <map-extent units="CBMTILE" checked>
+      <!-- the units and axis attributes here appear at odds --> 
+      <!-- however for rel="tile" and units="tilematrix" together tell the map that
+           the event being serialized is relative to a tile in a tilematrix coordinate
+           system (tcrs) -->
+      <map-input name="txmin" type="location" rel="tile" position="top-left" axis="easting" units="tilematrix" ></map-input>
+      <!-- in this case, position refers to a position on the tile that is to be fetched -->
+      <map-input name="tymin" type="location" rel="tile" position="bottom-left" axis="northing" units="tilematrix" ></map-input>
+      <map-input name="txmax" type="location" rel="tile" position="top-right" axis="easting" units="tilematrix" ></map-input>
+      <map-input name="tymax" type="location" rel="tile" position="top-left" axis="northing" units="tilematrix" ></map-input>
+      <map-link rel="tile" tref="https://datacube.services.geo.ca/ows/msi?SERVICE=WMS&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=TRUE&STYLES=msi-color&VERSION=1.3.0&LAYERS=msi&WIDTH=256&HEIGHT=256&CRS=EPSG:3978&BBOX={txmin},{tymin},{txmax},{tymax}" ></map-link>
+      <!-- a zoom input is necessary, but that's a bug: 
+           https://github.com/Maps4HTML/MapML.js/issues/669 -->
+      <map-input name="z" type="zoom" value="25" min="0" max="25"></map-input>
+    </map-extent>
+  </map-layer>
+</mapml-viewer>
+```

--- a/.github/skills/map-layer-markup/SKILL.md
+++ b/.github/skills/map-layer-markup/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: mapml-map-layermarkup
+description: Tells you how to correctly create and edit the markup for a <map-layer> element. Use it when generating MapML output markup in an HTML page.
+---
+
+Maps have one or more layers. Map layers are implemented by the `<map-layer>` custom element.  
+All `<mapml-viewer>` content is contained by one or more `<map-layer>` elements, either inline or by remote fetch representing the layer's content.
+
+```html
+<map-layer label="My Layer" checked>
+  ...layer content goes here...
+</map-layer>
+```
+
+`<map-layer>` is not a 'void' element - it must be closed with a `</map-layer>` tag.
+
+Map content can either be inline, as shown above - between the beginning `<map-layer>` and ending `</map-layer>` tags -
+or fetched, from the `<map-layer src="..."></map-layer>` source attribute URL:
+
+```html
+<map-layer label="My Layer" src="https://example.org/mapml/mylayer" checked></map-layer>
+```
+
+
+This documentation uses the convention of inline content mostly.  Fetched map content
+follows similar semantics, except it is parsed with the browser's XML parser and
+so must follow both MapML document conventions as well as
+[XML syntax rules](https://developer.mozilla.org/en-US/docs/Web/XML/XML_introduction).
+
+## Attributes
+
+### `src`
+
+Contains the path to a MapML document.
+
+---
+
+### `checked`
+
+The `<map-layer checked>` attribute and property is boolean. When present,
+the checked property value is taken to be 'true'; when not present, the property
+value is 'false'.  Beware that it is the _presence_ of the attribute that makes it
+true, not the value of the attribute. For example, the attribute `checked="false"`
+actually turns out to be checked,
+[as described by MDN Web docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes#boolean_attributes).
+
+---
+
+### `hidden`
+
+The `<map-layer hidden>` attribute and property is boolean. When present,
+the layer is hidden in the layer control.
+
+---
+
+### `label`
+
+The `label` attribute is used by inline content as the displayed text label of the
+layer in the layer control.  In fetched content, the `label` attribute is ignored,
+and the fetched `<map-title>` element is used.
+
+---
+
+### `media`
+
+The `media` attribute is used to express map media conditions under which the layer 
+content should be used (if inline content is present), or loaded from the `src` URL, 
+if that attribute is present.  Map media conditions evaluate to `true` or `false`. 
+A layer for which the map media condition evaluates to `false` is by default hidden. 
+A layer for which the map media condition evaluates to `true` is added to the map 
+according to its `checked` attribute, and is added to the layer control according
+to its `hidden` attribute.
+
+Map media queries can include map properties as documented in the [matchMedia](../../api/mapml-viewer-api#matchmedia) API.
+
+---
+
+### `opacity`
+
+The `opacity` attribute is used to set the initial opacity of the `<map-layer>` element.
+Valid `opacity` values range from from "0.0" to "1.0" and are reflected in the layer control
+opacity input slider control. When the `opacity` attribute is not present, the opacity is set to "1.0" by default.
+
+---
+
+## Examples
+
+### Layer Opacity
+
+The following example sets the initial `opacity` for a `<map-layer>`. 
+
+```html
+<mapml-viewer projection="CBMTILE" zoom="2" lat="45" lon="-90" controls>
+      <map-layer opacity = "0.5" label="CBMT" src="https://geogratis.gc.ca/mapml/en/cbmtile/cbmt/" checked></map-layer>
+</mapml-viewer>
+```
+

--- a/.github/skills/map-link-markup/SKILL.md
+++ b/.github/skills/map-link-markup/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: mapml-link-markup
+description: Tells you how to correctly create and edit the markup for a <map-link> element. Use it when generating MapML output markup in an HTML page.
+---
+
+The `<map-link>` element is an extended HTML `link` element, for use in Web 
+maps.  Most of the extensions center on proposed new values of the `rel` attribute.
+
+`<map-link>` has several uses:
+
+- include layer data attribution / licensing links in the bottom right-hand corner of the map
+- provide links to different styles of the layer, via `style` and `self` rel values. These links are rendered as user affordances, and can be used to switch, for example, from satellite to map view of a layer.
+- provide links to alternate projections for a layer, via the `alternate` rel value, in conjunction with the `projection="..."` attribute. Such links are automatically followed by the polyfill when appropriate.
+- provide a URL template that is processed and converted to a URL and fetched by the polyfill, each time the map requires new content to render, such as a tile, via the `tile`, `image`, `feature` and `query` rel values, in conjunction with the `tref="..."` attribute. Such links are automatically created and followed / imported when appropriate.
+- include links to legend graphics for a layer.  Currently such links are rendered as hyperlinks, not as graphics.
+- provide links to CSS stylesheets via the `stylesheet` rel value, which are imported by the polyfill automatically.
+- provide links to layers at next native zoom level via `zoomin`, `zoomout` rel values.  Such links are automatically followed by the polyfill when appropriate.
+
+
+## Attributes
+
+### `rel`
+
+The `rel` attribute designates the type of resource that is linked to. MapML 
+defines several uses of existing and new `rel` keyword values.
+
+| Value         | Description                                          	  |
+|--------------	|--------------------------------------------------------	|
+| `license`       | The `href` value links to a license description resource for the layer. The `title` attribute is used as the text to display for the link. The hyperlink is presented in the attribution control, at the lower right corner of the map viewport.
+| `alternate`     | The `alternate` rel value is used with the `projection` attribute to provide the link to an equivalent layer resource in a different projection than that provided by the current resource.  This can be very useful for providing an author-friendly experience, where a map document may be added as a layer to a map that declares a different projection than that of the layer.  The polyfill will automatically "redirect" to the alternate projection document that matches that of the map. |
+| `self`       | The `self style` (or `style self`) link rel indicates that the current document is one of a set of named alternate styles for a layer.  Other members of the set are `<map-link>` elements tagged with the `style` link relation. Other members of the set of alternate / different styles for the layer are presented to the user as a set of mutually exclusive choices.  User selection of one of the choices replaces the current layer entirely. |
+| `style`      | The `style` link relation by itself designates that link as an alternate or different style of the current layer style. This is often used to switch between, for example, satellite and cartographic views of the same layer. When used in conjunction with the `self` link relation, i.e. `rel="self style"`, the current document is identified as a member of the set of alternate styles, and is selected in the layer control affordance for changing styles. |
+| `tile`       | This link relation is used in conjunction with the `tref="..."` attribute to define a URL template that identifies native (server) tile resources. Can be used in conjunction with the `type="..."` attribute to indicate the media type of the remote resource, for example: `type="text/mapml"` tells the polyfill to parse and render the fetched resource as map feature content. This link relation is used with standard Web Map Tile Services (WMTS), and its non-standard equivalents. |
+| `image`      | The `image` link relation is used similarly to the `tile` link relation, except it tells the polyfill that the remote resources to be fetched are images that will be trimmed (by the server) to exactly match the width and height of the map viewport.  This link relation is used with standard Web Map Services (WMS) and its non-standard equivalents. |
+| `features`    | The `features` link relation tells the polyfill to parse and render the fetched resource as map feature content. |
+| `zoomin`     | The link `href` is followed automatically by the polyfill when the map is zoomed in by the user to a value greater than the maximimum value of the zoom range of the current layer.  The referenced map layer resource replaces the current map layer.  The polyfill does not represent this link as a user-visible affordance, it is followed automatically. If the remote resource does not contain a reciprocal `zoomout` link, the map state change is one-way i.e. the layer is permanently replaced. |
+| `zoomout`    | The link `href` is followed automatically by the polyfill when the map is zoomed out by the user to a value less than the minimum value of the zoom range of the current layer.  The referenced map layer resource replaces the current map layer.  The polyfill does not represent this link as a user-visible affordance, it is followed automatically.  If the remote resource does not contain a reciprocal `zoomin` link, the map state change is one-way i.e. the layer is permanently replaced.  |
+| `legend`     | The `legend` link relation designates a link to metadata, typically an image, describing the symbology used by the current layer.  Currently, the polyfill creates a hyperlink for the label of the layer in the layer control, which opens in a new browsing context. |
+| `query`      | The `query` link relation is used in combination with the `tref="..."` attribute to establish a URL template that composes a map query URL based on user map gestures such as click or touch. These URLs are fetched and the response presented on top of the map as a popup. Such queries can return text/html or text/mapml responses. In the latter case, the response may contain more than one feature, in which case a 'paged' popup is generated, allowing the user to cycle through the features' individual metadata. |
+| `stylesheet` | The link imports a CSS stylesheet from the `href` value. |
+
+
+---
+
+### `type`
+
+The `type` attribute defines the expected 
+[MIME media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) 
+of the remote resource. Depending on the [`rel` value](#rel), the `type` may play a significant role in determining
+the polyfill behaviour.
+
+Common values of `type` include **text/html**, **text/mapml**, and **image/\***.
+
+---
+### `title`
+
+The `title` of the linked resource is usually rendered or presented to the user, 
+for example, the `<map-link rel="license" title="Copyright FooBar Inc.">` link
+is rendered as a hyperlink in the attribution control entry for the current 
+layer.
+
+---
+### `href`
+
+The `href` of a `<map-link>` must be a URL value of a resource that can be fetched. 
+The URL can be absolute or relative.
+
+---
+### `hreflang`
+
+Advisory [language designation](https://datatracker.ietf.org/doc/html/rfc5646) about remote resource.
+
+---
+### `tref`
+
+The `tref` attribute contains a string that, once processed, will be treated as 
+a URL and fetched automatically by the polyfill. The string is known as a URL
+template.  The processing that takes place prior to a URL template becoming a
+valid URL is _variable reference substitution_.  Variables are created by 
+`<map-input name="foo">` elements.  The name of the variable can be
+referenced in the URL template string contained in the `tref` value, using the
+`{foo}` syntax notation.  A URL template string can contain 0 or more variable
+references.  Processing will remove variable references that are valid. That is,
+all variables that have been created by `<map-input>`s that are referenced in the
+template will be replaced with the value of the variable at the time of processing.
+
+---
+### `tms`
+
+The `tms` boolean attribute tells the polyfill that the row (vertical) axis of the
+remote tile server follows [the tms convention](https://wiki.osgeo.org/wiki/Tile_Map_Service_Specification)
+of the y (row) axis being reversed (compared with [convention](https://gist.github.com/tmcw/4954720#converting)), 
+with the positive direction of tile row values being up/north.  This convention is not a 
+standard, yet has unfortunately become popular among open source GIS professionals.
+
+---
+### `projection`
+
+The `projection` attribute identifies the projection of the remote layer resource.
+This attribute is used in conjunction with the [`rel=alternate` rel value](#rel).
+
+Projection values [defined by the polyfill](../mapml-viewer#projection) include: 
+`OSMTILE`, `WGS84`, `CBMTILE` and `APSTILE`.  Projection values are case-sensitive.
+
+---
+
+
+| <!-- -->    | <!-- -->    |
+|-------------|-------------|
+| [Content categories](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories) | [Metadata content](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#metadata_content) |
+| Permitted content | None. Like the HTML `<link>` element `<map-link>` is an empty element.  |
+| Tag omission | While the HTML `<link>` element is a void element, the polyfill must have an end tag. |
+| Permitted parents | Any element that accepts metadata element children. |
+| Implicit ARIA role   | [link](https://w3c.github.io/aria/#link) with `href` attribute. |
+| Permitted ARIA roles | No roles permitted. |
+| DOM Interface    | [HTMLLinkElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLinkElement) |
+
+---
+
+## Examples
+
+### Tile Mapping Specification (tms)
+
+```html
+<mapml-viewer  projection="OSMTILE" zoom="1" lat="0" lon="0" controls>
+ <layer- label="OpenStreetMap" src="https://geogratis.gc.ca/mapml/en/osmtile/osm/" checked hidden  ></layer->
+ <layer- label="TMS COG Source" checked>
+   <map-extent units="OSMTILE">
+       <map-input name="zoom" type="zoom"  min="1" max="12"></map-input>
+       <map-input name="row" type="location" axis="row" units="tilematrix" ></map-input>
+       <map-input name="col" type="location" axis="column" units="tilematrix"></map-input>
+       <!-- use the tms attribute to indicate that remote tile cache follows tms conventions -->
+       <map-link tms rel="tile" tref="https://s3-eu-west-1.amazonaws.com/vito-lcv/global/2019/cog-grass-colored-fraction_grass/{zoom}/{col}/{row}.png">
+   </map-link>
+   </map-extent>
+   </layer->
+</mapml-viewer>
+```

--- a/.github/skills/map-meta-markup/SKILL.md
+++ b/.github/skills/map-meta-markup/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: mapml-meta-markup
+description: Tells you how to correctly create and edit the markup for a <map-meta> element. Use it when generating MapML output markup in an HTML page or XHTML MapML document.
+---
+
+The `<map-meta>` element is an extended HTML `meta` element, for use in Web 
+maps.
+
+## Attributes
+
+### `name`
+
+The `name` attribute identifies the type of metadata that is being set. Possible
+values of `name` related to maps include:
+
+| Name          | Description                                          	  |
+|--------------	|--------------------------------------------------------	|
+| projection    | Set the [projection](../mapml-viewer/#projection) for the document |
+| extent        | Define the bounds of the document in terms of corner position keywords and axis names, potentially combined with a zoom value if necessary (depending on coordinate system). |
+| cs            | Identifies the default coordinate reference system of coordinate strings found in the document. |
+| zoom          | Specify the zoom range min, max and default zoom value for displaying the document contents. The 'native' zoom range of [templated map content](../link#tref) is specified by the min/max attributes of associated [zoom inputs](../input#type).  If templated content is not described by associated zoom input min/max/value attributes, the values specified in a `<map-meta name=zoom>` will be used as fallback, if it exists.  If no `<map-meta name=zoom>` exists, the corresponding min/max values from the projection will be used. |
+
+---
+### `content`
+
+| `name`          | `content` value                                          	  |
+|--------------	|--------------------------------------------------------	|
+| projection    | A case-sensitive [projection name](../mapml-viewer#projection), or a [custom projection name](../../api/mapml-viewer-api#definecustomprojectionoptions) |
+| extent        | \(\(_[position keyword](../input#position)_\)-\(_[axis name](../input#axis)_\)=\(_axis value_\)\(,\)\)4\(,\)\(zoom=\(_zoom value_\)\)0,1 |
+| cs            | A case-sensitive [coordinate system abbreviation](../input#units). |
+| zoom          | (min=_minimum zoom value_,max=_maximum zoom value_,)(value=_current zoom value_) |
+
+:::tip
+
+The grammar rules for the `<map-meta name="extent" content="..."></map-meta>`
+`content` attribute require that you specify coordinates of the top-left and 
+bottom-right corners of the extent being marked up. You must specify the axis values of the 
+extent as values for a set of four comma-separated keys which identify the coordinate
+system being used (i.e. pcrs, gcrs, tile, tilematrix, map or tcrs) by virtue of 
+the axis names. For example `top-left-easting=-8433179` identifies that the 
+coordinate system being used is pcrs.  You cannot mix coordinate systems within 
+a single `content` attribute value, for example `top-left-easting=-8433179, top-left-latitude=49.02174,...`
+is not legal.
+
+You can copy a correctly marked-up `<map-meta name="extent" content="...">` value 
+onto the clipboard for the current map viewport, in pcrs coordinates (by default), 
+via the map context menu Copy > Extent item as shown below:
+
+![Copy extent context menu](../assets/img/map-context-menu-copy-extent.png)
+
+:::
+
+---
+
+| <!-- -->    | <!-- -->    |
+|-------------|-------------|
+| [Content categories](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories) | [Metadata content](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#metadata_content) |
+| Permitted content | None, it is an [empty element](https://developer.mozilla.org/en-US/docs/Glossary/Empty_element).  |
+| Tag omission | While the HTML `<meta>` element is a void element, the polyfill `<map-link>` must have an end tag. |
+| Permitted parents | Inline: the `<map-layer>` element. In a MapML document: the `<map-head>` element. |
+| Implicit ARIA role   | [No corresponding role](https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role) |
+| Permitted ARIA roles | No role permitted |
+| DOM interface | [HTMLMetaElement extension](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMetaElement) |
+
+---
+
+## Examples
+
+### Setting zoom
+
+Using the `<map-meta>` element to specify the native zoom and fallback zoom range 
+for a `<map-feature>`.  The coordinate encoding is narrowly determined for the feature,
+by the `<map-geometry cs="gcrs">` attribute, which tells the polyfill how to parse and
+process strings of coordinates found in descendant `<map-coordinates>` elements.
+
+```html
+<map-layer label="Favourite Restaurant" checked>
+  <map-meta name="projection" content="OSMTILE"></map-meta>
+  <map-meta name="zoom" content="min=0,max=22,value=3"></map-meta>
+  <map-feature>
+    <map-featurecaption>Big Daddy's Crab Shack</map-featurecaption>
+      <map-geometry cs="gcrs">
+          <map-point>
+            <map-coordinates>-75.690276 45.41868</map-coordinates>
+          </map-point>
+      </map-geometry>
+  </map-feature>
+</map-layer>
+```
+
+### Setting extent
+
+Using the `<map-meta>` element to establish the pcrs (easting,northing) **extent** of 
+a map layer, the coordinates of which are encoded as gcrs pairs. 
+
+```html
+<map-layer label="Favourite Restaurant" checked>
+  <map-meta name="projection" content="OSMTILE"></map-meta>
+  <map-meta name="zoom" content="min=0,max=22,value=3"></map-meta>
+  <map-meta name="extent" content="top-left-easting=-8433179, top-left-northing=5689316, bottom-right-easting=-8420968,bottom-right-northing=5683139"></map-meta>
+  <map-feature>
+    <map-featurecaption>Big Daddy's Crab Shack</map-featurecaption>
+      <map-geometry cs="gcrs">
+          <map-point>
+            <map-coordinates>-75.690276 45.41868</map-coordinates>
+          </map-point>
+      </map-geometry>
+  </map-feature>
+</map-layer>
+```
+
+### Fallback cs for &lt;map-geometry&gt;
+
+Using the `<map-meta>` to specify a fallback coordinate encoding for geometries in
+the layer. The encoding of the coordinates is identified by the use of the 
+`<map-meta name="cs" content="gcrs">` element. Such a declaration tells the 
+polyfill how to parse and process any coordinates that don't have an ancestor 
+`<map-geometry cs="">` coordinate encoding declaration.  Note that the zoom level
+at which the feature should be displayed is not specified, nor the extent. Both
+values will fall back to the default values for the projection. 
+
+```html
+<map-layer label="Favourite Restaurant" checked>
+  <map-meta name="projection" content="OSMTILE"></map-meta>
+  <map-meta name="cs" content="gcrs" ></map-meta>
+  <map-feature>
+    <map-featurecaption>Big Daddy's Crab Shack</map-featurecaption>
+      <map-geometry>
+          <map-point>
+            <map-coordinates>-75.690276 45.41868</map-coordinates>
+          </map-point>
+      </map-geometry>
+  </map-feature>
+</map-layer>
+```
+
+### Default metadata
+
+Allowing all metadata values to default to those of the map's projection.  The 
+feature will be displayed at all zoom levels, and the coordinates are by default
+interpreted to be `gcrs` (longitude latitude).  The extent of the layer defaults 
+to that of the projection.
+
+```html
+<map-layer label="Favourite Restaurant" checked>
+  <map-feature>
+    <map-featurecaption>Big Daddy's Crab Shack</map-featurecaption>
+      <map-geometry>
+          <map-point>
+            <map-coordinates>-75.690276 45.41868</map-coordinates>
+          </map-point>
+      </map-geometry>
+  </map-feature>
+</map-layer>
+```

--- a/.github/skills/map-properties-markup/SKILLS.md
+++ b/.github/skills/map-properties-markup/SKILLS.md
@@ -1,0 +1,60 @@
+---
+name: mapml-properties-markup
+description: Tells you how to correctly create and edit the markup for a `<map-properties>` element. Use it when generating MapML output markup in an HTML page.
+---
+
+A `<map-properties>` element is a child of `<map-feature>` and is used to define the content of the popup associated to a given feature.
+
+A `<map-properties>` element can contain any HTML Element to describe the feature's content. 
+
+---
+
+## Examples
+
+### Properties Table
+
+The following example displays the popup as an HTML [table](https://html.spec.whatwg.org/multipage/tables.html#the-table-element).
+
+```html
+<mapml-viewer projection="OSMTILE" zoom="12" lat="45.42" lon="-75.70">
+  <map-layer label="OpenStreetMap" src="../data/osm.mapml" checked></map-layer>
+  <map-layer label="Ottawa" checked>
+    <map-meta name="projection" content="OSMTILE"></map-meta>
+    <map-meta name="cs" content="gcrs"></map-meta>
+    <map-feature>
+      <map-featurecaption>Ottawa</map-featurecaption>
+      <map-geometry>
+        <map-point class="ottawa">
+          <map-coordinates>-75.697193 45.421530</map-coordinates>
+        </map-point>
+      </map-geometry>
+      <map-properties>
+        <table>
+          <thead>
+            <tr>
+              <th role="columnheader" scope="col">Property name</th>
+              <th role="columnheader" scope="col">Property value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">Name</th>
+              <td itemprop="amenity">Ottawa</td>
+            </tr>
+            <tr>
+              <th scope="row">Type</th>
+              <td itemprop="name">City</td>
+            </tr>
+            <tr>
+              <th scope="row">Website</th>
+              <td itemprop="website"><a href="https://ottawa.ca/" target="_blank">Ottawa</a></td>
+            </tr>
+          </tbody>
+        </table>
+      </map-properties>
+    </map-feature>
+  </map-layer>
+</mapml-viewer>
+```
+
+

--- a/.github/skills/map-select-markup/SKILLS.md
+++ b/.github/skills/map-select-markup/SKILLS.md
@@ -1,0 +1,60 @@
+---
+name: map-select-markup
+description: Tells you how to correctly create and edit the markup for a <map-select> element. Use it when generating MapML output markup in an HTML page, especially when creating a template variable for dimensional data with discrete values selectable by the user.
+---
+
+The `<map-select>` element is an extension of HTML `<select>` and is used as a child of the `<map-extent>` element. The `<map-select>` element declares a variable with predefined `<map-option>'s` which are selected through the layer control and used by the polyfill.
+
+The `<map-select>` element contains one or more `<map-option>` elements.
+
+:::tip
+
+Change the `<map-select>` option through the layer control (top-right of the map) to view data for different timestamps.
+
+:::
+
+## Attributes
+
+### `name`
+Sets the name of the variable created by the input. The variable can then be 
+referenced by the URL template `<map-link>` [tref attribute](../link#tref), 
+using the `{name}` variable reference notation.
+
+---
+
+### `id`
+Sets the id of the `<map-select>` element, identifies the select within the current document.
+
+---
+
+## Child Elements
+
+### `<map-option>`
+
+This element contains the options for the `<map-select>` element. A `<map-select>` element can contain one or more `<map-option>` elements.
+
+---
+
+## Examples
+
+### Change map source
+```html
+<mapml-viewer projection="OSMTILE" zoom="2" lat="65" lon="-90" controls="">
+  <map-layer label="Basemap" checked>
+    <map-extent units="OSMTILE" checked>
+      <map-input name="z" type="zoom"  value="18" min="0" max="18"></map-input>
+      <map-input name="x" type="location" units="tilematrix" axis="column" min="0"  max="262144" ></map-input>
+      <map-input name="y" type="location" units="tilematrix" axis="row" min="0"  max="262144" ></map-input>
+      <map-link rel="license" href="https://www.openstreetmap.org/copyright" title="OpenStreetMap"></map-link>
+      <map-link rel="license" href="https://www.openstreetmap.bzh/" title="Breton OpenStreetMap Team"></map-link>
+      
+      <map-select id="urlOptions" name="source">
+        <map-option value="tile.openstreetmap.bzh/br">OpenStreetMap_BZH</map-option>
+        <map-option value="tile.openstreetmap.org">OpenStreetMap_Mapnik</map-option>    
+      </map-select>
+      
+      <map-link rel="tile" tref="https://{source}/{z}/{x}/{y}.png" ></map-link>
+    </map-extent>
+  </map-layer>
+</mapml-viewer>
+```

--- a/.github/skills/map-span-markup/SKILLS.md
+++ b/.github/skills/map-span-markup/SKILLS.md
@@ -1,0 +1,31 @@
+---
+name: map-span-markup
+description: Tells you how to correctly create and edit the markup for a <map-span> element. Use it when generating MapML output markup in an HTML page, especially when styling vector `<map-feature>` data descendant `<map-coordinates>` coordinate strings, where you can wrap sequences of coordinate pairs to allow them to be styled differently than the overall geometry which they're part of.
+---
+
+The `<map-span>` element is useful when used together with html global attributes such as [class](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/class). This element allows you to wrap the coordinate pairs in a `<map-coordinates>` element, allowing the wrapped coordinates to be targeted by CSS selectors, and thus independently styled.
+
+---
+
+## Examples
+
+### Styling Polygon Holes
+
+```html
+<mapml-viewer projection="OSMTILE" zoom="10" lon="-75.7" lat="45.4" controls>
+  <map-layer label="OpenStreetMap" src="../data/osm.mapml" checked></map-layer>
+  <map-layer label="Polygon" checked>
+    <map-meta name="projection" content="OSMTILE"></map-meta>
+    <map-feature>
+      <map-featurecaption>Polygon</map-featurecaption>
+      <map-geometry cs="gcrs">
+        <map-polygon>
+          <map-coordinates>-75.5859375 45.4656690 -75.6813812 45.4533876 -75.6961441 45.4239978 -75.7249832 45.4083331 -75.7792282 45.3772317 -75.7534790 45.3294614 -75.5831909 45.3815724 -75.6024170 45.4273712 -75.5673981 45.4639834 -75.5859375 45.4656690</map-coordinates>
+          <map-coordinates><map-span class="hole">-75.6467062 45.4215881 -75.6889363 45.4049585 -75.6693647 45.3767494 -75.6270640 45.3924229 -75.6467062 45.4215881</map-span></map-coordinates>
+        </map-polygon>
+      </map-geometry>
+      <map-properties><h2>This is a Polygon</h2></map-properties>
+    </map-feature>
+  </map-layer>
+</mapml-viewer>
+```

--- a/.github/skills/map-style-markup/SKILLS.md
+++ b/.github/skills/map-style-markup/SKILLS.md
@@ -1,0 +1,55 @@
+
+---
+name: map-style-markup
+description: Tells you how to correctly create and edit the markup for a <map-style> element. Use it when generating MapML output markup in an HTML page, especially when creating styling vector `<map-feature>` data.
+---
+
+The `<map-style>` element allows map authors to embed CSS into map layers. The CSS can be used to style the geometry of the layer using [`<map-span>`](../../elements/span/), and by setting the class attribute to the [child elements](../geometry/#child-elements) of the geometry.
+
+## Attributes
+
+### `media`
+
+The `media` attribute is used to express media conditions under which the contained 
+styles should be applied.  Media conditions evaluate to `true` or `false`. A map-style 
+for which the media condition evaluates to `false` is not loaded / is removed. Styles 
+contained in a `<map-style>` for which the media condition evaluates to `true` 
+are applied; when the condition subsequently evaluates to `false`, the styles are removed.
+An invalid media condition evaluates to `false`.
+
+Map media queries can include map properties including: [projection](../../api/mapml-viewer-api#projection), [zoom](../../api/mapml-viewer-api#zoom), 
+and [extent](../../api/mapml-viewer-api#extent).
+
+---
+
+:::note
+
+All the demo's on the documentation pages contain a "CSS" tab which adds the CSS using the `<map-style>` element dynamically.
+
+:::
+
+---
+
+## Examples
+
+### Styling using `<map-span>`
+
+```html
+<mapml-viewer projection="OSMTILE" zoom="10" lon="-75.7" lat="45.4" controls>
+  <map-layer label="OpenStreetMap" src="../data/osm.mapml" checked></map-layer>
+  <map-layer label="Polygon" checked>
+    <map-meta name="projection" content="OSMTILE"></map-meta>
+    <map-feature>
+      <map-featurecaption>Polygon</map-featurecaption>
+      <map-geometry cs="gcrs">
+        <map-polygon>
+          <map-coordinates>-75.5859375 45.4656690 -75.6813812 45.4533876 -75.6961441 45.4239978 -75.7249832 45.4083331 -75.7792282 45.3772317 -75.7534790 45.3294614 -75.5831909 45.3815724 -75.6024170 45.4273712 -75.5673981 45.4639834 -75.5859375 45.4656690</map-coordinates>
+          <map-coordinates><map-span class="hole">-75.6467062 45.4215881 -75.6889363 45.4049585 -75.6693647 45.3767494 -75.6270640 45.3924229 -75.6467062 45.4215881</map-span></map-coordinates>
+        </map-polygon>
+      </map-geometry>
+      <map-properties><h2>This is a Polygon</h2></map-properties>
+    </map-feature>
+    <map-style>.hole {stroke: #73A9AD;stroke-width: 4px;fill: none;fill-opacity: 1;}</map-style>
+  </map-layer>
+</mapml-viewer>
+```

--- a/.github/skills/mapml-markup/SKILLS.md
+++ b/.github/skills/mapml-markup/SKILLS.md
@@ -1,0 +1,76 @@
+---
+name: mapml-markup
+description: Tells you how to correctly create and edit the markup for a standalone MapML document. Use it when generating MapML output markup in an XHTML format.
+---
+
+The `<mapml->` element is the root of a MapML document (with a .mapml file extension) representing a layer. A MapML document allows itself to be fetched as a remote resource from the `<map-layer src="..."></map-layer>` source attribute URL:
+
+```html
+<map-layer label="My Layer" src="https://example.org/mapml/mylayer" checked></map-layer>
+```
+
+A `<mapml->` element declare the document to be in the xhtml namespace, and 
+must contain one `<map-head>` element, followed by one `<map-body>` element.
+
+<details>
+<summary>Click to view the contents of "../data/osm.mapml" from the demo above</summary>
+
+``` html
+<mapml- xmlns="http://www.w3.org/1999/xhtml">
+  <map-head>
+    <map-title>OpenStreetMap</map-title>
+    <meta http-equiv="Content-Type" content="text/mapml;projection=OSMTILE"/>
+    <meta charset="utf-8"/>
+    <map-link rel="license" href="https://www.openstreetmap.org/copyright" title="© OpenStreetMap contributors CC BY-SA"></map-link>
+  </map-head>
+  <map-body>
+    <!-- When 'boolean' attributes such as 'checked' or 'hidden' are used in a mapml file, they must have a string value. i.e 'checked="checked"' -->
+    <map-extent units="OSMTILE" checked="checked" hidden="hidden">
+      <map-input name="z" type="zoom"  value="18" min="0" max="18"></map-input>
+      <map-input name="x" type="location" units="tilematrix" axis="column" min="0"  max="262144" ></map-input>
+      <map-input name="y" type="location" units="tilematrix" axis="row" min="0"  max="262144" ></map-input>
+      <map-link rel="tile" tref="https://tile.openstreetmap.org/{z}/{x}/{y}.png" ></map-link>
+    </map-extent>
+  </map-body>
+</mapml->
+```
+
+</details> 
+
+
+## Attributes
+
+### `lang`
+
+The `lang` attribute defines the primary language of the MapML document. as defined by HTML [here](https://html.spec.whatwg.org/multipage/dom.html#attr-lang).
+
+### `xmlns`
+
+The `xmlns` attribute is **required**, and must have the value `"http://www.w3.org/1999/xhtml"`.
+
+---
+
+## Child Elements
+
+### `<map-head>`
+
+The `<map-head>` element is the first child of the `<mapml->` element. It contains metadata for the MapML document. 
+
+#### Child Elements
+  - `<map-title>`
+    - The title element should exist as the one and only title element in the head element. Its content should be a text string describing the document. It is conceivably used as a bookmark title.
+  - `<map-base>`
+    - The base element is used to identify a URL to be used to act as a base URL in order to resolve relative URLs later in the document.
+    - There must be only one `<map-base>` element in a MapML document, and it must be in the content of the `<map-head>` element, before any MapML elements which potentially carry a URL for resolution, notably the `<map-link>` element.
+  - `<map-meta>`
+    - The meta element describes the metadata in a MapML document. Details on the meta element and it's syntax can be found [here](../meta/).
+  - `<map-link>`
+    - The link element describes the metadata links in a MapML document. Details on the link element and it's syntax can be found [here](../link/).
+
+---
+
+### `<map-body>`
+
+The `<map-body>` element is the second child of the `<mapml->` element. It represents the content of the MapML document. This element contains the [features](../feature/) and metadata of the MapML document.
+
+---

--- a/.github/skills/mapml-viewer-markup/SKILL.md
+++ b/.github/skills/mapml-viewer-markup/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: mapml-viewer-markup
+description: Tells you how to correctly create and edit the markup for a <mapml-viewer> element. Use it when generating MapML output markup in an HTML page.
+---
+
+The `<mapml-viewer>` element is the main element you can use to put a custom Web map on your page.  To create a (really) simple Web map, you might use it like this:
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>A Simple Web Map[tm]</title>
+  <script type="module" src="web-map/mapml.js"></script>
+  <style>
+    html, body {
+    height: 100%; /* These styles are required if you wish to use a % based
+                     height value on the mapml-viewer element. */
+    }
+  </style>
+</head>
+<body>
+  <mapml-viewer projection="OSMTILE" zoom="0" lat="0.0" lon="0.0" controls>
+    <map-layer label="OpenStreetMap" src="https://geogratis.gc.ca/mapml/en/osmtile/osm/" checked></map-layer>
+  </mapml-viewer>
+</body>
+</html>    
+```
+
+Note that for the above example to run properly on your own site, you need to get a built copy of the `<mapml-viewer>` project in your site's folder. In the example, the `<mapml-viewer>` files are copied into the folder named "web-map" in your site root folder. Your own site's path to these files will depend on how you structure your folders.
+
+`<mapml-viewer>` is an "[autonomous custom element](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements)" in HTML.  You can distinguish an autonomous custom element from a "native" HTML element by the "-" anywhere in the element name. Autonomous custom elements are supported by all modern browsers, but don't work in old browsers (e.g. Internet Explorer and old Edge).
+
+The `<mapml-viewer>` element has several attributes to control the presentation and initial location of the map.  
+
+## Attributes
+
+### `projection`
+
+`projection` - an enumerated attribute. Case-sensitive values are: "`OSMTILE`", "`WGS84`", "`CBMTILE`" and "`APSTILE`".  
+The default projection is `OSMTILE`.
+
+  - `OSMTILE` corresponds to the widely-used "Web Mercator" projected coordinate reference system, implying a "tile pyramid" zoom range from 0 to 23 (minimum tile size ~2.4m).
+
+  - `WGS84` provides an implementation of the "pseudo plate carrée" projected coordinate reference system, wherein the easting and northing axis units are decimal degrees (not meters). In `WGS84`, zoom level 0 contains two tiles that each cover a hemisphere of Earth's surface. `WGS84` is defined with 21 zoom levels (0 to 20).  
+
+  - `CBMTILE` is the de facto standard grid layout for the Canadian Geospatial Data Infrastructure (CGDI), defined by Natural Resources Canada, and is based on the Lambert Conformal Conic projection (EPSG:3978). Zoom levels are based on a numeric map scale denominator (e.g. 10000 corresponding to a map scale of 1:10,000), with a particular pixel resolution selected, and as a result, successive zoom levels' tiles do not nest exactly (as they do in `OSMTILE`, `WGS84` and `APSTILE`). 
+
+  - `APSTILE` is based on the Alaska Polar Stereographic (EPSG:5936) projected coordinate reference system, and has 20 zoom levels (0 to 19).
+
+  - other projections are possible, using the [Custom Projections API](../../api/mapml-viewer-api/#definecustomprojectionoptions).
+
+---
+
+### `zoom`
+
+`zoom` - a non-negative integer.  The value establishes the _initial_ zoom level of the map, and is required. The value is updated when the map stops moving. For a smaller scale view of the world, use a lower value.  Use larger values for larger scales (smaller area maps). The maximum value depends on the particular `projection` and data source. Many map data sources have limited zoom levels available.
+
+---
+
+### `lat`
+
+`lat` - a real number latitude. The value establishes the _initial_ latitude of the of the center of the map, and is required. The value is updated when the map stops moving. Latitudes on Earth range from -90.0 (south) to 90.0 (north).  Many projections are not able to display all latitudes, and most projections have a limited range of locations where distortion is controlled or limited. In particular, OSMTILE (Web Mercator) can only display content between the latitude range -84 to 84.
+
+---
+
+### `lon`
+
+`lon` - a real number longitude. The value establishes the _initial_ longitude of the of the center of the map, and is required. The value is updated when the map stops moving. Longitudes on Earth range from -180.0 (west) to 180.0 (east). Similar comments related to distortion apply to those for latitude. Be careful, this attribute is named "lon" NOT "long", and if you use "long" your map won't work properly.
+
+---
+
+### `controls`
+
+`controls` - a "boolean" attribute. Turns map controls on (if present) or off (if omitted). In HTML "boolean" attributes don't have values of "true" or "false" per se - they have the implied value of "true" if the attribute exists, and an implied value of "false" if the attribute is not present.  Sometimes the default map controls may not be useful for your map, so you may turn them off and design your own.
+
+---
+
+### `controlslist`
+
+`controlslist` - an enumerated attribute, possible values are: "`nofullscreen`", "`nolayer`", "`noreload`", "`noscale`" and "`nozoom`".  Occasionally, you may not want your users to have access to a particular control, so you may prune the set of controls automatically presented (when you have used the `controls` boolean attribute).
+
+---
+
+### `height`
+
+`height` - the height of the map, in pixels. Must be an integer without a unit.
+
+---
+
+### `width`
+
+`width` - the width of the map, in pixels. Must be an integer without a unit.
+
+---
+
+### `static`
+
+`static` - a "boolean" attribute. It disables the keyboard interaction, and the zooming and dragging features with the map when it is 
+present. When it is not present or removed, these features are enabled again.

--- a/src/layer.js
+++ b/src/layer.js
@@ -215,6 +215,9 @@ export class BaseLayerElement extends HTMLElement {
       lc.removeLayer(l);
     }
     // remove properties of layer involved in whenReady() logic
+    if (this._layerRegistry) {
+      this._layerRegistry.clear();
+    }
     delete this._layer;
     delete this._layerControl;
     delete this._layerControlHTML;
@@ -228,6 +231,18 @@ export class BaseLayerElement extends HTMLElement {
     /* jshint ignore:start */
     this.#hasConnected = true;
     /* jshint ignore:end */
+    // _layerRegistry tracks child MapFeatureLayer and MapTileLayer instances
+    // by their calculated DOM position (z-index). Adjacent <map-feature> or
+    // <map-tile> elements share a single Leaflet layer; the first in a sequence
+    // creates it and registers here with count=1. Subsequent siblings look up
+    // the entry and increment count. On disconnect, count is decremented;
+    // when it reaches 0 the entry is deleted and the Leaflet layer is removed.
+    // This replaces fragile DOM sibling traversal (getPrevious()) with O(1)
+    // lookup and proper reference counting for cleanup.
+    // map-link.js uses the same pattern for its templated child layers.
+    if (!this._layerRegistry) {
+      this._layerRegistry = new Map();
+    }
     this._createLayerControlHTML = createLayerControlHTML.bind(this);
     const doConnected = this._onAdd.bind(this);
     const doRemove = this._onRemove.bind(this);

--- a/src/map-caption.js
+++ b/src/map-caption.js
@@ -13,37 +13,47 @@ export class HTMLMapCaptionElement extends HTMLElement {
       this.parentElement.nodeName === 'MAPML-VIEWER' ||
       this.parentElement.nodeName === 'MAP'
     ) {
-      // calls MutationObserver; needed to observe changes to content between <map-caption> tags and update to aria-label
-      let mapcaption =
-        this.parentElement.querySelector('map-caption').textContent;
+      setTimeout(() => {
+        // Only the first map-caption child should manage the aria-label
+        const firstMapCaption = this.parentElement.querySelector('map-caption');
+        const isFirstCaption = firstMapCaption === this;
 
-      this.observer = new MutationObserver(() => {
-        let mapcaptionupdate =
+        if (!isFirstCaption) {
+          return;
+        }
+
+        // calls MutationObserver; needed to observe changes to content between <map-caption> tags and update to aria-label
+        let mapcaption =
           this.parentElement.querySelector('map-caption').textContent;
 
-        if (mapcaptionupdate !== mapcaption) {
-          this.parentElement.setAttribute(
-            'aria-label',
-            this.parentElement.querySelector('map-caption').textContent
-          );
+        this.observer = new MutationObserver(() => {
+          let mapcaptionupdate =
+            this.parentElement.querySelector('map-caption').textContent;
+
+          if (mapcaptionupdate !== mapcaption) {
+            this.parentElement.setAttribute(
+              'aria-label',
+              this.parentElement.querySelector('map-caption').textContent
+            );
+          }
+        });
+
+        this.observer.observe(this, {
+          characterData: true,
+          subtree: true,
+          attributes: true,
+          childList: true
+        });
+
+        // don't change aria-label if one already exists from user  (checks when element is first created)
+        if (!this.parentElement.hasAttribute('aria-label')) {
+          const ariaLabel = this.textContent;
+          this.parentElement.setAttribute('aria-label', ariaLabel);
         }
-      });
-
-      this.observer.observe(this, {
-        characterData: true,
-        subtree: true,
-        attributes: true,
-        childList: true
-      });
-
-      // don't change aria-label if one already exists from user  (checks when element is first created)
-      if (!this.parentElement.hasAttribute('aria-label')) {
-        const ariaLabel = this.textContent;
-        this.parentElement.setAttribute('aria-label', ariaLabel);
-      }
+      }, 0);
     }
   }
   disconnectedCallback() {
-    this.observer.disconnect();
+    if (this.observer) this.observer.disconnect();
   }
 }

--- a/src/map-feature.js
+++ b/src/map-feature.js
@@ -221,6 +221,14 @@ export class HTMLFeatureElement extends HTMLElement {
     )
       return;
     this._observer.disconnect();
+    // Decrement layer registry count
+    const entry = this._parentEl?._layerRegistry?.get(this.position);
+    if (entry) {
+      entry.count--;
+      if (entry.count === 0) {
+        this._parentEl._layerRegistry.delete(this.position);
+      }
+    }
     if (this._featureLayer) {
       this.removeFeature(this._featureLayer);
       // If this was the last feature in the layer, clean up the layer
@@ -290,16 +298,7 @@ export class HTMLFeatureElement extends HTMLElement {
     this._setUpEvents();
   }
   isFirst() {
-    // Get the previous element sibling
-    const prevSibling = this.previousElementSibling;
-
-    // If there's no previous sibling, return true
-    if (!prevSibling) {
-      return true;
-    }
-
-    // Compare the node names (tag names) - return true if they're different
-    return this.nodeName !== prevSibling.nodeName;
+    return !this._parentEl._layerRegistry.has(this.position);
   }
   getPrevious() {
     // Check if this is the first element of a sequence
@@ -370,13 +369,23 @@ export class HTMLFeatureElement extends HTMLElement {
             })
           });
 
+          // Register in parent's layer registry
+          parentElement._layerRegistry.set(this.position, {
+            layer: this._featureLayer,
+            count: 1
+          });
+
           this.addFeature(this._featureLayer);
 
           // add MapFeatureLayer to appropriate parent layer
           parentLayer.addLayer(this._featureLayer);
         } else {
-          // get the previous feature's layer
-          this._featureLayer = this.getPrevious()?._featureLayer;
+          // Look up the existing layer from the registry
+          const entry = this._parentEl._layerRegistry.get(this.position);
+          this._featureLayer = entry?.layer;
+          if (entry) {
+            entry.count++;
+          }
           if (this._featureLayer) {
             this.addFeature(this._featureLayer);
           }

--- a/src/map-link.js
+++ b/src/map-link.js
@@ -271,6 +271,10 @@ export class HTMLLinkElement extends HTMLElement {
       (this.parentExtent && this.parentExtent.hasAttribute('data-moving'))
     )
       return;
+    // Layer registry for child map-feature/map-tile layers — see layer.js
+    if (!this._layerRegistry) {
+      this._layerRegistry = new Map();
+    }
     switch (this.rel.toLowerCase()) {
       // for some cases, require a dependency check
       case 'tile':
@@ -321,6 +325,9 @@ export class HTMLLinkElement extends HTMLElement {
     // what else?
   }
   disconnectedCallback() {
+    if (this._layerRegistry) {
+      this._layerRegistry.clear();
+    }
     switch (this.rel.toLowerCase()) {
       case 'stylesheet':
         if (this._stylesheetHost) {
@@ -453,12 +460,17 @@ export class HTMLLinkElement extends HTMLElement {
       this.link.setAttribute('href', new URL(this.href, this.getBase()).href);
       copyAttributes(this, this.link);
 
-      if (this._stylesheetHost._layer) {
+      // IMPORTANT: Only render if the correct container exists for THIS element's parent.
+      // Don't fall back to _extentLayer if this is a layer child - wait for _layer instead.
+      const isLayerChild = this._stylesheetHost.tagName === 'MAP-LAYER';
+      const isExtentChild = this._stylesheetHost.tagName === 'MAP-EXTENT';
+
+      if (isLayerChild && this._stylesheetHost._layer) {
         this._stylesheetHost._layer.renderStyles(this);
+      } else if (isExtentChild && this._stylesheetHost._extentLayer) {
+        this._stylesheetHost._extentLayer.renderStyles(this);
       } else if (this._stylesheetHost._templatedLayer) {
         this._stylesheetHost._templatedLayer.renderStyles(this);
-      } else if (this._stylesheetHost._extentLayer) {
-        this._stylesheetHost._extentLayer.renderStyles(this);
       }
     }
 

--- a/src/map-style.js
+++ b/src/map-style.js
@@ -70,12 +70,17 @@ export class HTMLStyleElement extends HTMLElement {
     this.styleElement.mapStyle = this;
     this.styleElement.textContent = this.textContent;
     copyAttributes(this, this.styleElement);
-    if (this._stylesheetHost._layer) {
+    // IMPORTANT: Only render if the correct container exists for THIS element's parent.
+    // Don't fall back to _extentLayer if this is a layer child - wait for _layer instead.
+    const isLayerChild = this._stylesheetHost.tagName === 'MAP-LAYER';
+    const isExtentChild = this._stylesheetHost.tagName === 'MAP-EXTENT';
+
+    if (isLayerChild && this._stylesheetHost._layer) {
       this._stylesheetHost._layer.renderStyles(this);
+    } else if (isExtentChild && this._stylesheetHost._extentLayer) {
+      this._stylesheetHost._extentLayer.renderStyles(this);
     } else if (this._stylesheetHost._templatedLayer) {
       this._stylesheetHost._templatedLayer.renderStyles(this);
-    } else if (this._stylesheetHost._extentLayer) {
-      this._stylesheetHost._extentLayer.renderStyles(this);
     }
 
     function copyAttributes(source, target) {

--- a/src/map-tile.js
+++ b/src/map-tile.js
@@ -233,9 +233,8 @@ export class HTMLTileElement extends HTMLElement {
   }
   async _createOrGetTileLayer() {
     await this._parentEl.whenReady();
+    const parentElement = this._parentEl;
     if (this.isFirst()) {
-      const parentElement = this._parentEl;
-
       // Create a new MapTileLayer
       this._tileLayer = mapTileLayer({
         projection: this.getMapEl().projection,

--- a/src/map-tile.js
+++ b/src/map-tile.js
@@ -135,6 +135,14 @@ export class HTMLTileElement extends HTMLElement {
   }
 
   disconnectedCallback() {
+    // Decrement layer registry count
+    const entry = this._parentEl?._layerRegistry?.get(this.position);
+    if (entry) {
+      entry.count--;
+      if (entry.count === 0) {
+        this._parentEl._layerRegistry.delete(this.position);
+      }
+    }
     // If this is a map-tile connected to a tile layer, remove it from the layer
     if (this._tileLayer) {
       this._tileLayer.removeMapTile(this);
@@ -148,16 +156,7 @@ export class HTMLTileElement extends HTMLElement {
     }
   }
   isFirst() {
-    // Get the previous element sibling
-    const prevSibling = this.previousElementSibling;
-
-    // If there's no previous sibling, return true
-    if (!prevSibling) {
-      return true;
-    }
-
-    // Compare the node names (tag names) - return true if they're different
-    return this.nodeName !== prevSibling.nodeName;
+    return !this._parentEl._layerRegistry.has(this.position);
   }
   getPrevious() {
     // Check if this is the first element of a sequence
@@ -249,6 +248,12 @@ export class HTMLTileElement extends HTMLElement {
       });
       this._tileLayer.addMapTile(this);
 
+      // Register in parent's layer registry
+      parentElement._layerRegistry.set(this.position, {
+        layer: this._tileLayer,
+        count: 1
+      });
+
       // add MapTileLayer to TemplatedFeaturesOrTilesLayer of the MapLink
       if (parentElement._templatedLayer?.addLayer) {
         parentElement._templatedLayer.addLayer(this._tileLayer);
@@ -257,8 +262,12 @@ export class HTMLTileElement extends HTMLElement {
         parentElement._layer.addLayer(this._tileLayer);
       }
     } else {
-      // get the previous tile's layer
-      this._tileLayer = this.getPrevious()?._tileLayer;
+      // Look up the existing layer from the registry
+      const entry = parentElement._layerRegistry.get(this.position);
+      this._tileLayer = entry?.layer;
+      if (entry) {
+        entry.count++;
+      }
       if (this._tileLayer) {
         this._tileLayer.addMapTile(this);
       }

--- a/src/mapml-viewer.js
+++ b/src/mapml-viewer.js
@@ -420,6 +420,16 @@ export class HTMLMapmlViewerElement extends HTMLElement {
             layersReady.push(reAttach.whenReady());
           }
           return Promise.allSettled(layersReady).then(() => {
+            // For single-layer case (e.g. link traversal), synchronously set
+            // zoom constraints so that layer.zoomTo() uses correct bounds
+            const layers = this.querySelectorAll('map-layer,layer-');
+            if (layers.length === 1) {
+              const layer = layers[0];
+              if (layer.extent) {
+                this._map.setMinZoom(layer.extent.zoom.minZoom);
+                this._map.setMaxZoom(layer.extent.zoom.maxZoom);
+              }
+            }
             // use the saved map location to ensure it is correct after
             // changing the map CRS.  Specifically affects projection
             // upgrades, e.g. https://maps4html.org/experiments/custom-projections/BNG/
@@ -660,13 +670,19 @@ export class HTMLMapmlViewerElement extends HTMLElement {
   _removeEvents() {
     if (this._map) {
       this._map.off();
-      this.removeEventListener('drop', this._dropHandler, false);
-      this.removeEventListener('dragover', this._dragoverHandler, false);
+      if (this._boundDropHandler) {
+        this.removeEventListener('drop', this._boundDropHandler, false);
+      }
+      if (this._boundDragoverHandler) {
+        this.removeEventListener('dragover', this._boundDragoverHandler, false);
+      }
     }
   }
   _setUpEvents() {
-    this.addEventListener('drop', this._dropHandler, false);
-    this.addEventListener('dragover', this._dragoverHandler, false);
+    this._boundDropHandler = this._dropHandler.bind(this);
+    this._boundDragoverHandler = this._dragoverHandler.bind(this);
+    this.addEventListener('drop', this._boundDropHandler, false);
+    this.addEventListener('dragover', this._boundDragoverHandler, false);
     this.addEventListener(
       'change',
       function (e) {

--- a/src/mapml.css
+++ b/src/mapml.css
@@ -447,6 +447,11 @@ and: https://developer.mozilla.org/en-US/docs/Web/CSS/:fullscreen */
   text-shadow: 1px 1px 1px #000, 1px 1px 1px #000;
 }
 
+/* Ensure white background persists in fullscreen */
+:host(.mapml-fullscreen-on) {
+  background-color: white;
+}
+
 /*
  * User interaction.
  */

--- a/src/mapml/elementSupport/layers/renderStyles.js
+++ b/src/mapml/elementSupport/layers/renderStyles.js
@@ -10,15 +10,19 @@ export function renderStyles(mapStyleOrLink) {
 
     // If there are no rendered styles or links yet, insert before any content
     if (renderedSiblingStyles.length === 0) {
-      return this._container.lastChild &&
-        (this._container.lastChild.nodeName.toUpperCase() === 'SVG' ||
-          this._container.lastChild.classList.contains(
-            'mapml-vector-container'
-          ))
-        ? { position: 'beforebegin', node: this._container.lastChild }
-        : this._container.lastChild
-        ? { position: 'afterend', node: this._container.lastChild }
-        : { position: 'afterbegin', node: this._container };
+      const lastChild = this._container.lastChild;
+      if (!lastChild) {
+        return { position: 'afterbegin', node: this._container };
+      }
+
+      const isSVG = lastChild.nodeName === 'SVG';
+      const isContainer =
+        lastChild.classList?.contains('mapml-vector-container') ||
+        lastChild.classList?.contains('mapml-extentlayer-container');
+
+      return isSVG || isContainer
+        ? { position: 'beforebegin', node: lastChild }
+        : { position: 'afterend', node: lastChild };
     }
 
     // Peek into the light DOM context for comparison

--- a/src/mapml/handlers/QueryHandler.js
+++ b/src/mapml/handlers/QueryHandler.js
@@ -184,7 +184,8 @@ export var QueryHandler = Handler.extend({
               features.forEach((f) => (f.meta = queryMetas));
           } else if (
             response.contenttype.startsWith('application/json') ||
-            response.contenttype.startsWith('application/geo+json')
+            response.contenttype.startsWith('application/geo+json') ||
+            response.contenttype.startsWith('application/geojson')
           ) {
             try {
               let json = JSON.parse(response.text);

--- a/src/mapml/layers/MapFeatureLayer.js
+++ b/src/mapml/layers/MapFeatureLayer.js
@@ -410,12 +410,18 @@ export var MapFeatureLayer = FeatureGroup.extend({
             !geometry._map
           ) {
             this.addRendering(geometry);
-            // update the layerbounds
-            let placeholder =
-              geometry.defaultOptions.group.parentNode.querySelector(
-                `span[id="${geometry._leaflet_id}"]`
-              );
-            placeholder.replaceWith(geometry.defaultOptions.group);
+            // Only try to find placeholder if the geometry group has a parentNode
+            // If parentNode is null, the geometry is being handled by reRender()
+            // which will attach it to the DOM after _validateRendering completes
+            if (geometry.defaultOptions.group.parentNode) {
+              let placeholder =
+                geometry.defaultOptions.group.parentNode.querySelector(
+                  `span[id="${geometry._leaflet_id}"]`
+                );
+              if (placeholder) {
+                placeholder.replaceWith(geometry.defaultOptions.group);
+              }
+            }
           }
         }
       }

--- a/src/mapml/layers/TemplatedTileLayer.js
+++ b/src/mapml/layers/TemplatedTileLayer.js
@@ -598,7 +598,12 @@ export var TemplatedTileLayer = TileLayer.extend({
       );
       template.pcrs.easting = east;
       template.pcrs.northing = north;
-    } else if (col && row && !isNaN(template.zoom.initialValue)) {
+    } else if (
+      col &&
+      row &&
+      template.zoom &&
+      !isNaN(template.zoom.initialValue)
+    ) {
       // convert the tile bounds at this zoom to a pcrs bounds, then
       // go through the zoom min/max and create a tile-based bounds
       // at each zoom that applies to the col/row values that constrain what tiles

--- a/src/mapml/utils/Util.js
+++ b/src/mapml/utils/Util.js
@@ -427,17 +427,30 @@ export const Util = {
       // specifically required for use cases like changing projection after
       // link traversal, e.g. BC link here https://maps4html.org/experiments/linking/features/
       if (!link.inPlace && zoomTo) updateMapZoomTo(zoomTo);
-      // the layer is newly created, so have to wait until it's fully init'd
-      // before setting properties.
-      layer.whenReady().then(() => {
-        // if the map projection isnt' changed by link traversal, it's necessary
-        // to perform pan/zoom operations after the layer is ready
+
+      // Only _parent target can trigger projection change (replaces all layers)
+      // For other targets, just wait for layer.whenReady()
+      const promises = [layer.whenReady()];
+      if (link.target === '_parent') {
+        const projectionChangePromise = new Promise((resolve) => {
+          const timeout = setTimeout(resolve, 5000);
+          map.options.mapEl.addEventListener(
+            'map-projectionchange',
+            () => {
+              clearTimeout(timeout);
+              resolve();
+            },
+            { once: true }
+          );
+        });
+        promises.push(projectionChangePromise);
+      }
+
+      Promise.all(promises).then(() => {
         if (!link.inPlace && zoomTo)
           layer.parentElement.zoomTo(+zoomTo.lat, +zoomTo.lng, +zoomTo.z);
         else if (!link.inPlace) layer.zoomTo();
-        // not sure if this is necessary
         if (opacity) layer.opacity = opacity;
-        // this is necessary to display the FeatureIndexOverlay, I believe
         map.getContainer().focus();
       });
     }

--- a/src/web-map.js
+++ b/src/web-map.js
@@ -460,6 +460,16 @@ export class HTMLWebMapElement extends HTMLMapElement {
               layersReady.push(reAttach.whenReady());
             }
             return Promise.allSettled(layersReady).then(() => {
+              // For single-layer case (e.g. link traversal), synchronously set
+              // zoom constraints so that layer.zoomTo() uses correct bounds
+              const layers = this.querySelectorAll('map-layer,layer-');
+              if (layers.length === 1) {
+                const layer = layers[0];
+                if (layer.extent) {
+                  this._map.setMinZoom(layer.extent.zoom.minZoom);
+                  this._map.setMaxZoom(layer.extent.zoom.maxZoom);
+                }
+              }
               // use the saved map location to ensure it is correct after
               // changing the map CRS.  Specifically affects projection
               // upgrades, e.g. https://maps4html.org/experiments/custom-projections/BNG/
@@ -702,13 +712,19 @@ export class HTMLWebMapElement extends HTMLMapElement {
   _removeEvents() {
     if (this._map) {
       this._map.off();
-      this.removeEventListener('drop', this._dropHandler, false);
-      this.removeEventListener('dragover', this._dragoverHandler, false);
+      if (this._boundDropHandler) {
+        this.removeEventListener('drop', this._boundDropHandler, false);
+      }
+      if (this._boundDragoverHandler) {
+        this.removeEventListener('dragover', this._boundDragoverHandler, false);
+      }
     }
   }
   _setUpEvents() {
-    this.addEventListener('drop', this._dropHandler, false);
-    this.addEventListener('dragover', this._dragoverHandler, false);
+    this._boundDropHandler = this._dropHandler.bind(this);
+    this._boundDragoverHandler = this._dragoverHandler.bind(this);
+    this.addEventListener('drop', this._boundDropHandler, false);
+    this.addEventListener('dragover', this._boundDragoverHandler, false);
     this.addEventListener(
       'change',
       function (e) {

--- a/test/e2e/core/featureLinks.test.js
+++ b/test/e2e/core/featureLinks.test.js
@@ -26,7 +26,7 @@ test.describe('Playwright Feature Links Tests', () => {
         await page.waitForTimeout(200);
       }
       await page.keyboard.press('Enter'); // Press enter on the point subpart of the 'Accessible Square' feature
-      await page.waitForTimeout(1000);
+      await page.waitForTimeout(3000);
       const layers = await page.$eval(
         'body > map',
         (map) => map.childElementCount
@@ -55,7 +55,7 @@ test.describe('Playwright Feature Links Tests', () => {
         'body > map',
         (map) => map.childElementCount
       );
-      await page.waitForTimeout(1000);
+      await page.waitForTimeout(3000);
       const layerName = await page.$eval(
         '//html/body/map/map-layer[2]',
         (layer) => layer.label
@@ -93,7 +93,7 @@ test.describe('Playwright Feature Links Tests', () => {
         'body > map',
         (map) => map.childElementCount
       );
-      await page.waitForTimeout(1000);
+      await page.waitForTimeout(5000);
       const layerName = await page.$eval(
         '//html/body/map/map-layer[2]',
         (layer) => layer.label

--- a/test/e2e/core/layerContextMenuKeyboard.test.js
+++ b/test/e2e/core/layerContextMenuKeyboard.test.js
@@ -9,7 +9,7 @@ test.describe('Playwright Layer Context Menu Tests', () => {
     page =
       context.pages().find((page) => page.url() === 'about:blank') ||
       (await context.newPage());
-    await page.goto('layerContextMenu.html');
+    await page.goto('layerContextMenu.html', { waitUntil: 'networkidle' });
   });
 
   test.afterAll(async function () {

--- a/test/e2e/core/linkTypes.test.js
+++ b/test/e2e/core/linkTypes.test.js
@@ -8,7 +8,7 @@ test.describe('Playwright Feature Links Tests', () => {
     page =
       context.pages().find((page) => page.url() === 'about:blank') ||
       (await context.newPage());
-    await page.goto('linkTypes.html');
+    await page.goto('linkTypes.html', { waitUntil: 'networkidle' });
   });
 
   test.afterAll(async function () {
@@ -53,7 +53,7 @@ test.describe('Playwright Feature Links Tests', () => {
         await page.waitForTimeout(200);
       }
       await page.keyboard.press('Enter'); // Press enter on the second feature in the top left
-      await page.waitForTimeout(1000);
+      await page.waitForLoadState('networkidle');
       const url = await page.url();
       expect(url).toEqual('https://geogratis.gc.ca/mapml/en/cbmtile/cbmtgeom/');
     });
@@ -64,6 +64,7 @@ test.describe('Playwright Feature Links Tests', () => {
       await page.keyboard.press('Tab');
       await page.waitForTimeout(200);
       await page.keyboard.press('Enter'); // Press enter on the second point in the top left
+      await page.waitForLoadState('networkidle');
       await page.waitForTimeout(1000);
       const extent = await page.$eval('body > map', (map) => map.extent);
       expect(extent.topLeft.gcrs).toEqual({

--- a/test/e2e/core/missingMetaParameters.test.js
+++ b/test/e2e/core/missingMetaParameters.test.js
@@ -39,6 +39,7 @@ test.describe('Missing Parameters Test', () => {
   });
 
   test("Static tiles with missing <map-meta name='zoom'></map-meta>", async () => {
+    await page.waitForTimeout(1000);
     const layerController = await page.$eval(
       'body > map:nth-child(1) > map-layer:nth-child(3)',
       (controller) => controller.extent

--- a/test/e2e/core/popupTabNavigation.test.js
+++ b/test/e2e/core/popupTabNavigation.test.js
@@ -8,7 +8,7 @@ test.describe('Playwright Keyboard Navigation + Query Layer Tests', () => {
     page =
       context.pages().find((page) => page.url() === 'about:blank') ||
       (await context.newPage());
-    await page.goto('popupTabNavigation.html');
+    await page.goto('popupTabNavigation.html', { waitUntil: 'networkidle' });
   });
 
   test.afterAll(async function () {

--- a/test/e2e/core/styleParsing.test.js
+++ b/test/e2e/core/styleParsing.test.js
@@ -78,7 +78,7 @@ as found, in expected shadow root location`, async () => {
     const mapExtent = page.getByTestId('map-ext1');
     const ids = await mapExtent.evaluate((e) => {
       const elementSequence = e.querySelectorAll(
-        'map-link[rel=stylesheet],map-style'
+        ':scope > map-link[rel=stylesheet],:scope > map-style'
       );
       let ids = '';
       for (let i = 0; i < elementSequence.length; i++)

--- a/test/e2e/layers/queryGeoJSON.html
+++ b/test/e2e/layers/queryGeoJSON.html
@@ -54,6 +54,17 @@
         <map-input name="h" type="height"></map-input>
         <map-link rel="query" tref="data/query/geojsonNullGeometry?{i}{j}{xmin}{ymin}{xmax}{ymax}{w}{h}"></map-link>
       </map-extent>
+      <map-extent label="GeoJSON erroneous media type" units="OSMTILE" checked>
+        <map-input name="i" type="location" units="map" axis="i"></map-input>
+        <map-input name="j" type="location" units="map" axis="j"></map-input>
+        <map-input name="xmin" type="location" units="gcrs" axis="longitude" position="top-left" min="-180" max="180"></map-input>
+        <map-input name="ymin" type="location" units="gcrs" axis="latitude" position="bottom-right" min="-90" max="90"></map-input>
+        <map-input name="xmax" type="location" units="gcrs" axis="longitude" position="bottom-right" min="-180" max="180"></map-input>
+        <map-input name="ymax" type="location" units="gcrs" axis="latitude" position="top-left" min="-90" max="90"></map-input>
+        <map-input name="w" type="width"></map-input>
+        <map-input name="h" type="height"></map-input>
+        <map-link rel="query" tref="data/query/geojsonErroneousMediaType?{i}{j}{xmin}{ymin}{xmax}{ymax}{w}{h}"></map-link>
+      </map-extent>
     </map-layer>
   </mapml-viewer>
 </body>

--- a/test/e2e/layers/queryGeoJSON.test.js
+++ b/test/e2e/layers/queryGeoJSON.test.js
@@ -20,7 +20,7 @@ test.describe('GeoJSON Query Response', () => {
     const popupContainer = page.locator('.mapml-popup-content > iframe');
     await expect(popupContainer).toBeVisible();
     const popupFeatureCount = page.locator('.mapml-feature-count');
-    await expect(popupFeatureCount).toHaveText('1/4', { useInnerText: true });
+    await expect(popupFeatureCount).toHaveText('1/5', { useInnerText: true });
   });
   test('Standard CRS:84 GeoJSON feature has cs meta set to gcrs', async () => {
     // The first feature comes from the CRS:84 extent (geojsonFeature)
@@ -95,6 +95,27 @@ test.describe('GeoJSON Query Response', () => {
       let props = f.querySelector('map-properties');
       let hasTable = props.querySelector('table') !== null;
       // check that a point geometry was synthesized
+      let hasPoint = f.querySelector('map-geometry map-point') !== null;
+      return { found: true, hasTable: hasTable, hasPoint: hasPoint };
+    });
+    expect(result.found).toBe(true);
+    expect(result.hasTable).toBe(true);
+    expect(result.hasPoint).toBe(true);
+  });
+  test('GeoJSON served with erroneous application/geojson media type is handled as GeoJSON', async () => {
+    // The feature from geojsonErroneousMediaType is served with the
+    // non-standard "application/geojson" content type. It should still
+    // be processed through the GeoJSON branch of QueryHandler.
+    let result = await page.evaluate(() => {
+      let layer = document.querySelector('mapml-viewer').layers[0]._layer;
+      let features = layer._mapmlFeatures;
+      // geojsonPoint.json has a feature with property "CURRENT_FLAG"
+      let f = features.find((feat) => {
+        let props = feat.querySelector('map-properties');
+        return props && props.innerHTML.includes('CURRENT_FLAG');
+      });
+      if (!f) return { found: false };
+      let hasTable = f.querySelector('map-properties table') !== null;
       let hasPoint = f.querySelector('map-geometry map-point') !== null;
       return { found: true, hasTable: hasTable, hasPoint: hasPoint };
     });

--- a/test/server.js
+++ b/test/server.js
@@ -170,6 +170,17 @@ app.get('/data/query/geojsonNullGeometry', (req, res, next) => {
     }
   );
 });
+app.get('/data/query/geojsonErroneousMediaType', (req, res, next) => {
+  res.sendFile(
+    __dirname + '/e2e/data/geojson/geojsonPoint.json',
+    { headers: { 'Content-Type': 'application/geojson' } },
+    (err) => {
+      if (err) {
+        res.status(403).send('Error.');
+      }
+    }
+  );
+});
 app.get('/data/query/geojsonFeature.geojson', (req, res, next) => {
   res.sendFile(
     __dirname + '/e2e/data/geojson/geojsonFeature.geojson',


### PR DESCRIPTION
- backport changes from gcds-map refactoring to here
- add support for querying and receiving incorrect `application/geojson` content-type header value
- add copilot instructions
- add skills for how to mark up MapML documents, based on a modified copy of the web-map-doc english documentation

Closes #1044